### PR TITLE
feat: Did document validator

### DIFF
--- a/pkg/dochandler/didvalidator/testdata/doc.json
+++ b/pkg/dochandler/didvalidator/testdata/doc.json
@@ -1,0 +1,37 @@
+{
+  "@context": "https://w3id.org/did/v1",
+  "publicKey": [
+    {
+      "id": "#key1",
+      "type": "Secp256k1VerificationKey2018",
+      "publicKeyJwk": {
+        "kty": "EC",
+        "kid": "key1",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc",
+        "use": "verify",
+        "defaultEncryptionAlgorithm": "none"
+      }
+    },
+    {
+      "id": "#key2",
+      "type": "RsaVerificationKey2018",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY.2.END PUBLIC KEY-----"
+    }
+  ],
+  "service": [
+    {
+      "id": "IdentityHub",
+      "type": "IdentityHub",
+      "serviceEndpoint": {
+        "@context": "schema.identity.foundation/hub",
+        "@type": "UserServiceEndpoint",
+        "instance": [
+          "did:sidetree:456",
+          "did:sidetree:789"
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/dochandler/didvalidator/validator.go
+++ b/pkg/dochandler/didvalidator/validator.go
@@ -1,0 +1,114 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didvalidator
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+)
+
+const (
+	didUniqueSuffix = "didUniqueSuffix"
+	didContext      = "https://w3id.org/did/v1"
+)
+
+// Validator is responsible for validating did operations and sidetree rules
+type Validator struct {
+	store OperationStoreClient
+}
+
+// OperationStoreClient defines interface for retrieving all operations related to document
+type OperationStoreClient interface {
+
+	// Get retrieves all operations related to document
+	Get(uniqueSuffix string) ([]batch.Operation, error)
+}
+
+// New creates a new did validator
+func New(store OperationStoreClient) *Validator {
+	return &Validator{
+		store: store,
+	}
+}
+
+// IsValidPayload verifies that the given payload is a valid Sidetree specific payload
+// that can be accepted by the Sidetree update operations
+func (v *Validator) IsValidPayload(payload []byte) error {
+
+	doc, err := document.FromBytes(payload)
+	if err != nil {
+		return err
+	}
+
+	didUniqueSuffix := doc.GetStringValue(didUniqueSuffix)
+	if didUniqueSuffix == "" {
+		return errors.New("missing did unique suffix")
+	}
+
+	// did document has to exist in the store for all operations except for create
+	docs, err := v.store.Get(didUniqueSuffix)
+	if err != nil {
+		return err
+	}
+
+	if len(docs) == 0 {
+		return errors.New("missing did document operations")
+	}
+
+	return nil
+}
+
+// IsValidOriginalDocument verifies that the given payload is a valid Sidetree specific did document that can be accepted by the Sidetree create operation.
+func (v *Validator) IsValidOriginalDocument(payload []byte) error {
+
+	didDoc, err := document.DidDocumentFromBytes(payload)
+	if err != nil {
+		return err
+	}
+
+	// Sidetree rule: The document must NOT have the id property
+	if didDoc.ID() != "" {
+		return errors.New("document must NOT have the id property")
+	}
+
+	// Sidetree rule: The document must contain at least 1 entry in the publicKey array property
+	if err := validatePublicKeys(didDoc); err != nil {
+		return err
+	}
+
+	// Sidetree rule: add service validation
+
+	// generic did document validation - must have context
+	if didDoc.Context() != didContext {
+		return errors.New("context is invalid or absent")
+	}
+
+	return nil
+}
+
+func validatePublicKeys(didDoc document.DIDDocument) error {
+
+	// The document must contain at least 1 entry in the publicKey array property
+	publicKeyArray := didDoc.PublicKeys()
+	if len(publicKeyArray) == 0 {
+		return errors.New("document must contain at least one public key")
+	}
+
+	// The id property of a publickey element must be specified and be a fragment (e.g. #key1).
+	for _, pubKey := range publicKeyArray {
+		i := strings.Index(pubKey.ID(), "#")
+		if pubKey.ID() == "" || i != 0 {
+			return errors.New("public key id is either absent or not starting with #")
+		}
+	}
+
+	return nil
+}

--- a/pkg/dochandler/didvalidator/validator_test.go
+++ b/pkg/dochandler/didvalidator/validator_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package didvalidator
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	v := New(mocks.NewMockOperationStore(nil))
+	require.NotNil(t, v)
+}
+
+func TestIsValidOriginalDocument(t *testing.T) {
+
+	r := reader(t, "testdata/doc.json")
+	didDoc, err := ioutil.ReadAll(r)
+	require.Nil(t, err)
+
+	v := getDefaultValidator()
+
+	err = v.IsValidOriginalDocument(didDoc)
+	require.Nil(t, err)
+}
+
+func TestIsValidOriginalDocument_PublicKeyErrors(t *testing.T) {
+
+	v := getDefaultValidator()
+
+	err := v.IsValidOriginalDocument(noPublicKeyDoc)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "document must contain at least one public key")
+
+	err = v.IsValidOriginalDocument(pubKeyNotFragmentDoc)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "public key id is either absent or not starting with #")
+
+}
+
+func TestIsValidOriginalDocument_MustNotHaveIDError(t *testing.T) {
+
+	v := getDefaultValidator()
+
+	err := v.IsValidOriginalDocument(docWithID)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "document must NOT have the id property")
+}
+
+func TestIsValidPayload(t *testing.T) {
+
+	store := mocks.NewMockOperationStore(nil)
+	v := New(store)
+
+	store.Put(batch.Operation{UniqueSuffix: "abc"})
+
+	err := v.IsValidPayload(validUpdate)
+	require.Nil(t, err)
+
+}
+
+
+func TestIsValidPayloadError(t *testing.T) {
+
+	v := getDefaultValidator()
+
+	err := v.IsValidPayload(invalidUpdate)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "missing did unique suffix")
+
+}
+
+func TestIsValidPayload_StoreErrors(t *testing.T) {
+
+	store := mocks.NewMockOperationStore(nil)
+	v := New(store)
+
+	// scenario: document is not in the store
+	err := v.IsValidPayload(validUpdate)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// scenario: found in the store and is valid
+	store.Put(batch.Operation{UniqueSuffix: "abc"})
+	err = v.IsValidPayload(validUpdate)
+	require.Nil(t, err)
+
+	// scenario: store error
+	storeErr := fmt.Errorf("store error")
+	v = New(mocks.NewMockOperationStore(storeErr))
+	err = v.IsValidPayload(validUpdate)
+	require.NotNil(t, err)
+	require.Equal(t, err, storeErr)
+}
+
+func TestInvalidPayloadError(t *testing.T) {
+
+	v := getDefaultValidator()
+
+	// payload is invalid json
+	payload := []byte("[test : 123]")
+
+	err := v.IsValidPayload(payload)
+	assert.NotNil(t, err)
+	require.Contains(t, err.Error(), "invalid character")
+
+	err = v.IsValidOriginalDocument(payload)
+	assert.NotNil(t, err)
+	require.Contains(t, err.Error(), "invalid character")
+
+}
+
+func getDefaultValidator() *Validator {
+	return New(mocks.NewMockOperationStore(nil))
+}
+
+func reader(t *testing.T, filename string) io.Reader {
+	f, err := os.Open(filename)
+	require.Nil(t, err)
+	return f
+}
+
+var noPublicKeyDoc = []byte(`{ "@context": "some context", "name": "John Smith" }`)
+var pubKeyNotFragmentDoc = []byte(`{ "@context": "some context", "publicKey": [{"id": "key1", "type": "type"}]}`)
+var docWithID = []byte(`{ "@context": "some context", "id" : "001", "name": "John Smith" }`)
+
+var validUpdate = []byte(`{ "didUniqueSuffix": "abc" }`)
+var invalidUpdate = []byte(`{ "patch": "" }`)
+

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -1,0 +1,154 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+)
+
+const (
+	jsonldContext = "@context"
+
+	jsonldType = "type"
+
+	jsonldService      = "service"
+	jsonldServicePoint = "serviceEndpoint"
+
+	jsonldPublicKey  = "publicKey"
+	jsonldController = "controller"
+
+	// various public key encodings
+	jsonldPublicKeyBase64 = "publicKeyBase64"
+	jsonldPublicKeyBase58 = "publicKeyBase58"
+	jsonldPublicKeyHex    = "publicKeyHex"
+	jsonldPublicKeyPem    = "publicKeyPem"
+	jsonldPublicKeyJwk    = "publicKeyJwk"
+)
+
+// DIDDocument Defines DID Document data structure used by Sidetree for basic type safety checks.
+type DIDDocument map[string]interface{}
+
+// ID is identifier for DID subject (what DID Document is about)
+func (doc *DIDDocument) ID() string {
+	return stringEntry((*doc)[jsonldID])
+}
+
+// Context is the context of did document
+func (doc *DIDDocument) Context() string {
+	return stringEntry((*doc)[jsonldContext])
+}
+
+// PublicKeys are used for digital signatures, encryption and other cryptographic operations
+func (doc *DIDDocument) PublicKeys() []PublicKey {
+	entry, ok := (*doc)[jsonldPublicKey]
+	if !ok {
+		return nil
+	}
+
+	typedEntry, ok := entry.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var result []PublicKey
+	for _, e := range typedEntry {
+		emap, ok := e.(map[string]interface{})
+		if !ok || !isValidPublicKey(emap) {
+			continue
+		}
+		result = append(result, NewPublicKey(emap))
+	}
+	return result
+}
+
+func isValidPublicKey(pubKey map[string]interface{}) bool {
+	if isEmpty(pubKey[jsonldID]) || isEmpty(pubKey[jsonldType]) {
+		return false
+	}
+	return true
+}
+
+// Services is an array of service endpoints
+func (doc *DIDDocument) Services() []Service {
+	entry, ok := (*doc)[jsonldService]
+	if !ok {
+		return nil
+	}
+
+	typedEntry, ok := entry.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var result []Service
+	for _, e := range typedEntry {
+		emap, ok := e.(map[string]interface{})
+		if !ok || !isValidService(emap) {
+			continue
+		}
+		result = append(result, NewService(emap))
+	}
+	return result
+}
+
+func isValidService(service map[string]interface{}) bool {
+	if isEmpty(service[jsonldID]) || isEmpty(service[jsonldType]) || service[jsonldServicePoint] == nil {
+		return false
+	}
+	return true
+}
+
+// JSONLdObject returns map that represents JSON LD Object
+func (doc DIDDocument) JSONLdObject() map[string]interface{} {
+	return doc
+}
+
+// DIDDocumentFromReader creates an instance of DIDDocument by reading a JSON document from Reader
+func DIDDocumentFromReader(r io.Reader) (DIDDocument, error) {
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return DidDocumentFromBytes(data)
+}
+
+// DidDocumentFromBytes creates an instance of DIDDocument by reading a JSON document from bytes
+func DidDocumentFromBytes(data []byte) (DIDDocument, error) {
+
+	doc := make(DIDDocument)
+	err := json.Unmarshal(data, &doc)
+	if err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// String returns string representation of did document
+func (doc *DIDDocument) String() string {
+	s, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "<ERROR marshalling DIDDocument>"
+	}
+	return string(s)
+}
+
+// Bytes returns byte representation of did document
+func (doc *DIDDocument) Bytes() []byte {
+	s, err := json.Marshal(doc)
+	if err != nil {
+		return []byte("<ERROR marshalling DIDDocument>")
+	}
+	return s
+}
+
+func isEmpty(entry interface{}) bool {
+	return stringEntry(entry) == ""
+}

--- a/pkg/document/diddocument_test.go
+++ b/pkg/document/diddocument_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValid(t *testing.T) {
+
+	r := reader(t, "testdata/doc.json")
+
+	doc, err := DIDDocumentFromReader(r)
+	require.Nil(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, "", doc.ID())
+	require.Equal(t, "https://w3id.org/did/v1", doc.Context())
+
+	publicKeys := doc.PublicKeys()
+	require.Equal(t, []PublicKey{
+		{
+			"id":   "#key1",
+			"type": "Secp256k1VerificationKey2018",
+			"publicKeyJwk": map[string]interface{}{
+				"kty":                        "EC",
+				"kid":                        "key1",
+				"crv":                        "P-256K",
+				"x":                          "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+				"y":                          "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc",
+				"use":                        "verify",
+				"defaultEncryptionAlgorithm": "none",
+			},
+		},
+		{
+			"id":           "#key2",
+			"type":         "RsaVerificationKey2018",
+			"publicKeyPem": "-----BEGIN PUBLIC KEY.2.END PUBLIC KEY-----",
+		},
+	}, publicKeys)
+
+	services := doc.Services()
+	require.Equal(t, []Service{
+		{
+			"id":   "IdentityHub",
+			"type": "IdentityHub",
+			"serviceEndpoint": map[string]interface{}{
+				"@context": "schema.identity.foundation/hub",
+				"@type":    "UserServiceEndpoint",
+				"instance": []interface{}{"did:sidetree:456", "did:sidetree:789"},
+			},
+		},
+	}, services)
+
+	str := doc.String()
+	require.NotEmpty(t, str)
+
+	bytes := doc.Bytes()
+	require.NotEmpty(t, bytes)
+
+	jsonld := doc.JSONLdObject()
+	require.NotNil(t, jsonld)
+}
+
+func TestEmptyDoc(t *testing.T) {
+
+	var bytes = []byte(`{ "@context": "https://w3id.org/did/v1" }`)
+
+	doc, err := DidDocumentFromBytes(bytes)
+	require.Nil(t, err)
+	require.NotNil(t, doc)
+
+	publicKeys := doc.PublicKeys()
+	require.Equal(t, 0, len(publicKeys))
+
+	services := doc.Services()
+	require.Equal(t, 0, len(services))
+}
+
+func TestMissingInfo(t *testing.T) {
+
+	r := reader(t, "testdata/missing-info.json")
+
+	doc, err := DIDDocumentFromReader(r)
+	require.Nil(t, err)
+	require.NotNil(t, doc)
+
+	publicKeys := doc.PublicKeys()
+	require.Equal(t, 0, len(publicKeys))
+
+	services := doc.Services()
+	require.Equal(t, 0, len(services))
+}
+
+func TestInvalidLists(t *testing.T) {
+
+	r := reader(t, "testdata/invalid-lists.json")
+
+	doc, err := DIDDocumentFromReader(r)
+	require.Nil(t, err)
+	require.NotNil(t, doc)
+
+	services := doc.Services()
+	require.Equal(t, 0, len(services))
+
+	pubKeys := doc.PublicKeys()
+	require.Equal(t, 0, len(pubKeys))
+}

--- a/pkg/document/publickey.go
+++ b/pkg/document/publickey.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+// PublicKey must include id and type properties, and exactly one value property
+type PublicKey map[string]interface{}
+
+// NewPublicKey creates new public key
+func NewPublicKey(pk map[string]interface{}) PublicKey {
+	return pk
+}
+
+// ID is public key ID
+func (pk *PublicKey) ID() string {
+	return stringEntry((*pk)[jsonldID])
+}
+
+// Type is public key type
+func (pk *PublicKey) Type() string {
+	return stringEntry((*pk)[jsonldType])
+}
+
+// Controller identifies the entity that controls the corresponding private key.
+func (pk *PublicKey) Controller() string {
+	return stringEntry((*pk)[jsonldController])
+}
+
+//PublicKeyBase64 is value property
+func (pk *PublicKey) PublicKeyBase64() string {
+	return stringEntry((*pk)[jsonldPublicKeyBase64])
+}
+
+// PublicKeyBase58 is value property
+func (pk *PublicKey) PublicKeyBase58() string {
+	return stringEntry((*pk)[jsonldPublicKeyBase58])
+}
+
+// PublicKeyHex is value property
+func (pk *PublicKey) PublicKeyHex() string {
+	return stringEntry((*pk)[jsonldPublicKeyHex])
+}
+
+// PublicKeyPEM is value property
+func (pk *PublicKey) PublicKeyPEM() string {
+	return stringEntry((*pk)[jsonldPublicKeyPem])
+}
+
+// PublicKeyJWK is value property
+func (pk *PublicKey) PublicKeyJWK() string {
+	return stringEntry((*pk)[jsonldPublicKeyJwk])
+}

--- a/pkg/document/publickey_test.go
+++ b/pkg/document/publickey_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicKey(t *testing.T) {
+
+	pk := NewPublicKey(map[string]interface{}{})
+	require.Empty(t, pk.ID())
+	require.Empty(t, pk.Type())
+	require.Empty(t, pk.Controller())
+
+	pk = NewPublicKey(map[string]interface{}{
+		"id":              "did:example:123456789abcdefghi#keys-1",
+		"type":            "RsaVerificationKey2018",
+		"controller":      "did:example:123456789abcdefghi",
+		"publicKeyPem":    "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----",
+		"publicKeyBase64": "Base64",
+		"publicKeyBase58": "Base58",
+		"publicKeyHex":    "Hex",
+		"publicKeyJwk":    "Jwk",
+		"other":           "otherValue",
+	})
+	require.Equal(t, "did:example:123456789abcdefghi#keys-1", pk.ID())
+	require.Equal(t, "RsaVerificationKey2018", pk.Type())
+	require.Equal(t, "did:example:123456789abcdefghi", pk.Controller())
+	require.Equal(t, "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----", pk.PublicKeyPEM())
+	require.Equal(t, "Base64", pk.PublicKeyBase64())
+	require.Equal(t, "Base58", pk.PublicKeyBase58())
+	require.Equal(t, "Hex", pk.PublicKeyHex())
+	require.Equal(t, "Jwk", pk.PublicKeyJWK())
+	require.Equal(t, "otherValue", pk["other"])
+
+}

--- a/pkg/document/service.go
+++ b/pkg/document/service.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+// Service represents any type of service the entity wishes to advertise
+type Service map[string]interface{}
+
+// NewService creates new service
+func NewService(m map[string]interface{}) Service {
+	return m
+}
+
+// ID is service ID
+func (s *Service) ID() interface{} {
+	return (*s)[jsonldID]
+}
+
+// Type is service type
+func (s *Service) Type() interface{} {
+	return (*s)[jsonldType]
+}
+
+// Endpoint is service endpoint
+func (s *Service) Endpoint() interface{} {
+	return (*s)[jsonldServicePoint]
+}

--- a/pkg/document/service_test.go
+++ b/pkg/document/service_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestService(t *testing.T) {
+
+	svc := NewService(map[string]interface{}{})
+	require.Empty(t, svc.Type())
+	require.Empty(t, svc.Endpoint())
+
+	svc = NewService(map[string]interface{}{
+		"id":              "did:example:123456789abcdefghi;openid",
+		"type":            "OpenIdConnectVersion3.1Service",
+		"serviceEndpoint": "https://openid.example.com/",
+	})
+	require.Equal(t, "did:example:123456789abcdefghi;openid", svc.ID())
+	require.Equal(t, "OpenIdConnectVersion3.1Service", svc.Type())
+	require.Equal(t, "https://openid.example.com/", svc.Endpoint())
+
+}

--- a/pkg/document/testdata/invalid-lists.json
+++ b/pkg/document/testdata/invalid-lists.json
@@ -1,0 +1,14 @@
+{
+  "publicKey":
+    {
+      "id": "#key2",
+      "type": "RsaVerificationKey2018",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY.2.END PUBLIC KEY-----"
+    },
+  "service":
+    {
+      "id": "IdentityHub",
+      "type": "IdentityHub",
+      "serviceEndpoint": ""
+    }
+}

--- a/pkg/document/testdata/missing-info.json
+++ b/pkg/document/testdata/missing-info.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://w3id.org/did/v1",
+  "publicKey": [
+    {
+      "id": "#key3"
+    },
+    {
+      "type": "RsaVerificationKey2018"
+    }
+  ],
+  "service": [
+    {
+      "type": "invalid"
+    },
+    {
+      "serviceEndpoint": {
+        "@context": "schema.identity.foundation/hub",
+        "@type": "UserServiceEndpoint",
+        "instance": [
+          "did:sidetree:456",
+          "did:sidetree:789"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Did document validator will check if document to be created conforms to Sidetree protocol specification for DID document creation. It also checks if update operation payload is valid: unique ID must be present and the original document with that ID exists in the document store.

Closes #15

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>