### PR TITLE
fix: Use a canonical JSON serializer

### DIFF
--- a/pkg/batch/filehandler/handler.go
+++ b/pkg/batch/filehandler/handler.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package filehandler
 
 import (
-	"encoding/json"
-
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"gitlab.com/NebulousLabs/merkletree"
 )
@@ -52,7 +50,7 @@ func (h *Handler) CreateBatchFile(operations [][]byte) ([]byte, error) {
 
 	bf := BatchFile{Operations: ops}
 
-	return json.Marshal(bf)
+	return docutil.MarshalCanonical(bf)
 }
 
 // CreateAnchorFile will create anchor file for Sidetree transaction
@@ -70,7 +68,7 @@ func (h *Handler) CreateAnchorFile(operations [][]byte, batchAddress string, mul
 		MerkleRoot:    docutil.EncodeToString(mtrHash),
 	}
 
-	return json.Marshal(af)
+	return docutil.MarshalCanonical(af)
 }
 
 func getMerkleTreeRoot(operations [][]byte, multihashCode uint) ([]byte, error) {

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -20,7 +20,6 @@ package dochandler
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"strings"
 
@@ -158,7 +157,7 @@ func applyID(doc document.Document, id string) document.Document {
 // helper namespace for adding operations to the batch
 func (r *DocumentHandler) addToBatch(operation batch.Operation) error {
 
-	opBytes, err := json.Marshal(operation)
+	opBytes, err := docutil.MarshalCanonical(operation)
 	if err != nil {
 		return err
 	}

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 )
 
 const (
@@ -133,7 +135,7 @@ func DidDocumentFromBytes(data []byte) (DIDDocument, error) {
 
 // String returns string representation of did document
 func (doc *DIDDocument) String() string {
-	s, err := json.MarshalIndent(doc, "", "  ")
+	s, err := docutil.MarshalIndentCanonical(doc, "", "  ")
 	if err != nil {
 		return "<ERROR marshalling DIDDocument>"
 	}
@@ -142,7 +144,7 @@ func (doc *DIDDocument) String() string {
 
 // Bytes returns byte representation of did document
 func (doc *DIDDocument) Bytes() []byte {
-	s, err := json.Marshal(doc)
+	s, err := docutil.MarshalCanonical(doc)
 	if err != nil {
 		return []byte("<ERROR marshalling DIDDocument>")
 	}

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -6,7 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package document
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+)
 
 const jsonldID = "id"
 
@@ -37,7 +41,7 @@ func (doc *Document) GetStringValue(key string) string {
 
 // Bytes returns byte representation of did document
 func (doc *Document) Bytes() ([]byte, error) {
-	return json.Marshal(doc)
+	return docutil.MarshalCanonical(doc)
 }
 
 // JSONLdObject returns map that represents JSON LD Object

--- a/pkg/docutil/json.go
+++ b/pkg/docutil/json.go
@@ -1,0 +1,92 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package docutil
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// MarshalCanonical marshals the object into a canonical JSON format
+func MarshalCanonical(v interface{}) ([]byte, error) {
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return getCanonicalContent(bytes)
+}
+
+// MarshalIndentCanonical is like MarshalCanonical but applies Indent to format the output.
+// Each JSON element in the output will begin on a new line beginning with prefix
+// followed by one or more copies of indent according to the indentation nesting.
+func MarshalIndentCanonical(v interface{}, prefix, indent string) ([]byte, error) {
+	b, err := MarshalCanonical(v)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = json.Indent(&buf, b, prefix, indent)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// getCanonicalContent ensures that fields in the JSON doc are marshaled in a deterministic order.
+func getCanonicalContent(content []byte) ([]byte, error) {
+	m, err := unmarshalJSONMap(content)
+	if err != nil {
+		a, err := unmarshalJSONArray(content)
+		if err != nil {
+			return nil, err
+		}
+
+		// Re-marshal it in order to ensure that the JSON fields are marshaled in a deterministic order.
+		bytes, err := marshalJSONArray(a)
+		if err != nil {
+			return nil, err
+		}
+		return bytes, nil
+	}
+
+	// Re-marshal it in order to ensure that the JSON fields are marshaled in a deterministic order.
+	bytes, err := marshalJSONMap(m)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+// marshalJSONMap marshals a JSON map. This variable may be overridden by unit tests.
+var marshalJSONMap = func(m map[string]interface{}) ([]byte, error) {
+	return json.Marshal(&m)
+}
+
+// unmarshalJSONMap unmarshals a JSON map from the given bytes. This variable may be overridden by unit tests.
+var unmarshalJSONMap = func(bytes []byte) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+	err := json.Unmarshal(bytes, &m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// unmarshalJSONArray unmarshals an array of JSON maps from the given bytes. This variable may be overridden by unit tests.
+var unmarshalJSONArray = func(bytes []byte) ([]map[string]interface{}, error) {
+	var a []map[string]interface{}
+	err := json.Unmarshal(bytes, &a)
+	if err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// marshalJSONArray marshals an array of JSON maps. This variable may be overridden by unit tests.
+var marshalJSONArray = func(a []map[string]interface{}) ([]byte, error) {
+	return json.Marshal(&a)
+}

--- a/pkg/docutil/json_test.go
+++ b/pkg/docutil/json_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package docutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testData struct {
+	FieldC string
+	FieldB int
+	FieldA string
+}
+
+func TestMarshalCanonical(t *testing.T) {
+	value1 := &testData{
+		FieldC: "valueC_1",
+		FieldB: 100,
+		FieldA: "valueA_1",
+	}
+	value2 := &testData{
+		FieldC: "valueC_2",
+		FieldB: 200,
+		FieldA: "valueA_2",
+	}
+
+	t.Run("Struct", func(t *testing.T) {
+		v1, err := MarshalCanonical(value1)
+		require.NoError(t, err)
+		assert.NotNil(t, v1)
+		fmt.Printf("%s\n", v1)
+
+		v := &testData{}
+		err = json.Unmarshal(v1, v)
+		require.NoError(t, err)
+
+		require.Equal(t, value1, v)
+	})
+
+	t.Run("Array", func(t *testing.T) {
+		arr := []*testData{value1, value2}
+		v1, err := MarshalCanonical(arr)
+		require.NoError(t, err)
+		assert.NotNil(t, v1)
+		fmt.Printf("%s\n", v1)
+
+		var v []*testData
+		err = json.Unmarshal(v1, &v)
+		require.NoError(t, err)
+
+		require.Equal(t, arr, v)
+	})
+
+	t.Run("Marshal struct error", func(t *testing.T) {
+		reset := SetJSONMarshaler(func(map[string]interface{}) (bytes []byte, e error) {
+			return nil, errors.New("injected marshal error")
+		})
+		defer reset()
+
+		_, err := MarshalCanonical(value1)
+		require.Error(t, err)
+	})
+
+	t.Run("Unmarshal struct error", func(t *testing.T) {
+		reset := SetJSONUnmarshaler(func(bytes []byte) (map[string]interface{}, error) {
+			return nil, errors.New("injected marshal error")
+		})
+		defer reset()
+
+		_, err := MarshalCanonical(value1)
+		require.Error(t, err)
+	})
+
+	t.Run("Marshal array error", func(t *testing.T) {
+		reset := SetJSONArrayMarshaler(func([]map[string]interface{}) (bytes []byte, e error) {
+			return nil, errors.New("injected marshal error")
+		})
+		defer reset()
+
+		_, err := MarshalCanonical([]*testData{value1, value2})
+		require.Error(t, err)
+	})
+
+	t.Run("Unmarshal array error", func(t *testing.T) {
+		reset := SetJSONArrayUnmarshaler(func(bytes []byte) ([]map[string]interface{}, error) {
+			return nil, errors.New("injected marshal error")
+		})
+		defer reset()
+
+		_, err := MarshalCanonical([]*testData{value1, value2})
+		require.Error(t, err)
+	})
+}
+
+func TestMarshalIndentCanonical(t *testing.T) {
+	value1 := &testData{
+		FieldC: "valueC_1",
+		FieldB: 100,
+		FieldA: "valueA_1",
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		v1, err := MarshalIndentCanonical(value1, "", " ")
+		require.NoError(t, err)
+		assert.NotNil(t, v1)
+		fmt.Printf("%s\n", v1)
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		reset := SetJSONMarshaler(func(m map[string]interface{}) (bytes []byte, e error) {
+			return nil, errors.New("injected marshal error")
+		})
+		defer reset()
+
+		_, err := MarshalIndentCanonical(value1, "", " ")
+		require.Error(t, err)
+	})
+}
+
+func TestGetCanonicalContent(t *testing.T) {
+	t.Run("Struct", func(t *testing.T) {
+		value1 := []byte(`{"field1":"value1","field2":"value2"}`)
+		value2 := []byte(`{"field2":"value2","field1":"value1"}`)
+
+		v1, err := getCanonicalContent(value1)
+		require.NoError(t, err)
+		assert.NotNil(t, v1)
+
+		v2, err := getCanonicalContent(value2)
+		require.NoError(t, err)
+		assert.Equal(t, v1, v2)
+	})
+
+	t.Run("Array", func(t *testing.T) {
+		value1 := []byte(`[{"field1":"value1_1","field2":"value2_1"},{"field1":"value1_2","field2":"value2_2"}]`)
+		value2 := []byte(`[{"field2":"value2_1","field1":"value1_1"},{"field2":"value2_2","field1":"value1_2"}]`)
+
+		v1, err := getCanonicalContent(value1)
+		require.NoError(t, err)
+		assert.NotNil(t, v1)
+
+		v2, err := getCanonicalContent(value2)
+		require.NoError(t, err)
+		assert.Equal(t, v1, v2)
+	})
+
+	t.Run("Marshal error", func(t *testing.T) {
+		value1 := []byte(`{"field1":"value1","field2":"value2"}`)
+
+		reset := SetJSONMarshaler(func(m map[string]interface{}) (bytes []byte, e error) {
+			return nil, errors.New("injected marshal error")
+		})
+		defer reset()
+
+		_, err := getCanonicalContent(value1)
+		require.Error(t, err)
+	})
+}

--- a/pkg/docutil/test_exports.go
+++ b/pkg/docutil/test_exports.go
@@ -1,0 +1,49 @@
+// +build testing
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package docutil
+
+// SetJSONMarshaler sets the JSON map marshaler for unit tests.
+// Returns a function that resets the marshaler to the previous value.
+func SetJSONMarshaler(marshaler func(m map[string]interface{}) ([]byte, error)) func() {
+	prevMarshaler := marshalJSONMap
+	marshalJSONMap = marshaler
+	return func() {
+		marshalJSONMap = prevMarshaler
+	}
+}
+
+// SetJSONUnmarshaler sets the JSON map unmarshaler for unit tests.
+// Returns a function that resets the unmarshaler to the previous value.
+func SetJSONUnmarshaler(unmarshaler func(bytes []byte) (map[string]interface{}, error)) func() {
+	prevUnmarshaler := unmarshalJSONMap
+	unmarshalJSONMap = unmarshaler
+	return func() {
+		unmarshalJSONMap = prevUnmarshaler
+	}
+}
+
+// SetJSONArrayMarshaler sets the JSON array marshaler for unit tests.
+// Returns a function that resets the marshaler to the previous value.
+func SetJSONArrayMarshaler(marshaler func(m []map[string]interface{}) ([]byte, error)) func() {
+	prevMarshaler := marshalJSONArray
+	marshalJSONArray = marshaler
+	return func() {
+		marshalJSONArray = prevMarshaler
+	}
+}
+
+// SetJSONArrayUnmarshaler sets the JSON array unmarshaler for unit tests.
+// Returns a function that resets the unmarshaler to the previous value.
+func SetJSONArrayUnmarshaler(unmarshaler func(bytes []byte) ([]map[string]interface{}, error)) func() {
+	prevUnmarshaler := unmarshalJSONArray
+	unmarshalJSONArray = unmarshaler
+	return func() {
+		unmarshalJSONArray = prevUnmarshaler
+	}
+}

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package observer
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -54,11 +53,11 @@ func TestStartObserver(t *testing.T) {
 		var rw sync.RWMutex
 		Start(mockLedger{registerForSidetreeTxnValue: sidetreeTxnCh}, mockDACS{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return json.Marshal(&AnchorFile{})
+				return docutil.MarshalCanonical(&AnchorFile{})
 			}
-			b, err := json.Marshal(batch.Operation{})
+			b, err := docutil.MarshalCanonical(batch.Operation{})
 			require.NoError(t, err)
-			return json.Marshal(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
+			return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 		}}, mockOperationStore{putFunc: func(ops []batch.Operation) error {
 			rw.Lock()
 			isCalled = true
@@ -89,7 +88,7 @@ func TestProcessSidetreeTxn(t *testing.T) {
 	t.Run("test error from processBatchFile", func(t *testing.T) {
 		err := processSidetreeTxn(SidetreeTxn{AnchorAddress: "anchorAddress"}, mockDACS{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return json.Marshal(&AnchorFile{})
+				return docutil.MarshalCanonical(&AnchorFile{})
 			}
 			return nil, fmt.Errorf("read error")
 		}}, nil)
@@ -102,7 +101,7 @@ func TestProcessBatchFile(t *testing.T) {
 	t.Run("test error from getBatchFile", func(t *testing.T) {
 		err := processBatchFile("", SidetreeTxn{AnchorAddress: "anchorAddress"}, mockDACS{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return json.Marshal(&AnchorFile{})
+				return docutil.MarshalCanonical(&AnchorFile{})
 			}
 			return []byte("1"), nil
 		}}, nil)
@@ -113,10 +112,10 @@ func TestProcessBatchFile(t *testing.T) {
 	t.Run("test error from updateOperation", func(t *testing.T) {
 		err := processBatchFile("", SidetreeTxn{AnchorAddress: "anchorAddress"}, mockDACS{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return json.Marshal(&AnchorFile{})
+				return docutil.MarshalCanonical(&AnchorFile{})
 			}
 
-			return json.Marshal(&BatchFile{Operations: []string{"1"}})
+			return docutil.MarshalCanonical(&BatchFile{Operations: []string{"1"}})
 		}}, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to update operation with blockchain metadata")
@@ -125,11 +124,11 @@ func TestProcessBatchFile(t *testing.T) {
 	t.Run("test error from operationStore Put", func(t *testing.T) {
 		err := processBatchFile("", SidetreeTxn{AnchorAddress: "anchorAddress"}, mockDACS{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return json.Marshal(&AnchorFile{})
+				return docutil.MarshalCanonical(&AnchorFile{})
 			}
-			b, err := json.Marshal(batch.Operation{})
+			b, err := docutil.MarshalCanonical(batch.Operation{})
 			require.NoError(t, err)
-			return json.Marshal(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
+			return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 		}}, mockOperationStore{putFunc: func(ops []batch.Operation) error {
 			return fmt.Errorf("put error")
 		}})
@@ -140,11 +139,11 @@ func TestProcessBatchFile(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		err := processBatchFile("", SidetreeTxn{AnchorAddress: "anchorAddress"}, mockDACS{readFunc: func(key string) ([]byte, error) {
 			if key == "anchorAddress" {
-				return json.Marshal(&AnchorFile{})
+				return docutil.MarshalCanonical(&AnchorFile{})
 			}
-			b, err := json.Marshal(batch.Operation{})
+			b, err := docutil.MarshalCanonical(batch.Operation{})
 			require.NoError(t, err)
-			return json.Marshal(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
+			return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 		}}, mockOperationStore{})
 		require.NoError(t, err)
 	})
@@ -159,7 +158,7 @@ func TestUpdateOperation(t *testing.T) {
 	})
 
 	t.Run("test success", func(t *testing.T) {
-		b, err := json.Marshal(batch.Operation{})
+		b, err := docutil.MarshalCanonical(batch.Operation{})
 		require.NoError(t, err)
 		updatedOps, err := updateOperation(docutil.EncodeToString(b), 1, SidetreeTxn{TransactionTime: 20, TransactionNumber: 2})
 		require.NoError(t, err)

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -12,13 +12,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
-	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
-
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
 const (
@@ -245,7 +243,7 @@ func getUpdateOperation(uniqueSuffix string, previousOperationHash string, opera
 		"value": "did:sidetree:updateid" + strconv.Itoa(int(operationNumber)),
 	}
 
-	patchBytes, err := json.Marshal([]map[string]interface{}{patch})
+	patchBytes, err := docutil.MarshalCanonical([]map[string]interface{}{patch})
 	if err != nil {
 		panic(err)
 	}
@@ -268,7 +266,7 @@ func getUpdateOperation(uniqueSuffix string, previousOperationHash string, opera
 
 func generateUpdateOperationBuffer(updatePayload updatePayloadSchema, keyID string, didUniqueSuffix string) batch.Operation {
 
-	updatePayloadJson, err := json.Marshal(updatePayload)
+	updatePayloadJson, err := docutil.MarshalCanonical(updatePayload)
 	if err != nil {
 		panic(err)
 	}

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -12,4 +12,4 @@ PKGS=`go list github.com/trustbloc/sidetree-core-go/pkg/... 2> /dev/null | \
                                                    grep -v /mocks | \
                                                    grep -v /api/`
 echo "Running pkg unit tests..."
-go test -count=1 -cover $PKGS -p 1 -timeout=10m -race -coverprofile=coverage.txt -covermode=atomic
+go test -count=1 -cover $PKGS -p 1 -timeout=10m -race -coverprofile=coverage.txt -covermode=atomic -tags testing


### PR DESCRIPTION
Use a canonical JSON serializer in order to ensure that the fields of JSON documents are always serialized in the same way so that the hash of the document is deterministic.

closes #38

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>