### PR TITLE
feat: Added handling of failed batch processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
 
 )
+
+go 1.13

--- a/pkg/batch/cutter/cutter.go
+++ b/pkg/batch/cutter/cutter.go
@@ -6,45 +6,84 @@ SPDX-License-Identifier: Apache-2.0
 
 package cutter
 
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+)
+
+var logger = logrus.New()
+
 // Cutter defines queue for batching document operations. It also cuts batch file based on batch size.
 type Cutter interface {
 
-	// Add adds an operation to pending batch and cuts batch if pending batch has reached max operations per batch
-	Add(operation []byte, maxOperationsPerBatch uint) (batch [][]byte, pending bool)
+	// Add adds the given operation(s) to pending batch queue and returns the total
+	// number of pending operations.
+	Add(operation ...[]byte) uint
 
-	// Cut returns the current batch and starts a new one
-	Cut() [][]byte
+	// AddFirst adds the given operation(s) to the front of the pending batch queue
+	// and returns the total number of pending operations.
+	AddFirst(bytes ...[]byte) uint
+
+	// Cut returns the current batch along with number of items remaining in the queue.
+	// If force is false then the batch will be cut only if it has reached the max batch size (as specified in the protocol)
+	// If force is true then the batch will be cut if there is at least one operation in the batch
+	Cut(force bool) ([][]byte, uint)
 }
 
 // BatchCutter implements batch cutting
 type BatchCutter struct {
 	pendingBatch [][]byte
+	client       protocol.Client
 }
 
 // New creates a Cutter implementation
-func New() *BatchCutter {
-	return &BatchCutter{}
+func New(client protocol.Client) *BatchCutter {
+	return &BatchCutter{
+		client: client,
+	}
 }
 
-// Add adds an operation to operations queue and cuts batch if pending batch has reached max operations per batch
-func (r *BatchCutter) Add(operation []byte, maxOperationsPerBatch uint) (batch [][]byte, pending bool) {
+// Add adds the given operation(s) to pending batch queue and returns the total
+// number of pending operations.
+func (r *BatchCutter) Add(operations ...[]byte) uint {
 
-	// Enqueuing operation into batch
-	r.pendingBatch = append(r.pendingBatch, operation)
-	pending = true
+	// Enqueuing operations into batch
+	r.pendingBatch = append(r.pendingBatch, operations...)
+	return uint(len(r.pendingBatch))
+}
 
-	if uint(len(r.pendingBatch)) >= maxOperationsPerBatch {
-		operationBatch := r.Cut()
-		batch = append(batch, operationBatch...)
-		pending = false
+// AddFirst adds the given operation(s) to the front of the pending batch queue
+// and returns the total number of pending operations.
+func (r *BatchCutter) AddFirst(operations ...[]byte) uint {
+	r.pendingBatch = append(operations, r.pendingBatch...)
+	return uint(len(r.pendingBatch))
+}
+
+// Cut returns the current batch along with number of items remaining in the queue.
+// If force is false then the batch will be cut only if it has reached the max batch size (as specified in the protocol)
+// If force is true then the batch will be cut if there is at least one operation in the batch
+func (r *BatchCutter) Cut(force bool) (operations [][]byte, pending uint) {
+	pendingSize := uint(len(r.pendingBatch))
+	if pendingSize == 0 {
+		return nil, 0
 	}
 
-	return
+	maxOperationsPerBatch := r.client.Current().MaxOperationsPerBatch
+	if !force && pendingSize < maxOperationsPerBatch {
+		return nil, pendingSize
+	}
+
+	batchSize := min(pendingSize, maxOperationsPerBatch)
+	batch := r.pendingBatch[0:batchSize]
+	r.pendingBatch = r.pendingBatch[batchSize:]
+
+	logger.Debugf("Pending Size: %d, MaxOperationsPerBatch: %d, Batch Size: %d", pendingSize, maxOperationsPerBatch, batchSize)
+	return batch, uint(len(r.pendingBatch))
 }
 
-// Cut returns the current batch and starts a new one
-func (r *BatchCutter) Cut() [][]byte {
-	batch := r.pendingBatch
-	r.pendingBatch = nil
-	return batch
+func min(i, j uint) uint {
+	if i < j {
+		return i
+	}
+	return j
 }

--- a/pkg/batch/cutter/cutter_test.go
+++ b/pkg/batch/cutter/cutter_test.go
@@ -10,32 +10,53 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
-var operation = []byte("Test Operation")
+var (
+	operation1 = []byte("operation1")
+	operation2 = []byte("operation2")
+	operation3 = []byte("operation3")
+	operation4 = []byte("operation4")
+)
 
-func TestAdd(t *testing.T) {
+func TestBatchCutter(t *testing.T) {
 
-	r := New()
+	c := mocks.NewMockProtocolClient()
+	c.Protocol.MaxOperationsPerBatch = 3
+	r := New(c)
 
-	batch, pending := r.Add(operation, 2)
-	require.Nil(t, batch)
-	require.True(t, pending)
+	batch, pending := r.Cut(false)
+	require.Empty(t, batch)
+	require.Zero(t, pending)
 
-	batch, pending = r.Add(operation, 2)
-	require.NotNil(t, batch)
-	require.False(t, pending)
-}
+	require.Equal(t, uint(2), r.Add(operation1, operation2))
+	batch, pending = r.Cut(false)
+	require.Empty(t, batch)
+	require.Equal(t, uint(2), pending)
 
-func TestCut(t *testing.T) {
+	batch, pending = r.Cut(true)
+	require.Len(t, batch, 2)
+	require.Equal(t, operation1, batch[0])
+	require.Equal(t, operation2, batch[1])
+	require.Zero(t, pending)
 
-	r := New()
+	require.Equal(t, uint(2), r.Add(operation1, operation2))
+	batch, pending = r.Cut(false)
+	require.Empty(t, batch)
+	require.Equal(t, uint(2), pending)
 
-	batch, pending := r.Add(operation, 2)
-	require.Nil(t, batch)
-	require.True(t, pending)
+	r.AddFirst(operation3, operation4)
 
-	batch = r.Cut()
-	require.NotNil(t, batch)
-	require.Equal(t, 1, len(batch))
+	batch, pending = r.Cut(false)
+	require.Len(t, batch, 3)
+	require.Equal(t, operation3, batch[0])
+	require.Equal(t, operation4, batch[1])
+	require.Equal(t, operation1, batch[2])
+	require.Equal(t, uint(1), pending)
+
+	batch, pending = r.Cut(true)
+	require.Len(t, batch, 1)
+	require.Equal(t, operation2, batch[0])
+	require.Zero(t, pending)
 }

--- a/pkg/mocks/cas.go
+++ b/pkg/mocks/cas.go
@@ -33,10 +33,9 @@ func NewMockCasClient(err error) *MockCasClient {
 // Write writes the given content to CAS.
 // returns the SHA256 hash in base64url encoding which represents the address of the content.
 func (m *MockCasClient) Write(content []byte) (string, error) {
-
-	if m.err != nil {
-		return "", m.err
-
+	err := m.GetError()
+	if err != nil {
+		return "", err
 	}
 	hash, err := docutil.ComputeMultihash(sha2_256, content)
 	if err != nil {
@@ -56,9 +55,9 @@ func (m *MockCasClient) Write(content []byte) (string, error) {
 // Read reads the content of the given address in CAS.
 // returns the content of the given address.
 func (m *MockCasClient) Read(address string) ([]byte, error) {
-
-	if m.err != nil {
-		return nil, m.err
+	err := m.GetError()
+	if err != nil {
+		return nil, err
 	}
 
 	m.RLock()
@@ -85,4 +84,20 @@ func (m *MockCasClient) Read(address string) ([]byte, error) {
 	}
 
 	return value, nil
+}
+
+// SetError injects an error into the mock client
+func (m *MockCasClient) SetError(err error) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.err = err
+}
+
+// GetError returns the injected error
+func (m *MockCasClient) GetError() error {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.err
 }


### PR DESCRIPTION
When a batch fails to be processed for whatever reason, the operations are returned to the head of the pending operations queue so that they may be processed at the next timeout.

closes #42

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>