### PR TITLE
feat: Publicly expose observer's txn processor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ run:
   deadline: 1m
   issues-exit-code: 1
   tests: true
-  build-tags: [""]
+  build-tags: ["testing"]
   skip-files:
     - ^(.*_test.go.*$)$
 

--- a/pkg/docutil/json.go
+++ b/pkg/docutil/json.go
@@ -40,15 +40,15 @@ func MarshalIndentCanonical(v interface{}, prefix, indent string) ([]byte, error
 func getCanonicalContent(content []byte) ([]byte, error) {
 	m, err := unmarshalJSONMap(content)
 	if err != nil {
-		a, err := unmarshalJSONArray(content)
-		if err != nil {
-			return nil, err
+		a, e := unmarshalJSONArray(content)
+		if e != nil {
+			return nil, e
 		}
 
 		// Re-marshal it in order to ensure that the JSON fields are marshaled in a deterministic order.
-		bytes, err := marshalJSONArray(a)
-		if err != nil {
-			return nil, err
+		bytes, e := marshalJSONArray(a)
+		if e != nil {
+			return nil, e
 		}
 		return bytes, nil
 	}


### PR DESCRIPTION
Created a TxnProcessor struct which may be invoked externally.
Also fixed some golangci-lint errors due to the latest version of golangci-lint.

closes #45

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>