### PR TITLE
fix: Set content-type appropriately

### DIFF
--- a/pkg/restapi/common/httputil.go
+++ b/pkg/restapi/common/httputil.go
@@ -15,6 +15,7 @@ import (
 
 // WriteResponse writes a response to the response writer
 func WriteResponse(rw http.ResponseWriter, status int, v interface{}) {
+	rw.Header().Set("Content-Type", "application/did+ld+json")
 	rw.WriteHeader(status)
 	err := json.NewEncoder(rw).Encode(v)
 	if err != nil {

--- a/pkg/restapi/common/httputil_test.go
+++ b/pkg/restapi/common/httputil_test.go
@@ -22,6 +22,7 @@ func TestWriteResponse(t *testing.T) {
 	WriteResponse(rw, http.StatusOK, "content")
 	require.Equal(t, http.StatusOK, rw.Code)
 	require.Equal(t, "\"content\"\n", rw.Body.String())
+	require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 }
 
 func TestWriteError(t *testing.T) {

--- a/pkg/restapi/diddochandler/doc.go
+++ b/pkg/restapi/diddochandler/doc.go
@@ -15,10 +15,10 @@ SPDX-License-Identifier: Apache-2.0
 //     License: SPDX-License-Identifier: Apache-2.0
 //
 //     Consumes:
-//     - application/json
+//     - application/did+ld+json
 //
 //     Produces:
-//     - application/json
+//     - application/did+ld+json
 //
 // swagger:meta
 package diddochandler

--- a/pkg/restapi/diddochandler/restapi_test.go
+++ b/pkg/restapi/diddochandler/restapi_test.go
@@ -80,13 +80,14 @@ func httpPut(t *testing.T, url string, req *model.Request) (*model.Response, err
 	httpReq, err := http.NewRequest("POST", url, bytes.NewReader(b))
 	require.NoError(t, err)
 
-	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Content-Type", "application/did+ld+json")
 	resp, err := invokeWithRetry(
 		func() (response *http.Response, e error) {
 			return client.Do(httpReq)
 		},
 	)
 	require.NoError(t, err)
+	require.Equal(t, "application/did+ld+json", resp.Header.Get("content-type"))
 	return handleHttpResp(t, resp)
 }
 

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -34,6 +34,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/document", nil)
 		handler.Resolve(rw, req)
 		require.Equal(t, http.StatusOK, rw.Code)
+		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
 	t.Run("Invalid ID", func(t *testing.T) {
 		getID = func(req *http.Request) string { return "someid" }

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -62,6 +62,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader([]byte(createRequest)))
 		handler.Update(rw, req)
 		require.Equal(t, http.StatusOK, rw.Code)
+		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
 	t.Run("Update", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
@@ -71,6 +72,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader([]byte(updateRequest)))
 		handler.Update(rw, req)
 		require.Equal(t, http.StatusOK, rw.Code)
+		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
 	t.Run("Unsupported operation", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)


### PR DESCRIPTION
Set the content-type in the response header to "application/did+ld+json".

closes #63

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>