### PR TITLE
feat: Allow DID doc handler base path to be configurable

### DIFF
--- a/pkg/restapi/diddochandler/resolvehandler.go
+++ b/pkg/restapi/diddochandler/resolvehandler.go
@@ -16,26 +16,28 @@ import (
 // ResolveHandler resolves DID documents
 type ResolveHandler struct {
 	*dochandler.ResolveHandler
+	basePath string
 }
 
 // NewResolveHandler returns a new DID document resolve handler
-func NewResolveHandler(resolver dochandler.Resolver) *ResolveHandler {
+func NewResolveHandler(basePath string, resolver dochandler.Resolver) *ResolveHandler {
 	return &ResolveHandler{
 		ResolveHandler: dochandler.NewResolveHandler(resolver),
+		basePath:       basePath,
 	}
 }
 
 // Path returns the context path
-func (o *ResolveHandler) Path() string {
-	return Path + "/{id}"
+func (h *ResolveHandler) Path() string {
+	return h.basePath + "/{id}"
 }
 
 // Method returns the HTTP method
-func (o *ResolveHandler) Method() string {
+func (h *ResolveHandler) Method() string {
 	return http.MethodGet
 }
 
 // Handler returns the handler
-func (o *ResolveHandler) Handler() common.HTTPRequestHandler {
-	return o.Resolve
+func (h *ResolveHandler) Handler() common.HTTPRequestHandler {
+	return h.Resolve
 }

--- a/pkg/restapi/diddochandler/resolvehandler_test.go
+++ b/pkg/restapi/diddochandler/resolvehandler_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestResolveHandler_Resolve(t *testing.T) {
 	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
-	handler := NewResolveHandler(docHandler)
-	require.Equal(t, Path+"/{id}", handler.Path())
+	handler := NewResolveHandler(basePath, docHandler)
+	require.Equal(t, basePath+"/{id}", handler.Path())
 	require.Equal(t, http.MethodGet, handler.Method())
 	require.NotNil(t, handler.Handler())
 

--- a/pkg/restapi/diddochandler/restapi_test.go
+++ b/pkg/restapi/diddochandler/restapi_test.go
@@ -28,6 +28,7 @@ import (
 const (
 	url       = "localhost:4656"
 	clientURL = "http://" + url
+	basePath  = "/Document"
 )
 
 const (
@@ -39,8 +40,8 @@ func TestRESTAPI(t *testing.T) {
 
 	s := newRESTService(
 		url,
-		NewUpdateHandler(didDocHandler),
-		NewResolveHandler(didDocHandler),
+		NewUpdateHandler(basePath, didDocHandler),
+		NewResolveHandler(basePath, didDocHandler),
 	)
 	s.start()
 	defer s.stop()
@@ -50,7 +51,7 @@ func TestRESTAPI(t *testing.T) {
 		err := json.Unmarshal([]byte(createRequest), request)
 		require.NoError(t, err)
 
-		resp, err := httpPut(t, clientURL+Path, request)
+		resp, err := httpPut(t, clientURL+basePath, request)
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 
@@ -59,7 +60,7 @@ func TestRESTAPI(t *testing.T) {
 		require.Equal(t, didID, doc["id"])
 	})
 	t.Run("Resolve DID doc", func(t *testing.T) {
-		resp, err := httpGet(t, clientURL+Path+"/"+didID)
+		resp, err := httpGet(t, clientURL+basePath+"/"+didID)
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 

--- a/pkg/restapi/diddochandler/updatehandler.go
+++ b/pkg/restapi/diddochandler/updatehandler.go
@@ -13,26 +13,23 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/dochandler"
 )
 
-const (
-	// Path is the context path for the DID document REST service
-	Path = "/document"
-)
-
 // UpdateHandler handles the creation and update of DID documents
 type UpdateHandler struct {
 	*dochandler.UpdateHandler
+	basePath string
 }
 
 // NewUpdateHandler returns a new DID document update handler
-func NewUpdateHandler(processor dochandler.Processor) *UpdateHandler {
+func NewUpdateHandler(basePath string, processor dochandler.Processor) *UpdateHandler {
 	return &UpdateHandler{
 		UpdateHandler: dochandler.NewUpdateHandler(processor),
+		basePath:      basePath,
 	}
 }
 
 // Path returns the context path
 func (h *UpdateHandler) Path() string {
-	return Path
+	return h.basePath
 }
 
 // Method returns the HTTP method

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -35,8 +35,8 @@ const (
 func TestUpdateHandler_Update(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
-		handler := NewUpdateHandler(docHandler)
-		require.Equal(t, Path, handler.Path())
+		handler := NewUpdateHandler(basePath, docHandler)
+		require.Equal(t, basePath, handler.Path())
 		require.Equal(t, http.MethodPost, handler.Method())
 		require.NotNil(t, handler.Handler())
 


### PR DESCRIPTION
Added a configurable base path to the DID document handler.
    
closes #72

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>