### PR TITLE
feat: Remove trailing delimiter from doc namespace

### DIFF
--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -112,7 +112,7 @@ func (r *DocumentHandler) ProcessOperation(operation batch.Operation) (document.
 // to generate and return as the resolved DID Document, in which case the supplied encoded DID Document is subject to
 // the same validation as an original DID Document in a create operation
 func (r *DocumentHandler) ResolveDocument(didOrInitialDID string) (document.Document, error) {
-	if !strings.HasPrefix(didOrInitialDID, r.namespace) {
+	if !strings.HasPrefix(didOrInitialDID, r.namespace+docutil.NamespaceDelimiter) {
 		return nil, errors.New("must start with configured namespace")
 	}
 
@@ -147,7 +147,7 @@ func (r *DocumentHandler) resolveRequestWithID(uniquePortion string) (document.D
 		log.Errorf("Failed to resolve uniquePortion[%s]: %s", uniquePortion, err.Error())
 		return nil, err
 	}
-	return applyID(doc, r.namespace+uniquePortion), nil
+	return applyID(doc, r.namespace+docutil.NamespaceDelimiter+uniquePortion), nil
 }
 
 func (r *DocumentHandler) resolveRequestWithDocument(encodedDocument string) (document.Document, error) {
@@ -230,12 +230,13 @@ func (r *DocumentHandler) validateOperation(operation batch.Operation) error {
 
 // getUniquePortion fetches unique portion of ID which is string after namespace
 func getUniquePortion(namespace, idOrDocument string) (string, error) {
-	pos := strings.Index(idOrDocument, namespace)
+	ns := namespace + docutil.NamespaceDelimiter
+	pos := strings.Index(idOrDocument, ns)
 	if pos == -1 {
 		return "", errors.New("ID must start with configured namespace")
 	}
 
-	adjustedPos := pos + len(namespace)
+	adjustedPos := pos + len(ns)
 	if adjustedPos >= len(idOrDocument) {
 		return "", errors.New("unique portion is empty")
 	}

--- a/pkg/docutil/doc.go
+++ b/pkg/docutil/doc.go
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package docutil
 
+// NamespaceDelimiter is the delimiter that separates the namespace from the unique suffix
+const NamespaceDelimiter = ":"
+
 //CalculateID calculates the ID from an encoded initial document (from create operation)
 func CalculateID(namespace, encodedDocument string, hashAlgorithmAsMultihashCode uint) (string, error) {
 	didDocumentBytes := []byte(encodedDocument)
@@ -14,6 +17,6 @@ func CalculateID(namespace, encodedDocument string, hashAlgorithmAsMultihashCode
 		return "", err
 	}
 
-	didID := namespace + EncodeToString(multiHashBytes)
+	didID := namespace + NamespaceDelimiter + EncodeToString(multiHashBytes)
 	return didID, nil
 }

--- a/pkg/docutil/doc_test.go
+++ b/pkg/docutil/doc_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	multihashCode uint = 18
-	didMethodName      = "did:sidetree:"
+	didMethodName      = "did:sidetree"
 	expectedID         = "did:sidetree:EiDOQXC2GnoVyHwIRbjhLx_cNc6vmZaS04SZjZdlLLAPRg=="
 	// encoded payload contains encoded document that corresponds to unique suffix above
 	encodedPayload = "ewogICJAY29udGV4dCI6ICJodHRwczovL3czaWQub3JnL2RpZC92MSIsCiAgInB1YmxpY0tleSI6IFt7CiAgICAiaWQiOiAiI2tleTEiLAogICAgInR5cGUiOiAiU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOCIsCiAgICAicHVibGljS2V5SGV4IjogIjAyZjQ5ODAyZmIzZTA5YzZkZDQzZjE5YWE0MTI5M2QxZTBkYWQwNDRiNjhjZjgxY2Y3MDc5NDk5ZWRmZDBhYTlmMSIKICB9XSwKICAic2VydmljZSI6IFt7CiAgICAiaWQiOiAiSWRlbnRpdHlIdWIiLAogICAgInR5cGUiOiAiSWRlbnRpdHlIdWIiLAogICAgInNlcnZpY2VFbmRwb2ludCI6IHsKICAgICAgIkBjb250ZXh0IjogInNjaGVtYS5pZGVudGl0eS5mb3VuZGF0aW9uL2h1YiIsCiAgICAgICJAdHlwZSI6ICJVc2VyU2VydmljZUVuZHBvaW50IiwKICAgICAgImluc3RhbmNlIjogWyJkaWQ6YmFyOjQ1NiIsICJkaWQ6emF6Ojc4OSJdCiAgICB9CiAgfV0KfQo="

--- a/pkg/restapi/diddochandler/restapi_test.go
+++ b/pkg/restapi/diddochandler/restapi_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
@@ -32,7 +33,7 @@ const (
 )
 
 const (
-	didID = namespace + "EiDOQXC2GnoVyHwIRbjhLx_cNc6vmZaS04SZjZdlLLAPRg=="
+	didID = namespace + docutil.NamespaceDelimiter + "EiDOQXC2GnoVyHwIRbjhLx_cNc6vmZaS04SZjZdlLLAPRg=="
 )
 
 func TestRESTAPI(t *testing.T) {

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	namespace string = "did:sidetree:"
+	namespace string = "did:sidetree"
 
 	createRequest = `{
   "header": {

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
@@ -50,7 +51,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rw.Code)
 	})
 	t.Run("Not found", func(t *testing.T) {
-		getID = func(req *http.Request) string { return namespace + "someid" }
+		getID = func(req *http.Request) string { return namespace + docutil.NamespaceDelimiter + "someid" }
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
 		handler := NewResolveHandler(docHandler)
 
@@ -60,7 +61,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, rw.Code)
 	})
 	t.Run("Error", func(t *testing.T) {
-		getID = func(req *http.Request) string { return namespace + "someid" }
+		getID = func(req *http.Request) string { return namespace + docutil.NamespaceDelimiter + "someid" }
 		errExpected := errors.New("get doc error")
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace).WithError(errExpected)
 		handler := NewResolveHandler(docHandler)

--- a/pkg/restapi/dochandler/updatehandler.go
+++ b/pkg/restapi/dochandler/updatehandler.go
@@ -90,7 +90,7 @@ func (h *UpdateHandler) getOperation(request *model.Request) (batch.Operation, e
 			return batch.Operation{}, err
 		}
 		operation.UniqueSuffix = uniqueSuffix
-		operation.ID = h.processor.Namespace() + uniqueSuffix
+		operation.ID = h.processor.Namespace() + docutil.NamespaceDelimiter + uniqueSuffix
 		operation.OperationNumber = 0
 		return operation, nil
 
@@ -103,7 +103,7 @@ func (h *UpdateHandler) getOperation(request *model.Request) (batch.Operation, e
 		operation.UniqueSuffix = decodedPayload.DidUniqueSuffix
 		operation.PreviousOperationHash = decodedPayload.PreviousOperationHash
 		operation.Patch = decodedPayload.Patch
-		operation.ID = h.processor.Namespace() + decodedPayload.DidUniqueSuffix
+		operation.ID = h.processor.Namespace() + docutil.NamespaceDelimiter + decodedPayload.DidUniqueSuffix
 		return operation, nil
 
 	default:

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	namespace string = "sample:sidetree:"
+	namespace string = "sample:sidetree"
 
 	createRequest = `{
   "header": {


### PR DESCRIPTION
The namespace for the document handler is now assumed to have no trailing delimiter (":"). The handler code will append the delimiter.

closes #74

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>