### PR TITLE
chore: Remove unused fields for update operation

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -22,12 +22,8 @@ type Operation struct {
 	EncodedPayload string `json:"encodedPayload"`
 	//Signature is the signature of this operation
 	Signature string `json:"signature"`
-	//PreviousOperationHash is the hash of the previous operation - undefined for create operation
-	PreviousOperationHash string `json:"previousOperationHash"`
 	//The unique suffix - encoded hash of the original create document
 	UniqueSuffix string `json:"uniqueSuffix"`
-	//The number incremented from the last change version number. 1 if first change.
-	OperationNumber uint `json:"operationNumber"`
 	//An RFC 6902 JSON patch to the current Document
 	Patch jsonpatch.Patch `json:"patch"`
 	//HashAlgorithmInMultiHashCode

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -296,7 +296,6 @@ func getCreateOperation() batchapi.Operation {
 		HashAlgorithmInMultiHashCode: sha2_256,
 		UniqueSuffix:                 uniqueSuffix,
 		ID:                           namespace + uniqueSuffix,
-		OperationNumber:              0,
 	}
 }
 
@@ -311,9 +310,6 @@ func getUpdateOperation() batchapi.Operation {
 		Type:                         batchapi.OperationTypeUpdate,
 		HashAlgorithmInMultiHashCode: sha2_256,
 		UniqueSuffix:                 decodedPayload.DidUniqueSuffix,
-		ID:                           namespace + docutil.NamespaceDelimiter + decodedPayload.PreviousOperationHash,
-		PreviousOperationHash:        decodedPayload.PreviousOperationHash,
-		OperationNumber:              decodedPayload.OperationNumber,
 		Patch:                        decodedPayload.Patch,
 	}
 }
@@ -335,10 +331,6 @@ func getDecodedPayload(encodedPayload string) (*payloadSchema, error) {
 type payloadSchema struct {
 	//The unique suffix of the DID
 	DidUniqueSuffix string
-	//The number incremented from the last change version number. 1 if first change.
-	OperationNumber uint
-	//The hash of the previous operation made to the DID Document.
-	PreviousOperationHash string
 	//An RFC 6902 JSON patch to the current DID Document
 	Patch jsonpatch.Patch
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -66,7 +66,7 @@ func (s *OperationProcessor) processOperation(index int, operations []batch.Oper
 		if index == 0 {
 			return nil, errors.New("update cannot be first operation")
 		}
-		return s.applyPatch(operation, operations[index-1], doc)
+		return s.applyPatch(operation, doc)
 	default:
 		return nil, errors.New("operation type not supported for process operation")
 	}
@@ -81,21 +81,7 @@ func (s *OperationProcessor) getInitialDocument(operation batch.Operation) (docu
 	return document.FromBytes(decodedBytes)
 }
 
-func (s *OperationProcessor) applyPatch(operation batch.Operation, previousOperation batch.Operation, currentDoc document.Document) (document.Document, error) {
-	if len(operation.PreviousOperationHash) == 0 {
-		return nil, errors.New("any non-create needs a previous operation hash")
-	}
-
-	calculatedOperationHash, err := docutil.GetOperationHash(previousOperation)
-	if err != nil {
-		return nil, err
-	}
-
-	// any non-create requires a previous operation hash that should match the hash of the latest valid operation (previousOperation)
-	if operation.PreviousOperationHash != calculatedOperationHash {
-		return nil, errors.New("previous operation hash has to match the hash of the previous valid operation")
-	}
-
+func (s *OperationProcessor) applyPatch(operation batch.Operation, currentDoc document.Document) (document.Document, error) {
 	docBytes, err := currentDoc.Bytes()
 	if err != nil {
 		return nil, err

--- a/pkg/restapi/dochandler/updatehandler.go
+++ b/pkg/restapi/dochandler/updatehandler.go
@@ -91,7 +91,6 @@ func (h *UpdateHandler) getOperation(request *model.Request) (batch.Operation, e
 		}
 		operation.UniqueSuffix = uniqueSuffix
 		operation.ID = h.processor.Namespace() + docutil.NamespaceDelimiter + uniqueSuffix
-		operation.OperationNumber = 0
 		return operation, nil
 
 	case batch.OperationTypeUpdate:
@@ -99,9 +98,7 @@ func (h *UpdateHandler) getOperation(request *model.Request) (batch.Operation, e
 		if err != nil {
 			return batch.Operation{}, errors.New("request payload doesn't follow the expected update payload schema")
 		}
-		operation.OperationNumber = decodedPayload.OperationNumber
 		operation.UniqueSuffix = decodedPayload.DidUniqueSuffix
-		operation.PreviousOperationHash = decodedPayload.PreviousOperationHash
 		operation.Patch = decodedPayload.Patch
 		operation.ID = h.processor.Namespace() + docutil.NamespaceDelimiter + decodedPayload.DidUniqueSuffix
 		return operation, nil
@@ -139,10 +136,7 @@ func getOperationType(t model.OperationType) batch.OperationType {
 type payloadSchema struct {
 	//The unique suffix of the DID
 	DidUniqueSuffix string
-	//The number incremented from the last change version number. 1 if first change.
-	OperationNumber uint
-	//The hash of the previous operation made to the DID Document.
-	PreviousOperationHash string
+
 	//An RFC 6902 JSON patch to the current DID Document
 	Patch jsonpatch.Patch
 }


### PR DESCRIPTION
Fields operation number and previous operation hash are no longer used.

Closes #97

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>