### PR TITLE
chore: Refactor the order of operation processing

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -34,6 +34,15 @@ type Operation struct {
 	TransactionNumber uint64 `json:"transactionNumber"`
 	//The index this operation was assigned to in the batch
 	OperationIndex uint `json:"operationIndex"`
+
+	// One-time password for update operation
+	UpdateOTP string `json:"updateOTP"`
+	// One-time password for this recovery/checkpoint/revoke operation
+	RecoveryOTP string `json:"recoveryOTP"`
+	// Hash of the one-time password for the next update operation
+	NextUpdateOTPHash string `json:"nextUpdateOTPHash"`
+	// Hash of the one-time password for this recovery/checkpoint/revoke operation.
+	NextRecoveryOTPHash string `json:"nextRecoveryOTPHash"`
 }
 
 // OperationType defines valid values for operation type

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -231,6 +231,7 @@ func generateUpdateOperationBuffer(updatePayload updatePayloadSchema, keyID stri
 		Patch:                        updatePayload.Patch,
 		Type:                         batch.OperationTypeUpdate,
 		EncodedPayload:               encodedPayload,
+		TransactionNumber:            1,
 	}
 	return operation
 }
@@ -252,6 +253,7 @@ func getDefaultStore() *mocks.MockOperationStore {
 		UniqueSuffix:                 uniqueSuffix,
 		Type:                         batch.OperationTypeCreate,
 		EncodedPayload:               encodedPayload,
+		TransactionNumber:            0,
 	}
 
 	// store default create operation


### PR DESCRIPTION
Full operations (create, recover, delete) should be processed before update operations.
Apply update operations that where submitted after last full operation.

Closes #100

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>