### PR TITLE
feat: One-time password for operations

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -12,20 +12,31 @@ import (
 
 // Operation defines an operation
 type Operation struct {
+
 	//Operation type
 	Type OperationType `json:"type"`
 	//ID is full ID for this document - includes namespace + unique suffix
 	ID string `json:"id"`
-	//SigningKeyID is the id of the key that was used to sign this operation
-	SigningKeyID string `json:"signingKeyID"`
-	//EncodedPayload  is the encoded operation payload
-	EncodedPayload string `json:"encodedPayload"`
-	//Signature is the signature of this operation
-	Signature string `json:"signature"`
+
 	//The unique suffix - encoded hash of the original create document
 	UniqueSuffix string `json:"uniqueSuffix"`
+
+	// EncodedProtectedHeader is the encoded protected header
+	EncodedProtectedHeader string `json:"encodedProtectedHeader"`
+	//EncodedPayload  is the encoded operation payload
+	EncodedPayload string `json:"encodedPayload"`
+
+	//EncodedDocument contains encoded original document
+	EncodedDocument string `json:"document"`
+
+	//SigningKeyID is the id of the key that was used to sign this operation
+	SigningKeyID string `json:"signingKeyID"`
+	//Signature is the signature of this operation
+	Signature string `json:"signature"`
+
 	//An RFC 6902 JSON patch to the current Document
 	Patch jsonpatch.Patch `json:"patch"`
+
 	//HashAlgorithmInMultiHashCode
 	HashAlgorithmInMultiHashCode uint `json:"hashAlgorithmInMultiHashCode"`
 	//The logical blockchain time that this operation was anchored on the blockchain
@@ -39,6 +50,7 @@ type Operation struct {
 	UpdateOTP string `json:"updateOTP"`
 	// One-time password for this recovery/checkpoint/revoke operation
 	RecoveryOTP string `json:"recoveryOTP"`
+
 	// Hash of the one-time password for the next update operation
 	NextUpdateOTPHash string `json:"nextUpdateOTPHash"`
 	// Hash of the one-time password for this recovery/checkpoint/revoke operation.

--- a/pkg/docutil/doc.go
+++ b/pkg/docutil/doc.go
@@ -11,12 +11,21 @@ const NamespaceDelimiter = ":"
 
 //CalculateID calculates the ID from an encoded initial document (from create operation)
 func CalculateID(namespace, encodedDocument string, hashAlgorithmAsMultihashCode uint) (string, error) {
-	didDocumentBytes := []byte(encodedDocument)
-	multiHashBytes, err := ComputeMultihash(hashAlgorithmAsMultihashCode, didDocumentBytes)
+	uniqueSuffix, err := CalculateUniqueSuffix(encodedDocument, hashAlgorithmAsMultihashCode)
 	if err != nil {
 		return "", err
 	}
 
-	didID := namespace + NamespaceDelimiter + EncodeToString(multiHashBytes)
+	didID := namespace + NamespaceDelimiter + uniqueSuffix
 	return didID, nil
+}
+
+//CalculateUniqueSuffix calculates the unique from an encoded initial document (from create operation)
+func CalculateUniqueSuffix(encodedDocument string, hashAlgorithmAsMultihashCode uint) (string, error) {
+	multiHashBytes, err := ComputeMultihash(hashAlgorithmAsMultihashCode, []byte(encodedDocument))
+	if err != nil {
+		return "", err
+	}
+
+	return EncodeToString(multiHashBytes), nil
 }

--- a/pkg/docutil/hash.go
+++ b/pkg/docutil/hash.go
@@ -60,15 +60,25 @@ func GetOperationHash(o batch.Operation) (string, error) {
 
 //IsSupportedMultihash checks to see if the given encoded hash has been hashed using valid multihash code
 func IsSupportedMultihash(encodedMultihash string) bool {
-	multihashBytes, err := DecodeString(encodedMultihash)
+	code, err := GetMultihashCode(encodedMultihash)
 	if err != nil {
 		return false
+	}
+
+	return multihash.ValidCode(code)
+}
+
+//GetMultihashCode returns multihash code from encoded multihash
+func GetMultihashCode(encodedMultihash string) (uint64, error) {
+	multihashBytes, err := DecodeString(encodedMultihash)
+	if err != nil {
+		return 0, err
 	}
 
 	mh, err := multihash.Decode(multihashBytes)
 	if err != nil {
-		return false
+		return 0, err
 	}
 
-	return multihash.ValidCode(mh.Code)
+	return mh.Code, nil
 }

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -86,7 +86,7 @@ func (m *MockDocumentHandler) ProcessOperation(operation batch.Operation) (docum
 }
 
 func getDocumentFromPayload(operation batch.Operation) (document.Document, error) {
-	decodedBytes, err := docutil.DecodeString(operation.EncodedPayload)
+	decodedBytes, err := docutil.DecodeString(operation.EncodedDocument)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package dochandler
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,9 +24,12 @@ func TestResolveHandler_Resolve(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().
 			WithNamespace(namespace)
+
+		encodedDocument := getEncodedDocument()
 		doc, err := docHandler.ProcessOperation(batch.Operation{
-			Type:           batch.OperationTypeCreate,
-			EncodedPayload: base64.URLEncoding.EncodeToString([]byte(createRequest)),
+			Type:            batch.OperationTypeCreate,
+			EncodedPayload:  getCreatePayload(encodedDocument),
+			EncodedDocument: encodedDocument,
 		})
 		require.NoError(t, err)
 

--- a/pkg/restapi/model/header.go
+++ b/pkg/restapi/model/header.go
@@ -16,8 +16,4 @@ type Header struct {
 	// kid
 	// Required: true
 	Kid string `json:"kid"`
-
-	// operation
-	// Required: true
-	Operation OperationType `json:"operation"`
 }

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -9,9 +9,9 @@ package model
 // Request is the document request
 // swagger:model docRequest
 type Request struct {
-	// header
+	// protected
 	// Required: true
-	Header *Header `json:"header"`
+	Protected *Header `json:"protected"`
 
 	// payload
 	// Required: true


### PR DESCRIPTION
Upon DID creation, the create operation payload must include:
-- The hash of a one-time password (OTP) for the next recovery operation.
-- The hash of a one-time password (OTP) for the next update operation.

The DID owner must reproduce and present the correct OTP in the subsequent operation for the operation to be considered valid. In addition, each subsequent operation must also include the hash of the new OTP(s) for the next operation. This scheme enables efficient dismissal of counterfeit operations without needing to evaluate signatures.

Closes #90

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>