### PR TITLE
feat: Add "controller" field to public key

### DIFF
--- a/pkg/dochandler/docvalidator/validator.go
+++ b/pkg/dochandler/docvalidator/validator.go
@@ -75,3 +75,8 @@ func (v *Validator) IsValidOriginalDocument(payload []byte) error {
 
 	return nil
 }
+
+// TransformDocument takes internal representation of document and transforms it to required representation
+func (v *Validator) TransformDocument(document document.Document) (document.Document, error) {
+	return document, nil
+}

--- a/pkg/dochandler/docvalidator/validator_test.go
+++ b/pkg/dochandler/docvalidator/validator_test.go
@@ -8,14 +8,12 @@ package docvalidator
 
 import (
 	"fmt"
-
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
@@ -56,11 +54,11 @@ func TestInvalidPayloadError(t *testing.T) {
 	payload := []byte("[test : 123]")
 
 	err := v.IsValidPayload(payload)
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid character")
 
 	err = v.IsValidOriginalDocument(payload)
-	assert.NotNil(t, err)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid character")
 }
 
@@ -92,6 +90,18 @@ func TestIsValidPayload_StoreErrors(t *testing.T) {
 	err = v.IsValidPayload(validUpdate)
 	require.NotNil(t, err)
 	require.Equal(t, err, storeErr)
+}
+
+func TestTransofrmDocument(t *testing.T) {
+	doc, err := document.FromBytes(validDoc)
+	require.NoError(t, err)
+
+	v := getDefaultValidator()
+
+	// there is no transformation for generic doc for now
+	transformed, err := v.TransformDocument(doc)
+	require.NoError(t, err)
+	require.Equal(t, doc, transformed)
 }
 
 func getDefaultValidator() *Validator {

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -177,11 +177,15 @@ func TestGetDocErrors(t *testing.T) {
 }
 
 func TestApplyID(t *testing.T) {
-	doc := applyID(nil, "abc")
+	dochandler := getDocumentHandler(nil)
+
+	doc, err := dochandler.transformDoc(nil, "abc")
+	require.NoError(t, err)
 	require.Nil(t, doc)
 
 	doc = document.Document{}
-	doc = applyID(doc, "abc")
+	doc, err = dochandler.transformDoc(doc, "abc")
+	require.NoError(t, err)
 	require.Equal(t, "abc", doc["id"])
 }
 

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -131,6 +131,11 @@ func DidDocumentFromBytes(data []byte) (DIDDocument, error) {
 	return doc, nil
 }
 
+// DidDocumentFromJSONLDObject creates an instance of DIDDocument from json ld object
+func DidDocumentFromJSONLDObject(jsonldObject map[string]interface{}) DIDDocument {
+	return jsonldObject
+}
+
 // String returns string representation of did document
 func (doc *DIDDocument) String() string {
 	s, err := docutil.MarshalIndentCanonical(doc, "", "  ")


### PR DESCRIPTION
Controller field in public key should be added upon document creation/resolution since it refers to document ID.
Also, it should not be provided in create request.

Closes #111

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>