### PR TITLE
feat: Add REST helper for creating requests

### DIFF
--- a/pkg/restapi/helper/request.go
+++ b/pkg/restapi/helper/request.go
@@ -1,0 +1,159 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package helper
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+)
+
+// CreateRequestInfo contains data for creating create payload
+type CreateRequestInfo struct {
+
+	// opaque content
+	OpaqueDocument string
+
+	// the recovery public key as a HEX string
+	RecoveryKey string
+
+	// one-time password to be used for the next recovery
+	NextRecoveryOTP string
+
+	// one-time password to be used for the next update
+	NextUpdateOTP string
+
+	// latest hashing algorithm supported by protocol
+	MultihashCode uint
+}
+
+//DeletePayloadInfo is the information required to create delete payload
+type DeletePayloadInfo struct {
+
+	// Unique Suffix
+	DidUniqueSuffix string
+
+	// One-time password for recovery operation
+	RecoveryOTP string
+}
+
+// SignedRequestInfo contains data required for signed requests
+type SignedRequestInfo struct {
+
+	// encoded payload
+	Payload string
+
+	// algorithm used for signing
+	Algorithm string
+
+	// ID of the signing key
+	KID string
+
+	// signature over payload
+	Signature string
+}
+
+// NewCreateRequest is utility function to create payload for 'create' request
+func NewCreateRequest(info *CreateRequestInfo) ([]byte, error) {
+	if info.OpaqueDocument == "" {
+		return nil, errors.New("missing opaque document")
+	}
+
+	if info.RecoveryKey == "" {
+		return nil, errors.New("missing recovery key")
+	}
+
+	mhNextRecoveryOTPHash, err := docutil.ComputeMultihash(info.MultihashCode, []byte(info.NextRecoveryOTP))
+	if err != nil {
+		return nil, err
+	}
+
+	mhNextUpdateOTPHash, err := docutil.ComputeMultihash(info.MultihashCode, []byte(info.NextUpdateOTP))
+	if err != nil {
+		return nil, err
+	}
+
+	operationData := model.OperationData{
+		NextUpdateOTPHash: docutil.EncodeToString(mhNextUpdateOTPHash),
+		Document:          info.OpaqueDocument,
+	}
+
+	operationDataBytes, err := json.Marshal(operationData)
+	if err != nil {
+		return nil, err
+	}
+
+	mhOperationData, err := docutil.ComputeMultihash(info.MultihashCode, operationDataBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	schema := &model.CreatePayloadSchema{
+		Operation:     model.OperationTypeCreate,
+		OperationData: operationData,
+		SuffixData: model.SuffixDataSchema{
+			OperationDataHash:   docutil.EncodeToString(mhOperationData),
+			RecoveryKey:         model.PublicKey{PublicKeyHex: info.RecoveryKey},
+			NextRecoveryOTPHash: docutil.EncodeToString(mhNextRecoveryOTPHash),
+		},
+	}
+
+	return json.Marshal(schema)
+}
+
+// NewDeletePayload is utility function to create payload for 'delete' request
+func NewDeletePayload(info *DeletePayloadInfo) (string, error) {
+	if info.DidUniqueSuffix == "" {
+		return "", errors.New("missing did unique suffix")
+	}
+
+	schema := &model.DeletePayloadSchema{
+		Operation:       model.OperationTypeDelete,
+		DidUniqueSuffix: info.DidUniqueSuffix,
+		RecoveryOTP:     info.RecoveryOTP,
+	}
+
+	payload, err := json.Marshal(schema)
+	if err != nil {
+		panic(err)
+	}
+
+	return docutil.EncodeToString(payload), nil
+}
+
+// NewSignedRequest is utility function to create request with payload and payload signature
+// This helper function applies to update, delete and recovery
+func NewSignedRequest(info *SignedRequestInfo) ([]byte, error) {
+	if info.Payload == "" {
+		return nil, errors.New("missing payload")
+	}
+
+	if info.Algorithm == "" {
+		return nil, errors.New("missing algorithm")
+	}
+
+	if info.KID == "" {
+		return nil, errors.New("missing signing key ID")
+	}
+
+	if info.Signature == "" {
+		return nil, errors.New("missing signature")
+	}
+
+	req := model.Request{
+		Protected: &model.Header{
+			Alg: info.Algorithm,
+			Kid: info.KID,
+		},
+		Payload:   info.Payload,
+		Signature: info.Signature,
+	}
+
+	return json.Marshal(req)
+}

--- a/pkg/restapi/helper/request_test.go
+++ b/pkg/restapi/helper/request_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+)
+
+const sha2_256 = 18
+
+func TestNewCreateRequest(t *testing.T) {
+	t.Run("missing opaque document", func(t *testing.T) {
+		request, err := NewCreateRequest(&CreateRequestInfo{})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing opaque document")
+	})
+	t.Run("missing recovery key", func(t *testing.T) {
+		request, err := NewCreateRequest(&CreateRequestInfo{OpaqueDocument: "{}"})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing recovery key")
+	})
+	t.Run("multihash not supported", func(t *testing.T) {
+		info := &CreateRequestInfo{OpaqueDocument: "{}",
+			RecoveryKey: "recovery"}
+
+		request, err := NewCreateRequest(info)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "algorithm not supported")
+	})
+	t.Run("success", func(t *testing.T) {
+		info := &CreateRequestInfo{OpaqueDocument: "{}",
+			RecoveryKey: "recovery", MultihashCode: sha2_256}
+
+		request, err := NewCreateRequest(info)
+		require.NoError(t, err)
+		require.NotEmpty(t, request)
+	})
+}
+
+func TestNewDeletePayload(t *testing.T) {
+	t.Run("missing opaque document", func(t *testing.T) {
+		info := &DeletePayloadInfo{}
+
+		request, err := NewDeletePayload(info)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing did unique suffix")
+	})
+	t.Run("success", func(t *testing.T) {
+		info := &DeletePayloadInfo{DidUniqueSuffix: "whatever"}
+
+		request, err := NewDeletePayload(info)
+		require.NoError(t, err)
+		require.NotEmpty(t, request)
+	})
+}
+
+func TestNewRequest(t *testing.T) {
+	create, err := NewCreateRequest(&CreateRequestInfo{
+		OpaqueDocument:  "{}",
+		RecoveryKey:     "recovery",
+		NextRecoveryOTP: "recoveryOTP",
+		NextUpdateOTP:   "updateOTP",
+		MultihashCode:   sha2_256,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, create)
+
+	payload := docutil.EncodeToString(create)
+
+	const alg = "ALG"
+	const kid = "kid"
+	const signature = "signature"
+
+	t.Run("success", func(t *testing.T) {
+		request, err := NewSignedRequest(
+			&SignedRequestInfo{Payload: payload, Algorithm: alg, Signature: signature, KID: kid})
+		require.NoError(t, err)
+		require.NotEmpty(t, request)
+	})
+	t.Run("missing payload", func(t *testing.T) {
+		request, err := NewSignedRequest(&SignedRequestInfo{Algorithm: alg, Signature: signature, KID: kid})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing payload")
+	})
+	t.Run("missing algorithm", func(t *testing.T) {
+		request, err := NewSignedRequest(&SignedRequestInfo{Payload: payload, Signature: signature, KID: kid})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing algorithm")
+	})
+	t.Run("missing signing key id", func(t *testing.T) {
+		request, err := NewSignedRequest(&SignedRequestInfo{Payload: payload, Algorithm: alg, Signature: signature})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing signing key ID")
+	})
+	t.Run("missing signature", func(t *testing.T) {
+		request, err := NewSignedRequest(&SignedRequestInfo{Payload: payload, Algorithm: alg, KID: kid})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing signature")
+	})
+}

--- a/pkg/restapi/model/payload.go
+++ b/pkg/restapi/model/payload.go
@@ -77,7 +77,7 @@ type DeletePayloadSchema struct {
 	// Required: true
 	DidUniqueSuffix string `json:"didUniqueSuffix"`
 
-	// One-time password for update operation
+	// One-time password for recovery operation
 	// Required: true
 	RecoveryOTP string `json:"recoveryOtp"`
 }


### PR DESCRIPTION
Add REST helper functions for create and delete requests
-create
-delete (signed request)

Closes #125

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>