### PR TITLE
feat: Remove requirement for signature for create

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -29,10 +29,12 @@ type Operation struct {
 	//Document contains original opaque document
 	Document string `json:"document"`
 
-	//SigningKeyID is the id of the key that was used to sign this operation
+	//SigningKeyID is the id of the key that was used to sign this encoded payload
 	SigningKeyID string `json:"signingKeyID"`
-	//Signature is the signature of this operation
+	//Signature is the signature of this encoded payload
 	Signature string `json:"signature"`
+	// Signing algorithm
+	SigningAlgorithm string `json:"algorithm"`
 
 	//An RFC 6902 JSON patch to the current Document
 	Patch jsonpatch.Patch `json:"patch"`

--- a/pkg/restapi/dochandler/payload_test.go
+++ b/pkg/restapi/dochandler/payload_test.go
@@ -100,7 +100,7 @@ func TestParseCreatePayload(t *testing.T) {
 	handler := NewUpdateHandler(docHandler)
 
 	t.Run("success", func(t *testing.T) {
-		payload, err := docutil.DecodeString(getCreatePayload())
+		payload, err := getCreateRequest()
 		require.NoError(t, err)
 
 		schema, err := handler.parseCreatePayload(payload)
@@ -179,7 +179,11 @@ func getOperation(opType string) *batch.Operation {
 
 	switch opType {
 	case create:
-		encodedPayload = getCreatePayload()
+		createReq, err := getCreateRequest()
+		if err != nil {
+			panic(err)
+		}
+		encodedPayload = docutil.EncodeToString(createReq)
 	case update:
 		encodedPayload = getUpdatePayload()
 	case delete:

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -25,9 +25,12 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().
 			WithNamespace(namespace)
 
+		createReq, err := getCreateRequest()
+		require.NoError(t, err)
+
 		doc, err := docHandler.ProcessOperation(&batch.Operation{
 			Type:           batch.OperationTypeCreate,
-			EncodedPayload: getCreatePayload(),
+			EncodedPayload: docutil.EncodeToString(createReq),
 			Document:       validDoc,
 		})
 		require.NoError(t, err)
@@ -76,9 +79,12 @@ func TestResolveHandler_Resolve(t *testing.T) {
 	t.Run("Document is no longer available", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
 
+		createReq, err := getCreateRequest()
+		require.NoError(t, err)
+
 		doc, err := docHandler.ProcessOperation(&batch.Operation{
 			Type:           batch.OperationTypeCreate,
-			EncodedPayload: getCreatePayload(),
+			EncodedPayload: docutil.EncodeToString(createReq),
 			Document:       validDoc,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
Currently for create request we require protected header and signature. Allow for latest create operation schema.

Closes #128

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>