### PR TITLE
fix: Update Issues

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: $(SourceBranchName)-$(Date:yyyyMMdd).$(Rev:r)
+trigger:
+  - master
+pr:
+  - master
+
 variables:
   GO_VERSION: 1.13
   GOPATH: $(Agent.BuildDirectory)/go

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -8,6 +8,7 @@ package processor
 
 import (
 	"errors"
+	"sort"
 
 	log "github.com/sirupsen/logrus"
 
@@ -45,6 +46,8 @@ func (s *OperationProcessor) Resolve(uniqueSuffix string) (document.Document, er
 		return nil, err
 	}
 
+	sortOperations(ops)
+
 	log.Debugf("[%s] Found %d operations for unique suffix [%s]: %+v", s.name, len(ops), uniqueSuffix, ops)
 
 	rm := &resolutionModel{}
@@ -66,7 +69,7 @@ func (s *OperationProcessor) Resolve(uniqueSuffix string) (document.Document, er
 	}
 
 	// next apply update ops since last 'full' transaction
-	rm, err = s.applyOperations(getOpsWithTxnGreaterThan(updateOps, rm.LastOperationTransactionNumber), rm)
+	rm, err = s.applyOperations(getOpsWithTxnGreaterThan(updateOps, rm.LastOperationTransactionTime, rm.LastOperationTransactionNumber), rm)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +89,17 @@ func splitOperations(ops []*batch.Operation) (fullOps, updateOps []*batch.Operat
 	return fullOps, updateOps
 }
 
-func getOpsWithTxnGreaterThan(ops []*batch.Operation, txnNumber uint64) []*batch.Operation {
+// pre-condition: operations have to be sorted
+func getOpsWithTxnGreaterThan(ops []*batch.Operation, txnTime, txnNumber uint64) []*batch.Operation {
 	for index, op := range ops {
+		if op.TransactionTime < txnTime {
+			continue
+		}
+
+		if op.TransactionTime > txnTime {
+			return ops[index:]
+		}
+
 		if op.TransactionNumber > txnNumber {
 			return ops[index:]
 		}
@@ -103,6 +115,8 @@ func (s *OperationProcessor) applyOperations(ops []*batch.Operation, rm *resolut
 		if rm, err = s.applyOperation(op, rm); err != nil {
 			return nil, err
 		}
+
+		log.Debugf("After applying op %+v, New doc: %s", op, rm.Doc)
 	}
 
 	return rm, nil
@@ -110,6 +124,7 @@ func (s *OperationProcessor) applyOperations(ops []*batch.Operation, rm *resolut
 
 type resolutionModel struct {
 	Doc                            document.Document
+	LastOperationTransactionTime   uint64
 	LastOperationTransactionNumber uint64
 	NextUpdateOTPHash              string
 	NextRecoveryOTPHash            string
@@ -142,6 +157,7 @@ func (s *OperationProcessor) applyCreateOperation(operation *batch.Operation, rm
 
 	return &resolutionModel{
 		Doc:                            doc,
+		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
 		NextUpdateOTPHash:              operation.NextUpdateOTPHash,
 		NextRecoveryOTPHash:            operation.NextRecoveryOTPHash}, nil
@@ -178,6 +194,7 @@ func (s *OperationProcessor) applyUpdateOperation(operation *batch.Operation, rm
 
 	return &resolutionModel{
 		Doc:                            doc,
+		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
 		NextUpdateOTPHash:              operation.NextUpdateOTPHash,
 		NextRecoveryOTPHash:            operation.NextRecoveryOTPHash}, nil
@@ -197,6 +214,7 @@ func (s *OperationProcessor) applyRevokeOperation(operation *batch.Operation, rm
 
 	return &resolutionModel{
 		Doc:                            nil,
+		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
 		NextUpdateOTPHash:              "",
 		NextRecoveryOTPHash:            ""}, nil
@@ -225,4 +243,14 @@ func isValidHash(encodedContent, encodedMultihash string) error {
 	}
 
 	return nil
+}
+
+func sortOperations(ops []*batch.Operation) {
+	sort.Slice(ops, func(i, j int) bool {
+		if ops[i].TransactionTime < ops[j].TransactionTime {
+			return true
+		}
+
+		return ops[i].TransactionNumber < ops[j].TransactionNumber
+	})
 }

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -276,6 +276,29 @@ func TestRevoke_InvalidRecoveryOTP(t *testing.T) {
 	require.Nil(t, doc)
 }
 
+func TestOpsWithTxnGreaterThan(t *testing.T) {
+	op1 := &batch.Operation{
+		TransactionTime:   1,
+		TransactionNumber: 1,
+	}
+
+	op2 := &batch.Operation{
+		TransactionTime:   1,
+		TransactionNumber: 2,
+	}
+
+	ops := []*batch.Operation{op1, op2}
+
+	txns := getOpsWithTxnGreaterThan(ops, 0, 0)
+	require.Equal(t, 2, len(txns))
+
+	txns = getOpsWithTxnGreaterThan(ops, 2, 1)
+	require.Equal(t, 0, len(txns))
+
+	txns = getOpsWithTxnGreaterThan(ops, 1, 1)
+	require.Equal(t, 1, len(txns))
+}
+
 func getUpdateOperation(uniqueSuffix string, operationNumber uint) *batch.Operation {
 	patch := map[string]interface{}{
 		"op":    "replace",
@@ -316,6 +339,7 @@ func getRevokeOperation(uniqueSuffix string, operationNumber uint) *batch.Operat
 	return &batch.Operation{
 		UniqueSuffix:      uniqueSuffix,
 		Type:              batch.OperationTypeRevoke,
+		TransactionTime:   0,
 		TransactionNumber: uint64(operationNumber),
 		RecoveryOTP:       base64.URLEncoding.EncodeToString([]byte(recoveryOTP)),
 	}

--- a/pkg/restapi/dochandler/update.go
+++ b/pkg/restapi/dochandler/update.go
@@ -35,7 +35,7 @@ func (h *UpdateHandler) parseUpdateOperation(request []byte) (*batch.Operation, 
 		UniqueSuffix:                 schema.DidUniqueSuffix,
 		UpdateOTP:                    schema.UpdateOTP,
 		NextUpdateOTPHash:            operationData.NextUpdateOTPHash,
-		Patch:                        schema.Patch,
+		Patch:                        operationData.DocumentPatch,
 		HashAlgorithmInMultiHashCode: h.processor.Protocol().Current().HashAlgorithmInMultiHashCode,
 	}, nil
 }

--- a/pkg/restapi/helper/request.go
+++ b/pkg/restapi/helper/request.go
@@ -164,7 +164,7 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 
 	opData := &model.UpdateOperationData{
 		NextUpdateOTPHash: mhNextUpdateOTPHash,
-		// TODO: Set new patches here
+		DocumentPatch:     info.Patch,
 	}
 
 	opDataBytes, err := docutil.MarshalCanonical(opData)

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -59,9 +59,6 @@ type UpdateRequest struct {
 	//The unique suffix of the DID
 	DidUniqueSuffix string `json:"didUniqueSuffix"`
 
-	//An RFC 6902 JSON patch to the current DID Document
-	Patch jsonpatch.Patch
-
 	// One-time password for update operation
 	UpdateOTP string `json:"updateOtp"`
 
@@ -78,8 +75,8 @@ type UpdateOperationData struct {
 	// Hash of the one-time password for the next update operation
 	NextUpdateOTPHash string `json:"nextUpdateOtpHash"`
 
-	// Opaque content
-	DocumentPatch string `json:"document"`
+	//An RFC 6902 JSON patch to the current DID Document
+	DocumentPatch jsonpatch.Patch `json:"documentPatch"`
 }
 
 //RevokeRequest is the struct for revoking document


### PR DESCRIPTION
-- Set json patch in operation data
-- Operations are filtered based on transaction number but should be filtered first by transactionTime and then by transactionNumber
-- Operations should be sorted by transactionTime/transactionNumber

Closes #137

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>