### PR TITLE
fix: Document validator looks for incorrect unique suffix field

### DIFF
--- a/pkg/dochandler/docvalidator/validator.go
+++ b/pkg/dochandler/docvalidator/validator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 )
 
-const uniqueSuffix = "uniqueSuffix"
+const uniqueSuffix = "didUniqueSuffix"
 
 // Validator is responsible for validating document operations and sidetree rules
 type Validator struct {

--- a/pkg/dochandler/docvalidator/validator_test.go
+++ b/pkg/dochandler/docvalidator/validator_test.go
@@ -111,5 +111,5 @@ func getDefaultValidator() *Validator {
 var validDoc = []byte(`{ "name": "John Smith" }`)
 var invalidDoc = []byte(`{ "id" : "001", "name": "John Smith" }`)
 
-var validUpdate = []byte(`{ "uniqueSuffix": "abc" }`)
+var validUpdate = []byte(`{ "didUniqueSuffix": "abc" }`)
 var invalidUpdate = []byte(`{ "patch": "" }`)


### PR DESCRIPTION
Change the field name from 'uniqueSuffix' to 'didUniqueSuffix'.

closes #139

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>