### PR TITLE
chore: Move parsing operation to separate package

### DIFF
--- a/pkg/operation/revoke.go
+++ b/pkg/operation/revoke.go
@@ -4,32 +4,30 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package dochandler
+package operation
 
 import (
 	"encoding/json"
 	"errors"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
-func (h *UpdateHandler) parseRevokeOperation(request []byte) (*batch.Operation, error) {
+// ParseRevokeOperation will parse revoke operation
+func ParseRevokeOperation(request []byte, protocol protocol.Protocol) (*batch.Operation, error) {
 	schema, err := parseRevokeRequest(request)
 	if err != nil {
 		return nil, err
 	}
 
-	id := h.processor.Namespace() + docutil.NamespaceDelimiter + schema.DidUniqueSuffix
-
 	return &batch.Operation{
 		Type:                         batch.OperationTypeRevoke,
 		OperationBuffer:              request,
-		ID:                           id,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
 		RecoveryOTP:                  schema.RecoveryOTP,
-		HashAlgorithmInMultiHashCode: h.processor.Protocol().Current().HashAlgorithmInMultiHashCode,
+		HashAlgorithmInMultiHashCode: protocol.HashAlgorithmInMultiHashCode,
 	}, nil
 }
 

--- a/pkg/operation/revoke_test.go
+++ b/pkg/operation/revoke_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package dochandler
+package operation
 
 import (
 	"encoding/json"
@@ -13,24 +13,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
-	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
+const sha2_256 = 18
+
 func TestParseRevokeOperation(t *testing.T) {
-	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
-	handler := NewUpdateHandler(docHandler)
+	p := protocol.Protocol{
+		HashAlgorithmInMultiHashCode: sha2_256,
+	}
 
 	t.Run("success", func(t *testing.T) {
 		payload, err := getRevokeRequestBytes()
 		require.NoError(t, err)
 
-		op, err := handler.parseRevokeOperation(payload)
+		op, err := ParseRevokeOperation(payload, p)
 		require.NoError(t, err)
 		require.Equal(t, batch.OperationTypeRevoke, op.Type)
 	})
 	t.Run("missing unique suffix", func(t *testing.T) {
-		schema, err := handler.parseRevokeOperation([]byte("{}"))
+		schema, err := ParseRevokeOperation([]byte("{}"), p)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "missing unique suffix")

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package dochandler
+package operation
 
 import (
 	"encoding/json"
@@ -13,25 +13,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
 func TestParseUpdateOperation(t *testing.T) {
-	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
-	handler := NewUpdateHandler(docHandler)
-
+	p := protocol.Protocol{
+		HashAlgorithmInMultiHashCode: sha2_256,
+	}
 	t.Run("success", func(t *testing.T) {
 		payload, err := getUpdateRequestBytes()
 		require.NoError(t, err)
 
-		op, err := handler.parseUpdateOperation(payload)
+		op, err := ParseUpdateOperation(payload, p)
 		require.NoError(t, err)
 		require.Equal(t, batch.OperationTypeUpdate, op.Type)
 	})
 	t.Run("invalid json", func(t *testing.T) {
-		schema, err := handler.parseUpdateOperation([]byte(""))
+		schema, err := ParseUpdateOperation([]byte(""), p)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "unexpected end of JSON input")
@@ -39,13 +39,10 @@ func TestParseUpdateOperation(t *testing.T) {
 }
 
 func TestValidateUpdateOperationData(t *testing.T) {
-	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
-	handler := NewUpdateHandler(docHandler)
-
 	t.Run("invalid next update OTP", func(t *testing.T) {
 		operationData := getUpdateOperationData()
 		operationData.NextUpdateOTPHash = ""
-		err := handler.validateUpdateOperationData(operationData)
+		err := validateUpdateOperationData(operationData, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
 			"next update OTP hash is not computed with the latest supported hash algorithm")

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
 func TestResolveHandler_Resolve(t *testing.T) {
@@ -109,4 +110,37 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		handler.Resolve(rw, req)
 		require.Equal(t, http.StatusGone, rw.Code)
 	})
+}
+
+func getCreateRequest() (*model.CreateRequest, error) {
+	operationDataBytes, err := docutil.MarshalCanonical(getOperationData())
+	if err != nil {
+		return nil, err
+	}
+
+	suffixDataBytes, err := docutil.MarshalCanonical(getSuffixData())
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.CreateRequest{
+		Operation:     model.OperationTypeCreate,
+		OperationData: docutil.EncodeToString(operationDataBytes),
+		SuffixData:    docutil.EncodeToString(suffixDataBytes),
+	}, nil
+}
+
+func getOperationData() *model.CreateOperationData {
+	return &model.CreateOperationData{
+		Document:          validDoc,
+		NextUpdateOTPHash: computeMultihash("updateOTP"),
+	}
+}
+
+func getSuffixData() *model.SuffixDataSchema {
+	return &model.SuffixDataSchema{
+		OperationDataHash:   computeMultihash(validDoc),
+		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
+		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
+	}
 }

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -109,6 +109,8 @@ func TestGetOperation(t *testing.T) {
 	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
 	handler := NewUpdateHandler(docHandler)
 
+	const uniqueSuffix = "whatever"
+
 	t.Run("create", func(t *testing.T) {
 		operation, err := getCreateRequestBytes()
 		require.NoError(t, err)
@@ -118,18 +120,20 @@ func TestGetOperation(t *testing.T) {
 		require.NotNil(t, op)
 	})
 	t.Run("update", func(t *testing.T) {
-		operation, err := getUpdateRequestBytes()
+		info := getUpdateRequestInfo(uniqueSuffix)
+		request, err := helper.NewUpdateRequest(info)
 		require.NoError(t, err)
 
-		op, err := handler.getOperation(operation)
+		op, err := handler.getOperation(request)
 		require.NoError(t, err)
 		require.NotNil(t, op)
 	})
 	t.Run("revoke", func(t *testing.T) {
-		operation, err := getRevokeRequestBytes()
+		info := getRevokeRequestInfo(uniqueSuffix)
+		request, err := helper.NewRevokeRequest(info)
 		require.NoError(t, err)
 
-		op, err := handler.getOperation(operation)
+		op, err := handler.getOperation(request)
 		require.NoError(t, err)
 		require.NotNil(t, op)
 	})
@@ -186,7 +190,7 @@ func computeMultihash(data string) string {
 }
 
 func getUnsupportedRequest() []byte {
-	schema := &requestSchema{
+	schema := &operationSchema{
 		Operation: "unsupported",
 	}
 
@@ -196,6 +200,15 @@ func getUnsupportedRequest() []byte {
 	}
 
 	return payload
+}
+
+func getCreateRequestBytes() ([]byte, error) {
+	req, err := getCreateRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(req)
 }
 
 const validDoc = `{


### PR DESCRIPTION
Operation parsing is currently used by REST API and will later be used when processing operations in anchor file.

Closes #

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>