### PR TITLE
feat: Filter out invalid operations at Observer

### DIFF
--- a/pkg/observer/noopoperationfilter.go
+++ b/pkg/observer/noopoperationfilter.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package observer
+
+import (
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+)
+
+// NoopOperationFilterProvider is an operation filter provider that does not filter operations
+type NoopOperationFilterProvider struct {
+}
+
+// Get returns a noop operation filter
+func (m *NoopOperationFilterProvider) Get(string) OperationFilter {
+	return &noopOperationFilter{}
+}
+
+type noopOperationFilter struct {
+}
+
+// Filter simply returns the provided operations without filtering them
+func (m *noopOperationFilter) Filter(_ string, ops []*batch.Operation) ([]*batch.Operation, error) {
+	return ops, nil
+}

--- a/pkg/observer/noopoperationfilter_test.go
+++ b/pkg/observer/noopoperationfilter_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package observer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+)
+
+func TestNoopOperationFilter_Filter(t *testing.T) {
+	p := &NoopOperationFilterProvider{}
+
+	const suffix = "1234"
+	const ns = "did:sidetree"
+
+	f := p.Get(ns)
+
+	ops := []*batch.Operation{
+		{
+			Type:         "create",
+			ID:           ns + docutil.NamespaceDelimiter + suffix,
+			UniqueSuffix: suffix,
+		},
+		{
+			Type:         "update",
+			ID:           ns + docutil.NamespaceDelimiter + suffix,
+			UniqueSuffix: suffix,
+		},
+	}
+
+	filteredOps, err := f.Filter("1234", ops)
+	require.NoError(t, err)
+	require.Equal(t, ops, filteredOps)
+}

--- a/pkg/processor/operationfilter.go
+++ b/pkg/processor/operationfilter.go
@@ -1,0 +1,120 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package processor
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+)
+
+// OperationValidationFilter filters out invalid operations.
+type OperationValidationFilter struct {
+	*OperationProcessor
+}
+
+// NewOperationFilter returns new operation filter with the given name. (Note that name is only used for logging.)
+func NewOperationFilter(name string, store OperationStoreClient) *OperationValidationFilter {
+	return &OperationValidationFilter{
+		OperationProcessor: New(name, store),
+	}
+}
+
+// Filter filters out the invalid operations and returns only the valid ones
+func (s *OperationValidationFilter) Filter(uniqueSuffix string, newOps []*batch.Operation) ([]*batch.Operation, error) {
+	log.Debugf("[%s] Validating operations for unique suffix [%s]...", s.name, uniqueSuffix)
+
+	newOps = s.filterInvalidSuffix(uniqueSuffix, newOps)
+
+	ops, err := s.store.Get(uniqueSuffix)
+	if err != nil {
+		if !strings.Contains(err.Error(), "not found") {
+			return nil, err
+		}
+
+		log.Debugf("[%s] Unique suffix not found in the store [%s]", s.name, uniqueSuffix)
+	}
+
+	// Combine the existing (persistet) operations with the new operations
+	ops = append(ops, newOps...)
+
+	// Sort the operations by transaction time/number
+	sortOperations(ops)
+
+	log.Debugf("[%s] Found %d operations for unique suffix [%s]: %+v", s.name, len(ops), uniqueSuffix, ops)
+
+	// split operations info 'full' and 'update' operations
+	fullOps, updateOps := splitOperations(ops)
+	if len(fullOps) == 0 {
+		return nil, errors.New("missing create operation")
+	}
+
+	// apply 'full' operations first
+	validFullOps, rm := s.getValidOperations(fullOps, &resolutionModel{})
+
+	var validUpdateOps []*batch.Operation
+	if rm.Doc == nil {
+		log.Debugf("[%s] Document was revoked [%s]", s.name, uniqueSuffix)
+	} else {
+		// next apply update ops since last 'full' transaction
+		validUpdateOps, _ = s.getValidOperations(getOpsWithTxnGreaterThan(updateOps, rm.LastOperationTransactionTime, rm.LastOperationTransactionNumber), rm)
+	}
+
+	var validNewOps []*batch.Operation
+	for _, op := range append(validFullOps, validUpdateOps...) {
+		if contains(newOps, op) {
+			validNewOps = append(validNewOps, op)
+		}
+	}
+
+	return validNewOps, nil
+}
+
+func (s *OperationValidationFilter) getValidOperations(ops []*batch.Operation, rm *resolutionModel) ([]*batch.Operation, *resolutionModel) {
+	var validOps []*batch.Operation
+	for _, op := range ops {
+		m, err := s.applyOperation(op, rm)
+		if err != nil {
+			log.Infof("[%s] Rejecting invalid operation {ID: %s, UniqueSuffix: %s, Type: %s, TransactionTime: %d, TransactionNumber: %d}. Reason: %s", s.name, op.ID, op.UniqueSuffix, op.Type, op.TransactionTime, op.TransactionNumber, err)
+			continue
+		}
+
+		validOps = append(validOps, op)
+		rm = m
+
+		log.Debugf("[%s] After applying op %+v, New doc: %s", s.name, op, rm.Doc)
+	}
+
+	return validOps, rm
+}
+
+func (s *OperationValidationFilter) filterInvalidSuffix(uniqueSuffix string, ops []*batch.Operation) []*batch.Operation {
+	var filtered []*batch.Operation
+	for _, op := range ops {
+		if op.UniqueSuffix != uniqueSuffix {
+			log.Infof("[%s] Rejecting invalid operation {ID: %s, UniqueSuffix: %s Type: %s, TransactionTime: %d, TransactionNumber: %d}. Reason: operation's unique suffix is not set to [%s]", s.name, op.ID, op.UniqueSuffix, op.Type, op.TransactionTime, op.TransactionNumber, uniqueSuffix)
+			continue
+		}
+
+		filtered = append(filtered, op)
+	}
+
+	return filtered
+}
+
+func contains(ops []*batch.Operation, op *batch.Operation) bool {
+	for _, o := range ops {
+		if o == op {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/processor/operationfilter_test.go
+++ b/pkg/processor/operationfilter_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package processor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+)
+
+func TestOperationFilter_Filter(t *testing.T) {
+	t.Run("Store error", func(t *testing.T) {
+		errExpected := errors.New("injected store error")
+		store := mocks.NewMockOperationStore(nil)
+		store.Validate = false
+		store.Err = errExpected
+
+		createOp := getCreateOperation()
+
+		filter := NewOperationFilter("test", store)
+		validOps, err := filter.Filter(createOp.UniqueSuffix, []*batch.Operation{createOp})
+		require.EqualError(t, err, err.Error())
+		require.Empty(t, validOps)
+	})
+
+	t.Run("No create operation error", func(t *testing.T) {
+		store := mocks.NewMockOperationStore(nil)
+		store.Validate = false
+
+		createOp := getCreateOperation()
+		updateOp1 := getUpdateOperation(createOp.UniqueSuffix, 1)
+
+		filter := NewOperationFilter("test", store)
+		validOps, err := filter.Filter(createOp.UniqueSuffix, []*batch.Operation{updateOp1})
+		require.EqualError(t, err, "missing create operation")
+		require.Empty(t, validOps)
+	})
+
+	t.Run("Unique suffix not found in store", func(t *testing.T) {
+		store := mocks.NewMockOperationStore(nil)
+		store.Validate = false
+
+		createOp := getCreateOperation()
+
+		updateOp1 := getUpdateOperation(createOp.UniqueSuffix, 1)
+		updateOp2 := getUpdateOperation(createOp.UniqueSuffix, 3)
+
+		// The second update should be discarded
+		filter := NewOperationFilter("test", store)
+		validOps, err := filter.Filter(createOp.UniqueSuffix, []*batch.Operation{createOp, updateOp1, updateOp2})
+		require.NoError(t, err)
+		require.Len(t, validOps, 2)
+		require.True(t, validOps[0] == createOp)
+		require.True(t, validOps[1] == updateOp1)
+	})
+
+	t.Run("Unique suffix exists in store", func(t *testing.T) {
+		store := mocks.NewMockOperationStore(nil)
+		store.Validate = false
+
+		createOp1 := getCreateOperation()
+		err := store.Put(createOp1)
+		require.Nil(t, err)
+
+		createOp2 := getCreateOperation()
+		updateOp1 := getUpdateOperation("123456", 1)
+		updateOp2 := getUpdateOperation(createOp1.UniqueSuffix, 1)
+		updateOp3 := getUpdateOperation(createOp1.UniqueSuffix, 3)
+
+		// The create operation and first and third update should be discarded
+		filter := NewOperationFilter("test", store)
+		validOps, err := filter.Filter(createOp1.UniqueSuffix, []*batch.Operation{createOp2, updateOp1, updateOp2, updateOp3})
+		require.NoError(t, err)
+		require.Len(t, validOps, 1)
+		require.True(t, validOps[0] == updateOp2)
+	})
+
+	t.Run("With revoke operation", func(t *testing.T) {
+		store := mocks.NewMockOperationStore(nil)
+		store.Validate = false
+
+		createOp1 := getCreateOperation()
+		err := store.Put(createOp1)
+		require.Nil(t, err)
+
+		createOp2 := getCreateOperation()
+		updateOp := getUpdateOperation(createOp1.UniqueSuffix, 1)
+		revokeOp := getRevokeOperation(createOp1.UniqueSuffix, 2)
+
+		// The create should be discarded (since there's already a create) and update should be discarded since the document was revoked
+		filter := NewOperationFilter("test", store)
+		validOps, err := filter.Filter(createOp1.UniqueSuffix, []*batch.Operation{createOp2, updateOp, revokeOp})
+		require.NoError(t, err)
+		require.Len(t, validOps, 1)
+		require.True(t, validOps[0] == revokeOp)
+	})
+}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -116,7 +116,7 @@ func (s *OperationProcessor) applyOperations(ops []*batch.Operation, rm *resolut
 			return nil, err
 		}
 
-		log.Debugf("After applying op %+v, New doc: %s", op, rm.Doc)
+		log.Debugf("[%s] After applying op %+v, New doc: %s", s.name, op, rm.Doc)
 	}
 
 	return rm, nil

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -323,6 +323,7 @@ func getUpdateOperation(uniqueSuffix string, operationNumber uint) *batch.Operat
 	}
 
 	operation := &batch.Operation{
+		ID:                           "did:sidetree:" + uniqueSuffix,
 		UniqueSuffix:                 uniqueSuffix,
 		HashAlgorithmInMultiHashCode: sha2_256,
 		Patch:                        jsonPatch,
@@ -337,6 +338,7 @@ func getUpdateOperation(uniqueSuffix string, operationNumber uint) *batch.Operat
 
 func getRevokeOperation(uniqueSuffix string, operationNumber uint) *batch.Operation {
 	return &batch.Operation{
+		ID:                "did:sidetree:" + uniqueSuffix,
 		UniqueSuffix:      uniqueSuffix,
 		Type:              batch.OperationTypeRevoke,
 		TransactionTime:   0,
@@ -385,6 +387,7 @@ func getCreateOperation() *batch.Operation {
 
 	return &batch.Operation{
 		HashAlgorithmInMultiHashCode: sha2_256,
+		ID:                           "did:sidetree:" + uniqueSuffix,
 		UniqueSuffix:                 uniqueSuffix,
 		Type:                         batch.OperationTypeCreate,
 		OperationBuffer:              operationBuffer,


### PR DESCRIPTION
The Observer ensures that only valid operations are persisted by applying all operations of a unique suffix (new and old) and discarding those that are not valid.

closes #124

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>