### PR TITLE
fix: Enable recovery in update handler

### DIFF
--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -41,6 +41,8 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
+	// TODO: Handle recovery key
+
 	return &batch.Operation{
 		OperationBuffer:              request,
 		Type:                         batch.OperationTypeCreate,

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -36,11 +36,14 @@ func ParseRecoverOperation(request []byte, protocol protocol.Protocol) (*batch.O
 		return nil, err
 	}
 
+	// TODO: Handle recovery key
+
 	return &batch.Operation{
 		OperationBuffer:              request,
 		Type:                         batch.OperationTypeRecover,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
 		Document:                     operationData.Document,
+		RecoveryOTP:                  schema.RecoveryOTP,
 		NextUpdateOTPHash:            operationData.NextUpdateOTPHash,
 		NextRecoveryOTPHash:          signedOperationData.NextRecoveryOTPHash,
 		HashAlgorithmInMultiHashCode: code,

--- a/pkg/restapi/dochandler/updatehandler.go
+++ b/pkg/restapi/dochandler/updatehandler.go
@@ -91,6 +91,8 @@ func (h *UpdateHandler) getOperation(operationBuffer []byte) (*batch.Operation, 
 		op, parseErr = operation.ParseUpdateOperation(operationBuffer, protocol)
 	case model.OperationTypeRevoke:
 		op, parseErr = operation.ParseRevokeOperation(operationBuffer, protocol)
+	case model.OperationTypeRecover:
+		op, parseErr = operation.ParseRecoverOperation(operationBuffer, protocol)
 	default:
 		return nil, fmt.Errorf("operation type [%s] not implemented", schema.Operation)
 	}

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -26,8 +27,10 @@ import (
 )
 
 const (
-	namespace  = "sample:sidetree"
-	badRequest = `bad request`
+	namespace   = "sample:sidetree"
+	badRequest  = `bad request`
+	recoveryOTP = "recoveryOTP"
+	updateOTP   = "updateOTP"
 
 	sha2_256 = 18
 )
@@ -77,6 +80,19 @@ func TestUpdateHandler_Update(t *testing.T) {
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader(revoke))
 		handler.Update(rw, req)
+		require.Equal(t, http.StatusOK, rw.Code)
+		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
+	})
+	t.Run("Recover", func(t *testing.T) {
+		recover, err := helper.NewRecoverRequest(getRecoverRequestInfo(id))
+		require.NoError(t, err)
+
+		fmt.Println(string(recover))
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader(recover))
+		handler.Update(rw, req)
+		fmt.Println(req.Body)
 		require.Equal(t, http.StatusOK, rw.Code)
 		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
@@ -137,6 +153,32 @@ func TestGetOperation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, op)
 	})
+	t.Run("recover", func(t *testing.T) {
+		info := getRecoverRequestInfo(uniqueSuffix)
+		request, err := helper.NewRecoverRequest(info)
+		require.NoError(t, err)
+
+		op, err := handler.getOperation(request)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+	})
+	t.Run("operation parsing error", func(t *testing.T) {
+		// set-up invalid hash algorithm in protocol configuration
+		protocol := mocks.NewMockProtocolClient()
+		protocol.Protocol.HashAlgorithmInMultiHashCode = 55
+
+		docHandlerWithErr := mocks.NewMockDocumentHandler().WithNamespace(namespace).WithProtocolClient(protocol)
+		handlerWithErr := NewUpdateHandler(docHandlerWithErr)
+
+		info := getRecoverRequestInfo(uniqueSuffix)
+		request, err := helper.NewRecoverRequest(info)
+		require.NoError(t, err)
+
+		op, err := handlerWithErr.getOperation(request)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "next update OTP hash is not computed with the latest supported hash algorithm")
+		require.Nil(t, op)
+	})
 	t.Run("unsupported operation type error", func(t *testing.T) {
 		operation := getUnsupportedRequest()
 		op, err := handler.getOperation(operation)
@@ -150,8 +192,8 @@ func getCreateRequestInfo() *helper.CreateRequestInfo {
 	return &helper.CreateRequestInfo{
 		OpaqueDocument:  validDoc,
 		RecoveryKey:     "HEX",
-		NextRecoveryOTP: docutil.EncodeToString([]byte("recoveryOTP")),
-		NextUpdateOTP:   docutil.EncodeToString([]byte("updateOTP")),
+		NextRecoveryOTP: docutil.EncodeToString([]byte(recoveryOTP)),
+		NextUpdateOTP:   docutil.EncodeToString([]byte(updateOTP)),
 		MultihashCode:   sha2_256,
 	}
 }
@@ -168,8 +210,8 @@ func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
 	return &helper.UpdateRequestInfo{
 		DidUniqueSuffix: uniqueSuffix,
 		Patch:           patch,
-		UpdateOTP:       docutil.EncodeToString([]byte("updateOTP")),
-		NextUpdateOTP:   docutil.EncodeToString([]byte("updateOTP")),
+		UpdateOTP:       docutil.EncodeToString([]byte(updateOTP)),
+		NextUpdateOTP:   docutil.EncodeToString([]byte(updateOTP)),
 		MultihashCode:   sha2_256,
 	}
 }
@@ -177,7 +219,19 @@ func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
 func getRevokeRequestInfo(uniqueSuffix string) *helper.RevokeRequestInfo {
 	return &helper.RevokeRequestInfo{
 		DidUniqueSuffix: uniqueSuffix,
-		RecoveryOTP:     "recoveryOTP",
+		RecoveryOTP:     docutil.EncodeToString([]byte(recoveryOTP)),
+	}
+}
+
+func getRecoverRequestInfo(uniqueSuffix string) *helper.RecoverRequestInfo {
+	return &helper.RecoverRequestInfo{
+		DidUniqueSuffix: uniqueSuffix,
+		OpaqueDocument:  recoverDoc,
+		RecoveryKey:     "HEX",
+		RecoveryOTP:     docutil.EncodeToString([]byte(recoveryOTP)),
+		NextRecoveryOTP: docutil.EncodeToString([]byte("newRecoveryOTP")),
+		NextUpdateOTP:   docutil.EncodeToString([]byte("newUpdateOTP")),
+		MultihashCode:   sha2_256,
 	}
 }
 
@@ -219,4 +273,12 @@ const validDoc = `{
 		"type": "Ed25519VerificationKey2018"
 	}],
 	"updated": "2019-09-23T14:16:59.261024-04:00"
+}`
+
+const recoverDoc = `{
+	"publicKey": [{
+		"id": "#recoverKey",
+		"publicKeyBase58": "GY4GunSXBPBfhLCzDL7iGmP5dR3sBDCJZkkaGK8VgYQf",
+		"type": "recoverKeyType"
+	}]
 }`


### PR DESCRIPTION
Update handler is returning 'operation not supported' for recovery operation.
Add operation processing for 'recovery' operation to update handler.

Closes #147

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>