### PR TITLE
chore: Rename operation data to patch data

### DIFF
--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -174,17 +174,17 @@ func (r *DocumentHandler) resolveRequestWithDocument(id, encodedCreateReq string
 		return nil, err
 	}
 
-	operationDataBytes, err := docutil.DecodeString(createReq.OperationData)
+	patchDataBytes, err := docutil.DecodeString(createReq.PatchData)
 	if err != nil {
 		return nil, err
 	}
 
-	var opData model.OperationDataModel
-	err = json.Unmarshal(operationDataBytes, &opData)
+	var patchData model.PatchDataModel
+	err = json.Unmarshal(patchDataBytes, &patchData)
 	if err != nil {
 		return nil, err
 	}
-	initialDocument := opData.Patches[0].GetStringValue(patch.DocumentKey)
+	initialDocument := patchData.Patches[0].GetStringValue(patch.DocumentKey)
 
 	// Verify that the document passes both Sidetree and document validation
 	if err = r.validator.IsValidOriginalDocument([]byte(initialDocument)); err != nil {

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -329,7 +329,7 @@ const validDoc = `{
 }`
 
 func getCreateRequest() (*model.CreateRequest, error) {
-	operationDataBytes, err := json.Marshal(getOperationData())
+	patchDataBytes, err := json.Marshal(getPatchData())
 	if err != nil {
 		return nil, err
 	}
@@ -340,22 +340,22 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:     model.OperationTypeCreate,
-		OperationData: docutil.EncodeToString(operationDataBytes),
-		SuffixData:    docutil.EncodeToString(suffixDataBytes),
+		Operation:  model.OperationTypeCreate,
+		PatchData:  docutil.EncodeToString(patchDataBytes),
+		SuffixData: docutil.EncodeToString(suffixDataBytes),
 	}, nil
 }
 
-func getOperationData() *model.OperationDataModel {
-	return &model.OperationDataModel{
+func getPatchData() *model.PatchDataModel {
+	return &model.PatchDataModel{
 		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 	}
 }
 
-func getSuffixData() *model.SuffixDataSchema {
-	return &model.SuffixDataSchema{
-		OperationDataHash:   computeMultihash(validDoc),
+func getSuffixData() *model.SuffixDataModel {
+	return &model.SuffixDataModel{
+		PatchDataHash:       computeMultihash(validDoc),
 		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
 		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
 	}
@@ -370,7 +370,7 @@ func computeMultihash(data string) string {
 }
 
 func getUpdateRequest() (*model.UpdateRequest, error) {
-	operationDataBytes, err := json.Marshal(getUpdateOperationData())
+	patchDataBytes, err := json.Marshal(getUpdatePatchData())
 	if err != nil {
 		return nil, err
 	}
@@ -378,12 +378,12 @@ func getUpdateRequest() (*model.UpdateRequest, error) {
 	return &model.UpdateRequest{
 		Operation:       model.OperationTypeUpdate,
 		DidUniqueSuffix: getCreateOperation().UniqueSuffix,
-		OperationData:   docutil.EncodeToString(operationDataBytes),
+		PatchData:       docutil.EncodeToString(patchDataBytes),
 	}, nil
 }
 
-func getUpdateOperationData() *model.OperationDataModel {
-	return &model.OperationDataModel{
+func getUpdatePatchData() *model.PatchDataModel {
+	return &model.PatchDataModel{
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 	}
 }

--- a/pkg/operation/revoke_test.go
+++ b/pkg/operation/revoke_test.go
@@ -42,10 +42,10 @@ func TestParseRevokeOperation(t *testing.T) {
 
 func getRevokeRequest() *model.RevokeRequest {
 	return &model.RevokeRequest{
-		Operation:           model.OperationTypeRevoke,
-		DidUniqueSuffix:     "did",
-		RecoveryOTP:         "recoveryOTP",
-		SignedOperationData: nil,
+		Operation:       model.OperationTypeRevoke,
+		DidUniqueSuffix: "did",
+		RecoveryOTP:     "recoveryOTP",
+		SignedData:      nil,
 	}
 }
 

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -25,12 +25,12 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
-	operationData, err := parseUpdateOperationData(schema.OperationData, protocol.HashAlgorithmInMultiHashCode)
+	patchData, err := parseUpdatePatchData(schema.PatchData, protocol.HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, err
 	}
 
-	patches := operationData.Patches[0].GetStringValue(patch.PatchesKey)
+	patches := patchData.Patches[0].GetStringValue(patch.PatchesKey)
 
 	// TODO: model for operation patch will change with issue-155
 	patch, err := jsonpatch.DecodePatch([]byte(patches))
@@ -43,7 +43,7 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		OperationBuffer:              request,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
 		UpdateOTP:                    schema.UpdateOTP,
-		NextUpdateOTPHash:            operationData.NextUpdateOTPHash,
+		NextUpdateOTPHash:            patchData.NextUpdateOTPHash,
 		Patch:                        patch,
 		HashAlgorithmInMultiHashCode: protocol.HashAlgorithmInMultiHashCode,
 	}, nil
@@ -58,19 +58,19 @@ func parseUpdateRequest(payload []byte) (*model.UpdateRequest, error) {
 	return schema, nil
 }
 
-func parseUpdateOperationData(encoded string, code uint) (*model.OperationDataModel, error) {
+func parseUpdatePatchData(encoded string, code uint) (*model.PatchDataModel, error) {
 	bytes, err := docutil.DecodeString(encoded)
 	if err != nil {
 		return nil, err
 	}
 
-	schema := &model.OperationDataModel{}
+	schema := &model.PatchDataModel{}
 	err = json.Unmarshal(bytes, schema)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := validateOperationData(schema, code); err != nil {
+	if err := validatePatchData(schema, code); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -38,10 +38,10 @@ func TestParseUpdateOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "unexpected end of JSON input")
 	})
 	t.Run("invalid next update OTP", func(t *testing.T) {
-		operationData := getUpdateOperationData()
-		operationData.NextUpdateOTPHash = ""
+		patchData := getUpdatePatchData()
+		patchData.NextUpdateOTPHash = ""
 
-		req, err := getUpdateRequest(operationData)
+		req, err := getUpdateRequest(patchData)
 		require.NoError(t, err)
 		payload, err := json.Marshal(req)
 		require.NoError(t, err)
@@ -54,54 +54,54 @@ func TestParseUpdateOperation(t *testing.T) {
 	})
 }
 
-func TestValidateUpdateOperationData(t *testing.T) {
+func TestValidateUpdatePatchData(t *testing.T) {
 	t.Run("invalid next update OTP", func(t *testing.T) {
-		operationData := getUpdateOperationData()
+		patchData := getUpdatePatchData()
 
-		operationData.NextUpdateOTPHash = ""
-		err := validateOperationData(operationData, sha2_256)
+		patchData.NextUpdateOTPHash = ""
+		err := validatePatchData(patchData, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
 			"next update OTP hash is not computed with the latest supported hash algorithm")
 	})
 }
 
-func TestParseOperationData(t *testing.T) {
+func TestParseUpdatePatchData(t *testing.T) {
 	t.Run("invalid next update OTP", func(t *testing.T) {
-		operationData := getUpdateOperationData()
+		patchData := getUpdatePatchData()
 
-		operationData.NextUpdateOTPHash = ""
-		opDataBytes, err := json.Marshal(operationData)
+		patchData.NextUpdateOTPHash = ""
+		patchDataBytes, err := json.Marshal(patchData)
 		require.NoError(t, err)
 
-		parsed, err := parseUpdateOperationData(docutil.EncodeToString(opDataBytes), sha2_256)
+		parsed, err := parseUpdatePatchData(docutil.EncodeToString(patchDataBytes), sha2_256)
 		require.Error(t, err)
 		require.Nil(t, parsed)
 		require.Contains(t, err.Error(),
 			"next update OTP hash is not computed with the latest supported hash algorithm")
 	})
 	t.Run("invalid bytes", func(t *testing.T) {
-		parsed, err := parseUpdateOperationData("invalid", sha2_256)
+		parsed, err := parseUpdatePatchData("invalid", sha2_256)
 		require.Error(t, err)
 		require.Nil(t, parsed)
 		require.Contains(t, err.Error(), "illegal base64 data")
 	})
 }
 
-func getUpdateRequest(opData *model.OperationDataModel) (*model.UpdateRequest, error) {
-	operationDataBytes, err := json.Marshal(opData)
+func getUpdateRequest(patchData *model.PatchDataModel) (*model.UpdateRequest, error) {
+	patchDataBytes, err := json.Marshal(patchData)
 	if err != nil {
 		return nil, err
 	}
 
 	return &model.UpdateRequest{
-		Operation:     model.OperationTypeUpdate,
-		OperationData: docutil.EncodeToString(operationDataBytes),
+		Operation: model.OperationTypeUpdate,
+		PatchData: docutil.EncodeToString(patchDataBytes),
 	}, nil
 }
 
 func getDefaultUpdateRequest() (*model.UpdateRequest, error) {
-	return getUpdateRequest(getUpdateOperationData())
+	return getUpdateRequest(getUpdatePatchData())
 }
 
 func getUpdateRequestBytes() ([]byte, error) {
@@ -113,10 +113,10 @@ func getUpdateRequestBytes() ([]byte, error) {
 	return json.Marshal(req)
 }
 
-func getUpdateOperationData() *model.OperationDataModel {
+func getUpdatePatchData() *model.PatchDataModel {
 	jsonPatch := patch.NewJSONPatch(getTestPatch())
 
-	return &model.OperationDataModel{
+	return &model.PatchDataModel{
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 		Patches:           []patch.Patch{jsonPatch},
 	}

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -454,13 +454,13 @@ func getRecoverOperation(uniqueSuffix string, operationNumber uint) *batch.Opera
 	}
 }
 
-func getRecoverRequest(opData *model.OperationDataModel, signedOpData *model.SignedOperationDataSchema) (*model.RecoverRequest, error) {
-	operationDataBytes, err := docutil.MarshalCanonical(opData)
+func getRecoverRequest(patchData *model.PatchDataModel, signedData *model.SignedDataModel) (*model.RecoverRequest, error) {
+	patchDataBytes, err := docutil.MarshalCanonical(patchData)
 	if err != nil {
 		return nil, err
 	}
 
-	signedOperationDataBytes, err := docutil.MarshalCanonical(signedOpData)
+	signedDataBytes, err := docutil.MarshalCanonical(signedData)
 	if err != nil {
 		return nil, err
 	}
@@ -468,28 +468,28 @@ func getRecoverRequest(opData *model.OperationDataModel, signedOpData *model.Sig
 	return &model.RecoverRequest{
 		Operation:       model.OperationTypeRecover,
 		DidUniqueSuffix: "suffix",
-		OperationData:   docutil.EncodeToString(operationDataBytes),
-		SignedOperationData: &model.JWS{
+		PatchData:       docutil.EncodeToString(patchDataBytes),
+		SignedData: &model.JWS{
 			// TODO: JWS encoded
-			Payload: docutil.EncodeToString(signedOperationDataBytes),
+			Payload: docutil.EncodeToString(signedDataBytes),
 		},
 	}, nil
 }
 
 func getDefaultRecoverRequest() (*model.RecoverRequest, error) {
-	return getRecoverRequest(getRecoverOperationData(), getRecoverSignedOperationData())
+	return getRecoverRequest(getRecoverPatchData(), getRecoverSignedData())
 }
 
-func getRecoverSignedOperationData() *model.SignedOperationDataSchema {
-	return &model.SignedOperationDataSchema{
+func getRecoverSignedData() *model.SignedDataModel {
+	return &model.SignedDataModel{
 		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
 		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
-		OperationDataHash:   computeMultihash("operation"),
+		PatchDataHash:       computeMultihash("operation"),
 	}
 }
 
-func getRecoverOperationData() *model.OperationDataModel {
-	return &model.OperationDataModel{
+func getRecoverPatchData() *model.PatchDataModel {
+	return &model.PatchDataModel{
 		Patches:           []patch.Patch{patch.NewReplacePatch(recoveredDoc)},
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 	}
@@ -547,7 +547,7 @@ func getCreateOperation() *batch.Operation {
 }
 
 func getCreateRequest() (*model.CreateRequest, error) {
-	operationDataBytes, err := docutil.MarshalCanonical(getOperationData())
+	patchDataBytes, err := docutil.MarshalCanonical(getPatchData())
 	if err != nil {
 		return nil, err
 	}
@@ -558,22 +558,22 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:     model.OperationTypeCreate,
-		OperationData: docutil.EncodeToString(operationDataBytes),
-		SuffixData:    docutil.EncodeToString(suffixDataBytes),
+		Operation:  model.OperationTypeCreate,
+		PatchData:  docutil.EncodeToString(patchDataBytes),
+		SuffixData: docutil.EncodeToString(suffixDataBytes),
 	}, nil
 }
 
-func getOperationData() *model.OperationDataModel {
-	return &model.OperationDataModel{
+func getPatchData() *model.PatchDataModel {
+	return &model.PatchDataModel{
 		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 	}
 }
 
-func getSuffixData() *model.SuffixDataSchema {
-	return &model.SuffixDataSchema{
-		OperationDataHash:   computeMultihash(validDoc),
+func getSuffixData() *model.SuffixDataModel {
+	return &model.SuffixDataModel{
+		PatchDataHash:       computeMultihash(validDoc),
 		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
 		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
 	}

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -83,7 +83,7 @@ func TestUpdateHandler_Update_Error(t *testing.T) {
 }
 
 func getCreateRequest() (*model.CreateRequest, error) {
-	operationDataBytes, err := docutil.MarshalCanonical(getOperationData())
+	patchDataBytes, err := docutil.MarshalCanonical(getPatchData())
 	if err != nil {
 		return nil, err
 	}
@@ -94,22 +94,22 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:     model.OperationTypeCreate,
-		OperationData: docutil.EncodeToString(operationDataBytes),
-		SuffixData:    docutil.EncodeToString(suffixDataBytes),
+		Operation:  model.OperationTypeCreate,
+		PatchData:  docutil.EncodeToString(patchDataBytes),
+		SuffixData: docutil.EncodeToString(suffixDataBytes),
 	}, nil
 }
 
-func getOperationData() *model.OperationDataModel {
-	return &model.OperationDataModel{
+func getPatchData() *model.PatchDataModel {
+	return &model.PatchDataModel{
 		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 	}
 }
 
-func getSuffixData() *model.SuffixDataSchema {
-	return &model.SuffixDataSchema{
-		OperationDataHash:   computeMultihash(validDoc),
+func getSuffixData() *model.SuffixDataModel {
+	return &model.SuffixDataModel{
+		PatchDataHash:       computeMultihash(validDoc),
 		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
 		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
 	}

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -114,7 +114,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 }
 
 func getCreateRequest() (*model.CreateRequest, error) {
-	operationDataBytes, err := docutil.MarshalCanonical(getOperationData())
+	patchDataBytes, err := docutil.MarshalCanonical(getPatchData())
 	if err != nil {
 		return nil, err
 	}
@@ -125,22 +125,22 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:     model.OperationTypeCreate,
-		OperationData: docutil.EncodeToString(operationDataBytes),
-		SuffixData:    docutil.EncodeToString(suffixDataBytes),
+		Operation:  model.OperationTypeCreate,
+		PatchData:  docutil.EncodeToString(patchDataBytes),
+		SuffixData: docutil.EncodeToString(suffixDataBytes),
 	}, nil
 }
 
-func getOperationData() *model.OperationDataModel {
-	return &model.OperationDataModel{
+func getPatchData() *model.PatchDataModel {
+	return &model.PatchDataModel{
 		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
 		NextUpdateOTPHash: computeMultihash("updateOTP"),
 	}
 }
 
-func getSuffixData() *model.SuffixDataSchema {
-	return &model.SuffixDataSchema{
-		OperationDataHash:   computeMultihash(validDoc),
+func getSuffixData() *model.SuffixDataModel {
+	return &model.SuffixDataModel{
+		PatchDataHash:       computeMultihash(validDoc),
 		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
 		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
 	}

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -16,20 +16,20 @@ type CreateRequest struct {
 	// Required: true
 	Operation OperationType `json:"type"`
 
-	// Encoded JSON object containing data required for creating suffix
+	// Encoded JSON object containing data used to compute the unique DID suffix
 	// Required: true
 	SuffixData string `json:"suffixData"`
 
-	// Encoded JSON object containing create operation data
+	// Encoded JSON object containing create patch data
 	// Required: true
-	OperationData string `json:"operationData"`
+	PatchData string `json:"patchData"`
 }
 
-// SuffixDataSchema is part of create request
-type SuffixDataSchema struct {
+// SuffixDataModel is part of create request
+type SuffixDataModel struct {
 
-	// Hash of the encoded operation data string
-	OperationDataHash string `json:"operationDataHash"`
+	// Hash of the patch data
+	PatchDataHash string `json:"patchDataHash"`
 
 	// The recovery public key as a HEX string.
 	RecoveryKey PublicKey `json:"recoveryKey"`
@@ -44,8 +44,8 @@ type PublicKey struct {
 	PublicKeyHex string `json:"publicKeyHex"`
 }
 
-// OperationDataModel contains operation data (patches used for create, recover, update)
-type OperationDataModel struct {
+// PatchDataModel contains patch data (patches used for create, recover, update)
+type PatchDataModel struct {
 
 	// Hash of the one-time password for the next update operation
 	NextUpdateOTPHash string `json:"nextUpdateOtpHash"`
@@ -65,10 +65,10 @@ type UpdateRequest struct {
 	UpdateOTP string `json:"updateOtp"`
 
 	// JWS signature information
-	SignedOperationDataHash *JWS `json:"signedOperationDataHash"`
+	SignedData *JWS `json:"signedData"`
 
-	// Encoded JSON object containing update operation data
-	OperationData string `json:"operationData"`
+	// Encoded JSON object containing patch data
+	PatchData string `json:"patchData"`
 }
 
 //RevokeRequest is the struct for revoking document
@@ -86,14 +86,14 @@ type RevokeRequest struct {
 	RecoveryOTP string `json:"recoveryOtp"`
 
 	// JWS Signature information
-	SignedOperationData *JWS `json:"signedOperationData"`
+	SignedData *JWS `json:"signedData"`
 }
 
-// SignedOperationDataSchema defines
-type SignedOperationDataSchema struct {
+// SignedDataModel defines
+type SignedDataModel struct {
 
-	// Hash of the unsigned operation data
-	OperationDataHash string `json:"operationDataHash"`
+	// Hash of the unsigned patch data
+	PatchDataHash string `json:"patchDataHash"`
 
 	// The new recovery key
 	RecoveryKey PublicKey `json:"recoveryKey"`
@@ -117,11 +117,11 @@ type RecoverRequest struct {
 	RecoveryOTP string `json:"recoveryOtp"`
 
 	// JWS Signature information
-	SignedOperationData *JWS `json:"signedOperationData"`
+	SignedData *JWS `json:"signedData"`
 
-	// Encoded JSON object containing unsigned portion of the recovery request
+	// Encoded JSON object containing recovery patch data
 	// Required: true
-	OperationData string `json:"operationData"`
+	PatchData string `json:"patchData"`
 }
 
 // Protected describes JWS header


### PR DESCRIPTION
Replace all references of "operation data" to be "patch data" in code
Also signedOperationDataHash to signedData

Closes #156

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>