### PR TITLE
chore: Rename OTP to commitment or reveal value

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -47,15 +47,15 @@ type Operation struct {
 	//The index this operation was assigned to in the batch
 	OperationIndex uint `json:"operationIndex"`
 
-	// One-time password for update operation
-	UpdateOTP string `json:"updateOTP"`
-	// One-time password for this recovery/checkpoint/revoke operation
-	RecoveryOTP string `json:"recoveryOTP"`
+	// Reveal value for this update operation
+	UpdateRevealValue string `json:"updateRevealValue"`
+	// Reveal value for this recovery/revoke operation
+	RecoveryRevealValue string `json:"recoveryRevealValue"`
 
-	// Hash of the one-time password for the next update operation
-	NextUpdateOTPHash string `json:"nextUpdateOTPHash"`
-	// Hash of the one-time password for this recovery/checkpoint/revoke operation.
-	NextRecoveryOTPHash string `json:"nextRecoveryOTPHash"`
+	// Hash of reveal value for the next update operation
+	NextUpdateCommitmentHash string `json:"nextUpdateCommitmentHash"`
+	// Hash of reveal value for next recovery/revoke operation
+	NextRecoveryCommitmentHash string `json:"nextRecoveryCommitmentHash"`
 }
 
 // OperationType defines valid values for operation type

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -348,16 +348,16 @@ func getCreateRequest() (*model.CreateRequest, error) {
 
 func getPatchData() *model.PatchDataModel {
 	return &model.PatchDataModel{
-		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
-		NextUpdateOTPHash: computeMultihash("updateOTP"),
+		Patches:                  []patch.Patch{patch.NewReplacePatch(validDoc)},
+		NextUpdateCommitmentHash: computeMultihash("updateReveal"),
 	}
 }
 
 func getSuffixData() *model.SuffixDataModel {
 	return &model.SuffixDataModel{
-		PatchDataHash:       computeMultihash(validDoc),
-		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
-		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
+		PatchDataHash:              computeMultihash(validDoc),
+		RecoveryKey:                model.PublicKey{PublicKeyHex: "HEX"},
+		NextRecoveryCommitmentHash: computeMultihash("recoveryReveal"),
 	}
 }
 
@@ -384,7 +384,7 @@ func getUpdateRequest() (*model.UpdateRequest, error) {
 
 func getUpdatePatchData() *model.PatchDataModel {
 	return &model.PatchDataModel{
-		NextUpdateOTPHash: computeMultihash("updateOTP"),
+		NextUpdateCommitmentHash: computeMultihash("updateReveal"),
 	}
 }
 

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -51,8 +51,8 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		Type:                         batch.OperationTypeCreate,
 		UniqueSuffix:                 uniqueSuffix,
 		Document:                     document,
-		NextUpdateOTPHash:            patchData.NextUpdateOTPHash,
-		NextRecoveryOTPHash:          suffixData.NextRecoveryOTPHash,
+		NextUpdateCommitmentHash:     patchData.NextUpdateCommitmentHash,
+		NextRecoveryCommitmentHash:   suffixData.NextRecoveryCommitmentHash,
 		HashAlgorithmInMultiHashCode: code,
 	}, nil
 }
@@ -110,8 +110,8 @@ func validatePatchData(patchData *model.PatchDataModel, code uint) error {
 		return errors.New("missing patches")
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(patchData.NextUpdateOTPHash, uint64(code)) {
-		return errors.New("next update OTP hash is not computed with the latest supported hash algorithm")
+	if !docutil.IsComputedUsingHashAlgorithm(patchData.NextUpdateCommitmentHash, uint64(code)) {
+		return errors.New("next update commitment hash is not computed with the latest supported hash algorithm")
 	}
 
 	return nil
@@ -122,8 +122,8 @@ func validateSuffixData(suffixData *model.SuffixDataModel, code uint) error {
 		return errors.New("missing recovery key")
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(suffixData.NextRecoveryOTPHash, uint64(code)) {
-		return errors.New("next recovery OTP hash is not computed with the latest supported hash algorithm")
+	if !docutil.IsComputedUsingHashAlgorithm(suffixData.NextRecoveryCommitmentHash, uint64(code)) {
+		return errors.New("next recovery commitment hash is not computed with the latest supported hash algorithm")
 	}
 
 	if !docutil.IsComputedUsingHashAlgorithm(suffixData.PatchDataHash, uint64(code)) {

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -84,23 +84,23 @@ func TestValidateSuffixData(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "patch data hash is not computed with the latest supported hash algorithm")
 	})
-	t.Run("invalid next recovery OTP hash", func(t *testing.T) {
+	t.Run("invalid next recovery commitment hash", func(t *testing.T) {
 		suffixData := getSuffixData()
-		suffixData.NextRecoveryOTPHash = ""
+		suffixData.NextRecoveryCommitmentHash = ""
 		err := validateSuffixData(suffixData, sha2_256)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "next recovery OTP hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "next recovery commitment hash is not computed with the latest supported hash algorithm")
 	})
 }
 
 func TestValidatePatchData(t *testing.T) {
-	t.Run("invalid next update OTP", func(t *testing.T) {
+	t.Run("invalid next update commitment hash", func(t *testing.T) {
 		patchData := getPatchData()
-		patchData.NextUpdateOTPHash = ""
+		patchData.NextUpdateCommitmentHash = ""
 		err := validatePatchData(patchData, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"next update OTP hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the latest supported hash algorithm")
 	})
 	t.Run("missing patches", func(t *testing.T) {
 		patchData := getPatchData()
@@ -141,16 +141,16 @@ func getCreateRequestBytes() ([]byte, error) {
 
 func getPatchData() *model.PatchDataModel {
 	return &model.PatchDataModel{
-		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
-		NextUpdateOTPHash: computeMultihash("updateOTP"),
+		Patches:                  []patch.Patch{patch.NewReplacePatch(validDoc)},
+		NextUpdateCommitmentHash: computeMultihash("updateReveal"),
 	}
 }
 
 func getSuffixData() *model.SuffixDataModel {
 	return &model.SuffixDataModel{
-		PatchDataHash:       computeMultihash(validDoc),
-		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
-		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
+		PatchDataHash:              computeMultihash(validDoc),
+		RecoveryKey:                model.PublicKey{PublicKeyHex: "HEX"},
+		NextRecoveryCommitmentHash: computeMultihash("recoveryReveal"),
 	}
 }
 func computeMultihash(data string) string {

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -46,9 +46,9 @@ func ParseRecoverOperation(request []byte, protocol protocol.Protocol) (*batch.O
 		Type:                         batch.OperationTypeRecover,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
 		Document:                     document,
-		RecoveryOTP:                  schema.RecoveryOTP,
-		NextUpdateOTPHash:            patchData.NextUpdateOTPHash,
-		NextRecoveryOTPHash:          signedData.NextRecoveryOTPHash,
+		RecoveryRevealValue:          schema.RecoveryRevealValue,
+		NextUpdateCommitmentHash:     patchData.NextUpdateCommitmentHash,
+		NextRecoveryCommitmentHash:   signedData.NextRecoveryCommitmentHash,
 		HashAlgorithmInMultiHashCode: code,
 	}, nil
 }
@@ -106,8 +106,8 @@ func validateSignedData(signedData *model.SignedDataModel, code uint) error {
 		return errors.New("missing recovery key")
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(signedData.NextRecoveryOTPHash, uint64(code)) {
-		return errors.New("next recovery OTP hash is not computed with the latest supported hash algorithm")
+	if !docutil.IsComputedUsingHashAlgorithm(signedData.NextRecoveryCommitmentHash, uint64(code)) {
+		return errors.New("next recovery commitment hash is not computed with the latest supported hash algorithm")
 	}
 
 	if !docutil.IsComputedUsingHashAlgorithm(signedData.PatchDataHash, uint64(code)) {

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -110,12 +110,12 @@ func TestValidateSignedData(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "patch data hash is not computed with the latest supported hash algorithm")
 	})
-	t.Run("invalid next recovery OTP hash", func(t *testing.T) {
+	t.Run("invalid next recovery commitment hash", func(t *testing.T) {
 		signed := getSignedData()
-		signed.NextRecoveryOTPHash = ""
+		signed.NextRecoveryCommitmentHash = ""
 		err := validateSignedData(signed, sha2_256)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "next recovery OTP hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "next recovery commitment hash is not computed with the latest supported hash algorithm")
 	})
 }
 
@@ -147,9 +147,9 @@ func getDefaultRecoverRequest() (*model.RecoverRequest, error) {
 
 func getSignedData() *model.SignedDataModel {
 	return &model.SignedDataModel{
-		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
-		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
-		PatchDataHash:       computeMultihash("operation"),
+		RecoveryKey:                model.PublicKey{PublicKeyHex: "HEX"},
+		NextRecoveryCommitmentHash: computeMultihash("recoveryReveal"),
+		PatchDataHash:              computeMultihash("operation"),
 	}
 }
 

--- a/pkg/operation/revoke.go
+++ b/pkg/operation/revoke.go
@@ -26,7 +26,7 @@ func ParseRevokeOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		Type:                         batch.OperationTypeRevoke,
 		OperationBuffer:              request,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
-		RecoveryOTP:                  schema.RecoveryOTP,
+		RecoveryRevealValue:          schema.RecoveryRevealValue,
 		HashAlgorithmInMultiHashCode: protocol.HashAlgorithmInMultiHashCode,
 	}, nil
 }

--- a/pkg/operation/revoke_test.go
+++ b/pkg/operation/revoke_test.go
@@ -42,10 +42,10 @@ func TestParseRevokeOperation(t *testing.T) {
 
 func getRevokeRequest() *model.RevokeRequest {
 	return &model.RevokeRequest{
-		Operation:       model.OperationTypeRevoke,
-		DidUniqueSuffix: "did",
-		RecoveryOTP:     "recoveryOTP",
-		SignedData:      nil,
+		Operation:           model.OperationTypeRevoke,
+		DidUniqueSuffix:     "did",
+		RecoveryRevealValue: "recoveryReveal",
+		SignedData:          nil,
 	}
 }
 

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -42,8 +42,8 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		Type:                         batch.OperationTypeUpdate,
 		OperationBuffer:              request,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
-		UpdateOTP:                    schema.UpdateOTP,
-		NextUpdateOTPHash:            patchData.NextUpdateOTPHash,
+		UpdateRevealValue:            schema.UpdateRevealValue,
+		NextUpdateCommitmentHash:     patchData.NextUpdateCommitmentHash,
 		Patch:                        patch,
 		HashAlgorithmInMultiHashCode: protocol.HashAlgorithmInMultiHashCode,
 	}, nil

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -37,9 +37,9 @@ func TestParseUpdateOperation(t *testing.T) {
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "unexpected end of JSON input")
 	})
-	t.Run("invalid next update OTP", func(t *testing.T) {
+	t.Run("invalid next update commitment hash", func(t *testing.T) {
 		patchData := getUpdatePatchData()
-		patchData.NextUpdateOTPHash = ""
+		patchData.NextUpdateCommitmentHash = ""
 
 		req, err := getUpdateRequest(patchData)
 		require.NoError(t, err)
@@ -50,27 +50,27 @@ func TestParseUpdateOperation(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(),
-			"next update OTP hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the latest supported hash algorithm")
 	})
 }
 
 func TestValidateUpdatePatchData(t *testing.T) {
-	t.Run("invalid next update OTP", func(t *testing.T) {
+	t.Run("invalid next update commitment hash", func(t *testing.T) {
 		patchData := getUpdatePatchData()
 
-		patchData.NextUpdateOTPHash = ""
+		patchData.NextUpdateCommitmentHash = ""
 		err := validatePatchData(patchData, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"next update OTP hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the latest supported hash algorithm")
 	})
 }
 
 func TestParseUpdatePatchData(t *testing.T) {
-	t.Run("invalid next update OTP", func(t *testing.T) {
+	t.Run("invalid next update commitment", func(t *testing.T) {
 		patchData := getUpdatePatchData()
 
-		patchData.NextUpdateOTPHash = ""
+		patchData.NextUpdateCommitmentHash = ""
 		patchDataBytes, err := json.Marshal(patchData)
 		require.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestParseUpdatePatchData(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, parsed)
 		require.Contains(t, err.Error(),
-			"next update OTP hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the latest supported hash algorithm")
 	})
 	t.Run("invalid bytes", func(t *testing.T) {
 		parsed, err := parseUpdatePatchData("invalid", sha2_256)
@@ -117,8 +117,8 @@ func getUpdatePatchData() *model.PatchDataModel {
 	jsonPatch := patch.NewJSONPatch(getTestPatch())
 
 	return &model.PatchDataModel{
-		NextUpdateOTPHash: computeMultihash("updateOTP"),
-		Patches:           []patch.Patch{jsonPatch},
+		NextUpdateCommitmentHash: computeMultihash("updateReveal"),
+		Patches:                  []patch.Patch{jsonPatch},
 	}
 }
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -126,8 +126,8 @@ type resolutionModel struct {
 	Doc                            document.Document
 	LastOperationTransactionTime   uint64
 	LastOperationTransactionNumber uint64
-	NextUpdateOTPHash              string
-	NextRecoveryOTPHash            string
+	NextUpdateCommitmentHash       string
+	NextRecoveryCommitmentHash     string
 }
 
 func (s *OperationProcessor) applyOperation(operation *batch.Operation, rm *resolutionModel) (*resolutionModel, error) {
@@ -161,8 +161,8 @@ func (s *OperationProcessor) applyCreateOperation(operation *batch.Operation, rm
 		Doc:                            doc,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		NextUpdateOTPHash:              operation.NextUpdateOTPHash,
-		NextRecoveryOTPHash:            operation.NextRecoveryOTPHash}, nil
+		NextUpdateCommitmentHash:       operation.NextUpdateCommitmentHash,
+		NextRecoveryCommitmentHash:     operation.NextRecoveryCommitmentHash}, nil
 }
 
 func (s *OperationProcessor) applyUpdateOperation(operation *batch.Operation, rm *resolutionModel) (*resolutionModel, error) {
@@ -172,7 +172,7 @@ func (s *OperationProcessor) applyUpdateOperation(operation *batch.Operation, rm
 		return nil, errors.New("update cannot be first operation")
 	}
 
-	err := isValidHash(operation.UpdateOTP, rm.NextUpdateOTPHash)
+	err := isValidHash(operation.UpdateRevealValue, rm.NextUpdateCommitmentHash)
 	if err != nil {
 		return nil, err
 	}
@@ -198,8 +198,8 @@ func (s *OperationProcessor) applyUpdateOperation(operation *batch.Operation, rm
 		Doc:                            doc,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		NextUpdateOTPHash:              operation.NextUpdateOTPHash,
-		NextRecoveryOTPHash:            operation.NextRecoveryOTPHash}, nil
+		NextUpdateCommitmentHash:       operation.NextUpdateCommitmentHash,
+		NextRecoveryCommitmentHash:     operation.NextRecoveryCommitmentHash}, nil
 }
 
 func (s *OperationProcessor) applyRevokeOperation(operation *batch.Operation, rm *resolutionModel) (*resolutionModel, error) {
@@ -209,7 +209,7 @@ func (s *OperationProcessor) applyRevokeOperation(operation *batch.Operation, rm
 		return nil, errors.New("revoke can only be applied to an existing document")
 	}
 
-	err := isValidHash(operation.RecoveryOTP, rm.NextRecoveryOTPHash)
+	err := isValidHash(operation.RecoveryRevealValue, rm.NextRecoveryCommitmentHash)
 	if err != nil {
 		return nil, err
 	}
@@ -218,8 +218,8 @@ func (s *OperationProcessor) applyRevokeOperation(operation *batch.Operation, rm
 		Doc:                            nil,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		NextUpdateOTPHash:              "",
-		NextRecoveryOTPHash:            ""}, nil
+		NextUpdateCommitmentHash:       "",
+		NextRecoveryCommitmentHash:     ""}, nil
 }
 
 func (s *OperationProcessor) applyRecoverOperation(operation *batch.Operation, rm *resolutionModel) (*resolutionModel, error) {
@@ -229,7 +229,7 @@ func (s *OperationProcessor) applyRecoverOperation(operation *batch.Operation, r
 		return nil, errors.New("recover can only be applied to an existing document")
 	}
 
-	err := isValidHash(operation.RecoveryOTP, rm.NextRecoveryOTPHash)
+	err := isValidHash(operation.RecoveryRevealValue, rm.NextRecoveryCommitmentHash)
 	if err != nil {
 		return nil, err
 	}
@@ -245,8 +245,8 @@ func (s *OperationProcessor) applyRecoverOperation(operation *batch.Operation, r
 		Doc:                            doc,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		NextUpdateOTPHash:              operation.NextUpdateOTPHash,
-		NextRecoveryOTPHash:            operation.NextRecoveryOTPHash}, nil
+		NextUpdateCommitmentHash:       operation.NextUpdateCommitmentHash,
+		NextRecoveryCommitmentHash:     operation.NextRecoveryCommitmentHash}, nil
 }
 
 func isValidHash(encodedContent, encodedMultihash string) error {

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -102,16 +102,16 @@ func getCreateRequest() (*model.CreateRequest, error) {
 
 func getPatchData() *model.PatchDataModel {
 	return &model.PatchDataModel{
-		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
-		NextUpdateOTPHash: computeMultihash("updateOTP"),
+		Patches:                  []patch.Patch{patch.NewReplacePatch(validDoc)},
+		NextUpdateCommitmentHash: computeMultihash("updateReveal"),
 	}
 }
 
 func getSuffixData() *model.SuffixDataModel {
 	return &model.SuffixDataModel{
-		PatchDataHash:       computeMultihash(validDoc),
-		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
-		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
+		PatchDataHash:              computeMultihash(validDoc),
+		RecoveryKey:                model.PublicKey{PublicKeyHex: "HEX"},
+		NextRecoveryCommitmentHash: computeMultihash("recoveryReveal"),
 	}
 }
 

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -133,15 +133,15 @@ func getCreateRequest() (*model.CreateRequest, error) {
 
 func getPatchData() *model.PatchDataModel {
 	return &model.PatchDataModel{
-		Patches:           []patch.Patch{patch.NewReplacePatch(validDoc)},
-		NextUpdateOTPHash: computeMultihash("updateOTP"),
+		Patches:                  []patch.Patch{patch.NewReplacePatch(validDoc)},
+		NextUpdateCommitmentHash: computeMultihash("updateReveal"),
 	}
 }
 
 func getSuffixData() *model.SuffixDataModel {
 	return &model.SuffixDataModel{
-		PatchDataHash:       computeMultihash(validDoc),
-		RecoveryKey:         model.PublicKey{PublicKeyHex: "HEX"},
-		NextRecoveryOTPHash: computeMultihash("recoveryOTP"),
+		PatchDataHash:              computeMultihash(validDoc),
+		RecoveryKey:                model.PublicKey{PublicKeyHex: "HEX"},
+		NextRecoveryCommitmentHash: computeMultihash("recoveryReveal"),
 	}
 }

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
-	namespace   = "sample:sidetree"
-	badRequest  = `bad request`
-	recoveryOTP = "recoveryOTP"
-	updateOTP   = "updateOTP"
+	namespace  = "sample:sidetree"
+	badRequest = `bad request`
 
 	sha2_256 = 18
 )
+
+var recoveryReveal = []byte("recoveryReveal")
+var updateReveal = []byte("updateReveal")
 
 func TestUpdateHandler_Update(t *testing.T) {
 	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
@@ -175,7 +176,7 @@ func TestGetOperation(t *testing.T) {
 
 		op, err := handlerWithErr.getOperation(request)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "next update OTP hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "next update commitment hash is not computed with the latest supported hash algorithm")
 		require.Nil(t, op)
 	})
 	t.Run("unsupported operation type error", func(t *testing.T) {
@@ -189,11 +190,11 @@ func TestGetOperation(t *testing.T) {
 
 func getCreateRequestInfo() *helper.CreateRequestInfo {
 	return &helper.CreateRequestInfo{
-		OpaqueDocument:  validDoc,
-		RecoveryKey:     "HEX",
-		NextRecoveryOTP: docutil.EncodeToString([]byte(recoveryOTP)),
-		NextUpdateOTP:   docutil.EncodeToString([]byte(updateOTP)),
-		MultihashCode:   sha2_256,
+		OpaqueDocument:          validDoc,
+		RecoveryKey:             "HEX",
+		NextRecoveryRevealValue: recoveryReveal,
+		NextUpdateRevealValue:   updateReveal,
+		MultihashCode:           sha2_256,
 	}
 }
 
@@ -201,30 +202,30 @@ func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
 	patchJSON := `[{"op": "replace", "path": "/name", "value": "value"}]`
 
 	return &helper.UpdateRequestInfo{
-		DidUniqueSuffix: uniqueSuffix,
-		Patch:           patchJSON,
-		UpdateOTP:       docutil.EncodeToString([]byte(updateOTP)),
-		NextUpdateOTP:   docutil.EncodeToString([]byte(updateOTP)),
-		MultihashCode:   sha2_256,
+		DidUniqueSuffix:       uniqueSuffix,
+		Patch:                 patchJSON,
+		UpdateRevealValue:     updateReveal,
+		NextUpdateRevealValue: updateReveal,
+		MultihashCode:         sha2_256,
 	}
 }
 
 func getRevokeRequestInfo(uniqueSuffix string) *helper.RevokeRequestInfo {
 	return &helper.RevokeRequestInfo{
-		DidUniqueSuffix: uniqueSuffix,
-		RecoveryOTP:     docutil.EncodeToString([]byte(recoveryOTP)),
+		DidUniqueSuffix:     uniqueSuffix,
+		RecoveryRevealValue: docutil.EncodeToString(recoveryReveal),
 	}
 }
 
 func getRecoverRequestInfo(uniqueSuffix string) *helper.RecoverRequestInfo {
 	return &helper.RecoverRequestInfo{
-		DidUniqueSuffix: uniqueSuffix,
-		OpaqueDocument:  recoverDoc,
-		RecoveryKey:     "HEX",
-		RecoveryOTP:     docutil.EncodeToString([]byte(recoveryOTP)),
-		NextRecoveryOTP: docutil.EncodeToString([]byte("newRecoveryOTP")),
-		NextUpdateOTP:   docutil.EncodeToString([]byte("newUpdateOTP")),
-		MultihashCode:   sha2_256,
+		DidUniqueSuffix:         uniqueSuffix,
+		OpaqueDocument:          recoverDoc,
+		RecoveryKey:             "HEX",
+		RecoveryRevealValue:     recoveryReveal,
+		NextRecoveryRevealValue: []byte("newRecoveryReveal"),
+		NextUpdateRevealValue:   []byte("newUpdateReveal"),
+		MultihashCode:           sha2_256,
 	}
 }
 

--- a/pkg/restapi/helper/request_test.go
+++ b/pkg/restapi/helper/request_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 )
 
 const (
@@ -45,32 +43,6 @@ func TestNewCreateRequest(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "algorithm not supported")
-	})
-	t.Run("next update otp not encoded", func(t *testing.T) {
-		info := &CreateRequestInfo{
-			OpaqueDocument: "{}",
-			RecoveryKey:    "recovery",
-			NextUpdateOTP:  "invalid",
-			MultihashCode:  sha2_256}
-
-		request, err := NewCreateRequest(info)
-		require.Error(t, err)
-		require.Empty(t, request)
-		require.Contains(t, err.Error(), "illegal base64 data")
-	})
-	t.Run("next update otp not encoded", func(t *testing.T) {
-		info := &CreateRequestInfo{
-			OpaqueDocument:  "{}",
-			RecoveryKey:     "recovery",
-			NextUpdateOTP:   docutil.EncodeToString([]byte("updateOTP")),
-			NextRecoveryOTP: "invalid",
-			MultihashCode:   sha2_256,
-		}
-
-		request, err := NewCreateRequest(info)
-		require.Error(t, err)
-		require.Empty(t, request)
-		require.Contains(t, err.Error(), "illegal base64 data")
 	})
 	t.Run("success", func(t *testing.T) {
 		info := &CreateRequestInfo{OpaqueDocument: "{}",
@@ -120,7 +92,6 @@ func TestNewUpdateRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "missing update information")
 	})
-
 	t.Run("multihash not supported", func(t *testing.T) {
 		info := &UpdateRequestInfo{DidUniqueSuffix: didUniqueSuffix, Patch: patch}
 
@@ -129,16 +100,6 @@ func TestNewUpdateRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "algorithm not supported")
 	})
-
-	t.Run("next update otp not encoded", func(t *testing.T) {
-		info := &UpdateRequestInfo{DidUniqueSuffix: didUniqueSuffix, Patch: patch, NextUpdateOTP: "invalid"}
-
-		request, err := NewUpdateRequest(info)
-		require.Error(t, err)
-		require.Empty(t, request)
-		require.Contains(t, err.Error(), "illegal base64 data")
-	})
-
 	t.Run("success", func(t *testing.T) {
 		info := &UpdateRequestInfo{DidUniqueSuffix: didUniqueSuffix, Patch: patch, MultihashCode: sha2_256}
 
@@ -190,24 +151,6 @@ func TestNewRecoverRequest(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "algorithm not supported")
-	})
-	t.Run("next update otp not encoded", func(t *testing.T) {
-		info := getRecoverRequestInfo()
-		info.NextUpdateOTP = "otp"
-
-		request, err := NewRecoverRequest(info)
-		require.Error(t, err)
-		require.Empty(t, request)
-		require.Contains(t, err.Error(), "illegal base64 data")
-	})
-	t.Run("next recover otp not encoded", func(t *testing.T) {
-		info := getRecoverRequestInfo()
-		info.NextRecoveryOTP = "otp"
-
-		request, err := NewRecoverRequest(info)
-		require.Error(t, err)
-		require.Empty(t, request)
-		require.Contains(t, err.Error(), "illegal base64 data")
 	})
 	t.Run("success", func(t *testing.T) {
 		info := getRecoverRequestInfo()

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -34,8 +34,8 @@ type SuffixDataModel struct {
 	// The recovery public key as a HEX string.
 	RecoveryKey PublicKey `json:"recoveryKey"`
 
-	// Hash of the one-time password for this recovery/checkpoint/revoke operation.
-	NextRecoveryOTPHash string `json:"nextRecoveryOtpHash"`
+	// Commitment hash for the next recovery
+	NextRecoveryCommitmentHash string `json:"nextRecoveryCommitmentHash"`
 }
 
 // PublicKey is holder for public key in hex
@@ -47,8 +47,8 @@ type PublicKey struct {
 // PatchDataModel contains patch data (patches used for create, recover, update)
 type PatchDataModel struct {
 
-	// Hash of the one-time password for the next update operation
-	NextUpdateOTPHash string `json:"nextUpdateOtpHash"`
+	// Commitment hash for the next update operation
+	NextUpdateCommitmentHash string `json:"nextUpdateCommitmentHash"`
 
 	// Patches defines document patches
 	Patches []patch.Patch `json:"patches"`
@@ -61,8 +61,8 @@ type UpdateRequest struct {
 	//The unique suffix of the DID
 	DidUniqueSuffix string `json:"didUniqueSuffix"`
 
-	// One-time password for update operation
-	UpdateOTP string `json:"updateOtp"`
+	// Reveal value for this update operation
+	UpdateRevealValue string `json:"updateRevealValue"`
 
 	// JWS signature information
 	SignedData *JWS `json:"signedData"`
@@ -81,9 +81,9 @@ type RevokeRequest struct {
 	// Required: true
 	DidUniqueSuffix string `json:"didUniqueSuffix"`
 
-	// the current one-time recovery password
+	// the current reveal value to use for this request
 	// Required: true
-	RecoveryOTP string `json:"recoveryOtp"`
+	RecoveryRevealValue string `json:"recoveryRevealValue"`
 
 	// JWS Signature information
 	SignedData *JWS `json:"signedData"`
@@ -99,7 +99,7 @@ type SignedDataModel struct {
 	RecoveryKey PublicKey `json:"recoveryKey"`
 
 	// Hash of the one-time password to be used for the next recovery/revoke
-	NextRecoveryOTPHash string `json:"nextRecoveryOtpHash"`
+	NextRecoveryCommitmentHash string `json:"nextRecoveryCommitmentHash"`
 }
 
 // RecoverRequest is the struct for document recovery payload
@@ -112,9 +112,9 @@ type RecoverRequest struct {
 	// Required: true
 	DidUniqueSuffix string `json:"didUniqueSuffix"`
 
-	// One-time recovery password for this recovery
+	// The reveal value for this recovery
 	// Required: true
-	RecoveryOTP string `json:"recoveryOtp"`
+	RecoveryRevealValue string `json:"recoveryRevealValue"`
 
 	// JWS Signature information
 	SignedData *JWS `json:"signedData"`


### PR DESCRIPTION
rename OTPHash to CommitmentHash
rename OTP to RevealValue
minor change for reveal value type in helper requests - makes it easier for client

Closes #153

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>