### PR TITLE
feat: Add document composer for applying patches

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package batch
 
 import (
-	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
 // Operation defines an operation
@@ -25,18 +25,14 @@ type Operation struct {
 	// OperationBuffer is the original operation request
 	OperationBuffer []byte `json:"operationBuffer"`
 
-	//Document contains original opaque document
-	Document string `json:"document"`
+	// signed data for the operation
+	SignedData *model.JWS `json:"signedData"`
 
-	//SigningKeyID is the id of the key that was used to sign this encoded payload
-	SigningKeyID string `json:"signingKeyID"`
-	//Signature is the signature of this encoded payload
-	Signature string `json:"signature"`
-	// Signing algorithm
-	SigningAlgorithm string `json:"algorithm"`
+	// operation patch data
+	PatchData *model.PatchDataModel `json:"patchData"`
 
-	//An RFC 6902 JSON patch to the current Document
-	Patch jsonpatch.Patch `json:"patch"`
+	// encoded patch data
+	EncodedPatchData string `json:"encodedPatchData"`
 
 	//HashAlgorithmInMultiHashCode
 	HashAlgorithmInMultiHashCode uint `json:"hashAlgorithmInMultiHashCode"`

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -1,0 +1,66 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package composer
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// ApplyPatches applies patches to the document
+func ApplyPatches(doc document.Document, patches []patch.Patch) (document.Document, error) {
+	var err error
+
+	for _, p := range patches {
+		doc, err = applyPatch(doc, p)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return doc, nil
+}
+
+// applyPatch applies a patch to the document
+func applyPatch(doc document.Document, p patch.Patch) (document.Document, error) {
+	action := p.GetAction()
+	switch action {
+	case patch.Replace:
+		return applyRecover(p.GetStringValue(patch.DocumentKey))
+	case patch.JSONPatch:
+		return applyJSON(doc, p.GetStringValue(patch.PatchesKey))
+	}
+
+	return nil, fmt.Errorf("action '%s' is not supported", action)
+}
+
+func applyRecover(newDoc string) (document.Document, error) {
+	return document.FromBytes([]byte(newDoc))
+}
+
+func applyJSON(doc document.Document, patches string) (document.Document, error) {
+	jsonPatches, err := jsonpatch.DecodePatch([]byte(patches))
+	if err != nil {
+		return nil, err
+	}
+
+	docBytes, err := doc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	docBytes, err = jsonPatches.Apply(docBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return document.FromBytes(docBytes)
+}

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestApplyPatches(t *testing.T) {
+	t.Run("action not supported", func(t *testing.T) {
+		replace := patch.NewReplacePatch("{}")
+		replace["action"] = "invalid"
+
+		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+		require.Error(t, err)
+		require.Nil(t, doc)
+		require.Contains(t, err.Error(), "not supported")
+	})
+}
+
+func TestApplyPatches_Replace(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		replace := patch.NewReplacePatch(testDoc)
+
+		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+	})
+}
+
+func TestApplyPatches_JSON(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		replace := patch.NewReplacePatch(testDoc)
+		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+
+		ietf := patch.NewJSONPatch(patches)
+		doc, err = ApplyPatches(doc, []patch.Patch{ietf})
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+	})
+	t.Run("invalid json", func(t *testing.T) {
+		replace := patch.NewReplacePatch(testDoc)
+		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+
+		ietf := patch.NewJSONPatch("invalid")
+		doc, err = ApplyPatches(doc, []patch.Patch{ietf})
+		require.Error(t, err)
+		require.Nil(t, doc)
+		require.Contains(t, err.Error(), "invalid character")
+	})
+	t.Run("invalid operation", func(t *testing.T) {
+		replace := patch.NewReplacePatch(testDoc)
+		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+
+		ietf := patch.NewJSONPatch(invalidPatches)
+		doc, err = ApplyPatches(doc, []patch.Patch{ietf})
+		require.Error(t, err)
+		require.Nil(t, doc)
+		require.Contains(t, err.Error(), "Unexpected kind: invalid")
+	})
+}
+
+const invalidPatches = `[
+	{
+      "op": "invalid",
+      "path": "/service",
+      "value": "new value"
+	}
+]`
+
+const patches = `[
+	{
+      "op": "replace",
+      "path": "/service",
+      "value": "new value"
+	}
+]`
+
+const testDoc = `{
+  "service": [{
+    "id":"#vcs",
+    "type": "VerifiableCredentialService",
+    "serviceEndpoint": "https://example.com/vc/"
+  }]
+}`

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -9,6 +9,8 @@ package mocks
 import (
 	"errors"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/composer"
+
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
@@ -73,7 +75,7 @@ func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (docu
 		return nil, nil
 	}
 
-	doc, err := document.FromBytes([]byte(operation.Document))
+	doc, err := composer.ApplyPatches(nil, operation.PatchData.Patches)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -37,8 +36,6 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
-	document := patchData.Patches[0].GetStringValue(patch.DocumentKey)
-
 	uniqueSuffix, err := docutil.CalculateUniqueSuffix(schema.SuffixData, code)
 	if err != nil {
 		return nil, err
@@ -50,7 +47,8 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		OperationBuffer:              request,
 		Type:                         batch.OperationTypeCreate,
 		UniqueSuffix:                 uniqueSuffix,
-		Document:                     document,
+		PatchData:                    patchData,
+		EncodedPatchData:             schema.PatchData,
 		NextUpdateCommitmentHash:     patchData.NextUpdateCommitmentHash,
 		NextRecoveryCommitmentHash:   suffixData.NextRecoveryCommitmentHash,
 		HashAlgorithmInMultiHashCode: code,

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -14,7 +14,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -37,15 +36,14 @@ func ParseRecoverOperation(request []byte, protocol protocol.Protocol) (*batch.O
 		return nil, err
 	}
 
-	document := patchData.Patches[0].GetStringValue(patch.DocumentKey)
-
 	// TODO: Handle recovery key
 
 	return &batch.Operation{
 		OperationBuffer:              request,
 		Type:                         batch.OperationTypeRecover,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
-		Document:                     document,
+		PatchData:                    patchData,
+		EncodedPatchData:             schema.PatchData,
 		RecoveryRevealValue:          schema.RecoveryRevealValue,
 		NextUpdateCommitmentHash:     patchData.NextUpdateCommitmentHash,
 		NextRecoveryCommitmentHash:   signedData.NextRecoveryCommitmentHash,

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -9,12 +9,9 @@ package operation
 import (
 	"encoding/json"
 
-	jsonpatch "github.com/evanphx/json-patch"
-
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -30,21 +27,14 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
-	patches := patchData.Patches[0].GetStringValue(patch.PatchesKey)
-
-	// TODO: model for operation patch will change with issue-155
-	patch, err := jsonpatch.DecodePatch([]byte(patches))
-	if err != nil {
-		return nil, err
-	}
-
 	return &batch.Operation{
 		Type:                         batch.OperationTypeUpdate,
 		OperationBuffer:              request,
 		UniqueSuffix:                 schema.DidUniqueSuffix,
+		PatchData:                    patchData,
+		EncodedPatchData:             schema.PatchData,
 		UpdateRevealValue:            schema.UpdateRevealValue,
 		NextUpdateCommitmentHash:     patchData.NextUpdateCommitmentHash,
-		Patch:                        patch,
 		HashAlgorithmInMultiHashCode: protocol.HashAlgorithmInMultiHashCode,
 	}, nil
 }

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -34,9 +34,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.NoError(t, err)
 
 		doc, err := docHandler.ProcessOperation(&batch.Operation{
-			Type:     batch.OperationTypeCreate,
-			ID:       id,
-			Document: validDoc,
+			Type:             batch.OperationTypeCreate,
+			ID:               id,
+			PatchData:        getPatchData(),
+			EncodedPatchData: create.PatchData,
 		})
 		require.NoError(t, err)
 
@@ -91,9 +92,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.NoError(t, err)
 
 		doc, err := docHandler.ProcessOperation(&batch.Operation{
-			Type:     batch.OperationTypeCreate,
-			ID:       id,
-			Document: validDoc,
+			Type:             batch.OperationTypeCreate,
+			ID:               id,
+			PatchData:        getPatchData(),
+			EncodedPatchData: create.PatchData,
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
Add document composer for applying patches.
Modify operation model as follows:
-- remove document
-- add patch data and encoded patch data

Resolution with initial-value is also done via patches

Closes #167

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>