### PR TITLE
feat: Allow for different operation store per namespace in Observer

### DIFF
--- a/pkg/observer/noopoperationfilter.go
+++ b/pkg/observer/noopoperationfilter.go
@@ -15,8 +15,8 @@ type NoopOperationFilterProvider struct {
 }
 
 // Get returns a noop operation filter
-func (m *NoopOperationFilterProvider) Get(string) OperationFilter {
-	return &noopOperationFilter{}
+func (m *NoopOperationFilterProvider) Get(string) (OperationFilter, error) {
+	return &noopOperationFilter{}, nil
 }
 
 type noopOperationFilter struct {

--- a/pkg/observer/noopoperationfilter_test.go
+++ b/pkg/observer/noopoperationfilter_test.go
@@ -21,7 +21,8 @@ func TestNoopOperationFilter_Filter(t *testing.T) {
 	const suffix = "1234"
 	const ns = "did:sidetree"
 
-	f := p.Get(ns)
+	f, err := p.Get(ns)
+	require.NoError(t, err)
 
 	ops := []*batch.Operation{
 		{

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -7,16 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package observer
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
-
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 )
 
 const anchorAddressKey = "anchorAddress"
@@ -35,11 +35,16 @@ func TestStartObserver(t *testing.T) {
 
 		providers := &Providers{
 			Ledger:           mockLedger{registerForSidetreeTxnValue: sidetreeTxnCh},
-			DCASClient:       mockDACS{readFunc: readFunc},
+			DCASClient:       mockDCAS{readFunc: readFunc},
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
-		Start(providers)
+		o := New(providers)
+		require.NotNil(t, o)
+
+		o.Start()
+		defer o.Stop()
+
 		sidetreeTxnCh <- []SidetreeTxn{{TransactionTime: 20, TransactionNumber: 2, AnchorAddress: "address"}}
 		time.Sleep(200 * time.Millisecond)
 		rw.RLock()
@@ -55,7 +60,12 @@ func TestStartObserver(t *testing.T) {
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
-		Start(providers)
+		o := New(providers)
+		require.NotNil(t, o)
+
+		o.Start()
+		defer o.Stop()
+
 		close(sidetreeTxnCh)
 		time.Sleep(200 * time.Millisecond)
 	})
@@ -65,9 +75,16 @@ func TestStartObserver(t *testing.T) {
 		isCalled := false
 
 		var rw sync.RWMutex
+		opStore := &mockOperationStore{putFunc: func(ops []*batch.Operation) error {
+			rw.Lock()
+			isCalled = true
+			rw.Unlock()
+			return nil
+		}}
+
 		providers := &Providers{
 			Ledger: mockLedger{registerForSidetreeTxnValue: sidetreeTxnCh},
-			DCASClient: mockDACS{readFunc: func(key string) ([]byte, error) {
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
 				if key == anchorAddressKey {
 					return docutil.MarshalCanonical(&AnchorFile{})
 				}
@@ -75,16 +92,16 @@ func TestStartObserver(t *testing.T) {
 				require.NoError(t, err)
 				return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 			}},
-			OpStore: mockOperationStore{putFunc: func(ops []*batch.Operation) error {
-				rw.Lock()
-				isCalled = true
-				rw.Unlock()
-				return nil
-			}},
+			OpStoreProvider:  &mockOperationStoreProvider{opStore: opStore},
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
-		Start(providers)
+		o := New(providers)
+		require.NotNil(t, o)
+
+		o.Start()
+		defer o.Stop()
+
 		sidetreeTxnCh <- []SidetreeTxn{{TransactionTime: 20, TransactionNumber: 2, AnchorAddress: "address"}}
 		time.Sleep(200 * time.Millisecond)
 		rw.RLock()
@@ -92,10 +109,11 @@ func TestStartObserver(t *testing.T) {
 		rw.RUnlock()
 	})
 }
+
 func TestTxnProcessor_Process(t *testing.T) {
 	t.Run("test error from dacs read", func(t *testing.T) {
 		providers := &Providers{
-			DCASClient:       mockDACS{readFunc: func(key string) ([]byte, error) { return nil, fmt.Errorf("read error") }},
+			DCASClient:       mockDCAS{readFunc: func(key string) ([]byte, error) { return nil, fmt.Errorf("read error") }},
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
@@ -107,7 +125,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 
 	t.Run("test error from getAnchorFile", func(t *testing.T) {
 		providers := &Providers{
-			DCASClient:       mockDACS{readFunc: func(key string) ([]byte, error) { return []byte("1"), nil }},
+			DCASClient:       mockDCAS{readFunc: func(key string) ([]byte, error) { return []byte("1"), nil }},
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
@@ -119,7 +137,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 
 	t.Run("test error from processBatchFile", func(t *testing.T) {
 		providers := &Providers{
-			DCASClient: mockDACS{readFunc: func(key string) ([]byte, error) {
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
 				if key == anchorAddressKey {
 					return docutil.MarshalCanonical(&AnchorFile{})
 				}
@@ -138,7 +156,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 func TestProcessBatchFile(t *testing.T) {
 	t.Run("test error from getBatchFile", func(t *testing.T) {
 		providers := &Providers{
-			DCASClient: mockDACS{readFunc: func(key string) ([]byte, error) {
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
 				if key == anchorAddressKey {
 					return docutil.MarshalCanonical(&AnchorFile{})
 				}
@@ -155,7 +173,7 @@ func TestProcessBatchFile(t *testing.T) {
 
 	t.Run("test error from updateOperation", func(t *testing.T) {
 		providers := &Providers{
-			DCASClient: mockDACS{readFunc: func(key string) ([]byte, error) {
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
 				if key == anchorAddressKey {
 					return docutil.MarshalCanonical(&AnchorFile{})
 				}
@@ -171,9 +189,11 @@ func TestProcessBatchFile(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to update operation with blockchain metadata")
 	})
 
-	t.Run("test error from operationStore Put", func(t *testing.T) {
+	t.Run("test error from operationStoreProvider ForNamespace", func(t *testing.T) {
+		errExpected := errors.New("injected store provider error")
+
 		providers := &Providers{
-			DCASClient: mockDACS{readFunc: func(key string) ([]byte, error) {
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
 				if key == anchorAddressKey {
 					return docutil.MarshalCanonical(&AnchorFile{})
 				}
@@ -181,9 +201,31 @@ func TestProcessBatchFile(t *testing.T) {
 				require.NoError(t, err)
 				return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 			}},
-			OpStore: mockOperationStore{putFunc: func(ops []*batch.Operation) error {
-				return fmt.Errorf("put error")
+			OpStoreProvider:  &mockOperationStoreProvider{err: errExpected},
+			OpFilterProvider: &NoopOperationFilterProvider{},
+		}
+
+		p := NewTxnProcessor(providers)
+		err := p.processBatchFile("", SidetreeTxn{AnchorAddress: anchorAddressKey})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("test error from operationStore Put", func(t *testing.T) {
+		opStore := &mockOperationStore{putFunc: func(ops []*batch.Operation) error {
+			return fmt.Errorf("put error")
+		}}
+
+		providers := &Providers{
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
+				if key == anchorAddressKey {
+					return docutil.MarshalCanonical(&AnchorFile{})
+				}
+				b, err := docutil.MarshalCanonical(batch.Operation{ID: "did:sideteree:123456"})
+				require.NoError(t, err)
+				return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 			}},
+			OpStoreProvider:  &mockOperationStoreProvider{opStore: opStore},
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
@@ -195,7 +237,7 @@ func TestProcessBatchFile(t *testing.T) {
 
 	t.Run("test success", func(t *testing.T) {
 		providers := &Providers{
-			DCASClient: mockDACS{readFunc: func(key string) ([]byte, error) {
+			DCASClient: mockDCAS{readFunc: func(key string) ([]byte, error) {
 				if key == anchorAddressKey {
 					return docutil.MarshalCanonical(&AnchorFile{})
 				}
@@ -203,7 +245,7 @@ func TestProcessBatchFile(t *testing.T) {
 				require.NoError(t, err)
 				return docutil.MarshalCanonical(&BatchFile{Operations: []string{docutil.EncodeToString(b)}})
 			}},
-			OpStore:          mockOperationStore{},
+			OpStoreProvider:  &mockOperationStoreProvider{opStore: &mockOperationStore{}},
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
@@ -257,11 +299,11 @@ func (m mockLedger) RegisterForSidetreeTxn() <-chan []SidetreeTxn {
 	return m.registerForSidetreeTxnValue
 }
 
-type mockDACS struct {
+type mockDCAS struct {
 	readFunc func(key string) ([]byte, error)
 }
 
-func (m mockDACS) Read(key string) ([]byte, error) {
+func (m mockDCAS) Read(key string) ([]byte, error) {
 	if m.readFunc != nil {
 		return m.readFunc(key)
 	}
@@ -270,11 +312,32 @@ func (m mockDACS) Read(key string) ([]byte, error) {
 
 type mockOperationStore struct {
 	putFunc func(ops []*batch.Operation) error
+	getFunc func(suffix string) ([]*batch.Operation, error)
 }
 
-func (m mockOperationStore) Put(ops []*batch.Operation) error {
+func (m *mockOperationStore) Put(ops []*batch.Operation) error {
 	if m.putFunc != nil {
 		return m.putFunc(ops)
 	}
 	return nil
+}
+
+func (m *mockOperationStore) Get(suffix string) ([]*batch.Operation, error) {
+	if m.getFunc != nil {
+		return m.getFunc(suffix)
+	}
+	return nil, nil
+}
+
+type mockOperationStoreProvider struct {
+	opStore OperationStore
+	err     error
+}
+
+func (m *mockOperationStoreProvider) ForNamespace(string) (OperationStore, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return m.opStore, nil
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -29,8 +29,6 @@ type OperationProcessor struct {
 type OperationStoreClient interface {
 	// Get retrieves all operations related to document
 	Get(uniqueSuffix string) ([]*batch.Operation, error)
-	// Put storing operation
-	Put(op *batch.Operation) error
 }
 
 // New returns new operation processor with the given name. (Note that name is only used for logging.)


### PR DESCRIPTION
Added an OperationStoreProvider which manages operation stores by namespace.

Also, created an Observer struct to contain Observer operations, including Start and Stop functions.

closes #169

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>