### PR TITLE
feat: Handle usage property

### DIFF
--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -18,11 +18,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 )
 
-const (
-	jsonldPublicKey = "publicKey"
-	jsonldService   = "service"
-)
-
 // ApplyPatches applies patches to the document
 func ApplyPatches(doc document.Document, patches []patch.Patch) (document.Document, error) {
 	var err error
@@ -89,7 +84,7 @@ func applyAddPublicKeys(doc document.Document, publicKeys string) (document.Docu
 	log.Debugf("applying add public keys patch: %s", publicKeys)
 
 	// create an empty did document with public keys
-	pkDoc, err := document.DidDocumentFromBytes([]byte(fmt.Sprintf(`{"%s":%s}`, jsonldPublicKey, publicKeys)))
+	pkDoc, err := document.DidDocumentFromBytes([]byte(fmt.Sprintf(`{"%s":%s}`, document.PublicKeyProperty, publicKeys)))
 	if err != nil {
 		return nil, errors.Errorf("public keys invalid: %s", err.Error())
 	}
@@ -107,7 +102,7 @@ func applyAddPublicKeys(doc document.Document, publicKeys string) (document.Docu
 		}
 	}
 
-	doc[jsonldPublicKey] = mapToSlicePK(newPublicKeys)
+	doc[document.PublicKeyProperty] = mapToSlicePK(newPublicKeys)
 
 	return doc, nil
 }
@@ -129,7 +124,7 @@ func applyRemovePublicKeys(doc document.Document, removeKeyIDs string) (document
 		delete(newPublicKeys, key)
 	}
 
-	doc[jsonldPublicKey] = mapToSlicePK(newPublicKeys)
+	doc[document.PublicKeyProperty] = mapToSlicePK(newPublicKeys)
 
 	return doc, nil
 }
@@ -161,7 +156,7 @@ func applyAddServiceEndpoints(doc document.Document, serviceEnpoints string) (do
 	diddoc := document.DidDocumentFromJSONLDObject(doc.JSONLdObject())
 
 	// create an empty did document with service endpoints
-	svcDocStr := fmt.Sprintf(`{"%s":%s}`, jsonldService, serviceEnpoints)
+	svcDocStr := fmt.Sprintf(`{"%s":%s}`, document.ServiceProperty, serviceEnpoints)
 
 	svcDoc, err := document.DidDocumentFromBytes([]byte(svcDocStr))
 	if err != nil {
@@ -179,7 +174,7 @@ func applyAddServiceEndpoints(doc document.Document, serviceEnpoints string) (do
 		}
 	}
 
-	doc[jsonldService] = mapToSliceServices(newServices)
+	doc[document.ServiceProperty] = mapToSliceServices(newServices)
 
 	return doc, nil
 }
@@ -200,7 +195,7 @@ func applyRemoveServiceEndpoints(doc document.Document, serviceIDs string) (docu
 		delete(newServices, svc)
 	}
 
-	doc[jsonldService] = mapToSliceServices(newServices)
+	doc[document.ServiceProperty] = mapToSliceServices(newServices)
 
 	return doc, nil
 }

--- a/pkg/dochandler/didvalidator/testdata/doc.json
+++ b/pkg/dochandler/didvalidator/testdata/doc.json
@@ -1,17 +1,58 @@
 {
   "publicKey": [
     {
-      "id": "key1",
+      "id": "master",
       "type": "EcdsaSecp256k1VerificationKey2019",
+      "usage": ["ops", "general", "auth"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "ops-only",
+      "type": "JwsVerificationKey2020",
       "usage": ["ops"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc",
-        "use": "verify",
-        "defaultEncryptionAlgorithm": "none"
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-auth-general",
+      "type": "JwsVerificationKey2020",
+      "usage": ["auth", "general"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "auth-only",
+      "type": "JwsVerificationKey2020",
+      "usage": ["auth"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "general-only",
+      "type": "JwsVerificationKey2020",
+      "usage": ["general"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
       }
     }
   ],

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -13,15 +13,24 @@ import (
 )
 
 const (
-	jsonldContext = "@context"
 
-	jsonldType = "type"
+	// ContextProperty defines key for context property
+	ContextProperty = "@context"
 
-	jsonldService      = "service"
+	// ServiceProperty defines key for service property
+	ServiceProperty = "service"
+
+	// PublicKeyProperty defines key for public key property
+	PublicKeyProperty = "publicKey"
+
+	// AuthenticationProperty defines key for authentication property
+	AuthenticationProperty = "authentication"
+
+	// ControllerProperty defines key for controller
+	ControllerProperty = "controller"
+
+	jsonldType         = "type"
 	jsonldServicePoint = "serviceEndpoint"
-
-	jsonldPublicKey  = "publicKey"
-	jsonldController = "controller"
 
 	// various public key encodings
 	jsonldPublicKeyBase64 = "publicKeyBase64"
@@ -39,17 +48,17 @@ type DIDDocument map[string]interface{}
 
 // ID is identifier for DID subject (what DID Document is about)
 func (doc DIDDocument) ID() string {
-	return stringEntry(doc[jsonldID])
+	return stringEntry(doc[IDProperty])
 }
 
 // Context is the context of did document
 func (doc DIDDocument) Context() []string {
-	return stringArray(doc[jsonldContext])
+	return stringArray(doc[ContextProperty])
 }
 
 // PublicKeys are used for digital signatures, encryption and other cryptographic operations
 func (doc DIDDocument) PublicKeys() []PublicKey {
-	entry, ok := doc[jsonldPublicKey]
+	entry, ok := doc[PublicKeyProperty]
 	if !ok {
 		return nil
 	}
@@ -72,7 +81,7 @@ func (doc DIDDocument) PublicKeys() []PublicKey {
 
 // Services is an array of service endpoints
 func (doc DIDDocument) Services() []Service {
-	entry, ok := doc[jsonldService]
+	entry, ok := doc[ServiceProperty]
 	if !ok {
 		return nil
 	}
@@ -98,6 +107,11 @@ func (doc DIDDocument) JSONLdObject() map[string]interface{} {
 	return doc
 }
 
+// Authentication return authentication array (mixture of strings and objects)
+func (doc DIDDocument) Authentication() []interface{} {
+	return interfaceArray(doc[AuthenticationProperty])
+}
+
 // DIDDocumentFromReader creates an instance of DIDDocument by reading a JSON document from Reader
 func DIDDocumentFromReader(r io.Reader) (DIDDocument, error) {
 	data, err := ioutil.ReadAll(r)
@@ -121,4 +135,18 @@ func DidDocumentFromBytes(data []byte) (DIDDocument, error) {
 // DidDocumentFromJSONLDObject creates an instance of DIDDocument from json ld object
 func DidDocumentFromJSONLDObject(jsonldObject map[string]interface{}) DIDDocument {
 	return jsonldObject
+}
+
+// interfaceArray
+func interfaceArray(entry interface{}) []interface{} {
+	if entry == nil {
+		return nil
+	}
+
+	entries, ok := entry.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	return entries
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -12,7 +12,8 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 )
 
-const jsonldID = "id"
+// IDProperty describes id key
+const IDProperty = "id"
 
 // Document defines generic document data structure
 type Document map[string]interface{}
@@ -35,7 +36,7 @@ func FromJSONLDObject(jsonldObject map[string]interface{}) Document {
 
 // ID is document identifier
 func (doc Document) ID() string {
-	return stringEntry(doc[jsonldID])
+	return stringEntry(doc[IDProperty])
 }
 
 // GetStringValue returns string value for specified key or "" if not found or wrong type

--- a/pkg/document/publickey.go
+++ b/pkg/document/publickey.go
@@ -16,7 +16,7 @@ func NewPublicKey(pk map[string]interface{}) PublicKey {
 
 // ID is public key ID
 func (pk PublicKey) ID() string {
-	return stringEntry(pk[jsonldID])
+	return stringEntry(pk[IDProperty])
 }
 
 // Type is public key type
@@ -26,7 +26,7 @@ func (pk PublicKey) Type() string {
 
 // Controller identifies the entity that controls the corresponding private key.
 func (pk PublicKey) Controller() string {
-	return stringEntry(pk[jsonldController])
+	return stringEntry(pk[ControllerProperty])
 }
 
 //PublicKeyBase64 is value property

--- a/pkg/document/resolution.go
+++ b/pkg/document/resolution.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package document
+
+// ResolutionResult describes resolution result
+type ResolutionResult struct {
+	Context        string
+	DIDDocument    DIDDocument
+	MethodMetadata MethodMetadata
+}
+
+// MethodMetadata contains document metadata
+type MethodMetadata struct {
+	OperationPublicKeys []PublicKey
+	RecoveryKey         PublicKey
+	Published           bool
+}

--- a/pkg/document/service.go
+++ b/pkg/document/service.go
@@ -16,7 +16,7 @@ func NewService(m map[string]interface{}) Service {
 
 // ID is service ID
 func (s Service) ID() string {
-	return stringEntry(s[jsonldID])
+	return stringEntry(s[IDProperty])
 }
 
 // Type is service type

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -91,8 +91,22 @@ func ValidateOperationsKey(pubKey PublicKey) error {
 
 // IsOperationsKey returns true if key is an operations key
 func IsOperationsKey(pubKey PublicKey) bool {
+	return isUsageKey(pubKey, ops)
+}
+
+// IsGeneralKey returns true if key is a general key
+func IsGeneralKey(pubKey PublicKey) bool {
+	return isUsageKey(pubKey, general)
+}
+
+// IsAuthenticationKey returns true if key is an authentication key
+func IsAuthenticationKey(pubKey PublicKey) bool {
+	return isUsageKey(pubKey, auth)
+}
+
+func isUsageKey(pubKey PublicKey, mode string) bool {
 	for _, usage := range pubKey.Usage() {
-		if usage == ops {
+		if usage == mode {
 			return true
 		}
 	}
@@ -100,6 +114,10 @@ func IsOperationsKey(pubKey PublicKey) bool {
 	return false
 }
 
+// The object MUST include a usage property, and its value MUST be an array that includes one or more of the following:
+// - ops: the key is allowed to generate DID operations for the DID.
+// - general: the key is to be included in the publicKeys section of the resolved DID Document.
+// - auth: the key is to be included in the authentication section of the resolved DID Document
 func validateKeyUsage(pubKey PublicKey) error {
 	if len(pubKey.Usage()) == 0 {
 		return fmt.Errorf("key '%s' is missing usage", pubKey.ID())

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -110,6 +110,26 @@ func TestValidateOperationsKey(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIsAuthenticationKey(t *testing.T) {
+	pk := NewPublicKey(map[string]interface{}{})
+	ok := IsAuthenticationKey(pk)
+	require.False(t, ok)
+
+	pk["usage"] = []interface{}{auth}
+	ok = IsAuthenticationKey(pk)
+	require.True(t, ok)
+}
+
+func TestIsGeneralKey(t *testing.T) {
+	pk := NewPublicKey(map[string]interface{}{})
+	ok := IsGeneralKey(pk)
+	require.False(t, ok)
+
+	pk["usage"] = []interface{}{general}
+	ok = IsGeneralKey(pk)
+	require.True(t, ok)
+}
+
 const noUsage = `{
   "publicKey": [
     {
@@ -117,7 +137,6 @@ const noUsage = `{
       "type": "JwsVerificationKey2020",
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
@@ -134,7 +153,6 @@ const wrongUsage = `{
       "usage": ["invalid"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
@@ -151,7 +169,6 @@ const tooMuchUsage = `{
       "usage": ["ops", "general", "auth", "other"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
@@ -177,7 +194,6 @@ const noID = `{
       "usage": ["ops"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
@@ -194,7 +210,6 @@ const invalidKeyType = `{
       "usage": ["general"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
@@ -211,7 +226,6 @@ const duplicateID = `{
       "usage": ["ops"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
@@ -223,7 +237,6 @@ const duplicateID = `{
       "usage": ["ops"],
       "publicKeyJwk": {
         "kty": "EC",
-        "kid": "key1",
         "crv": "P-256K",
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"


### PR DESCRIPTION
The object MUST include a usage property, and its value MUST be an array that includes one or more of the following strings:
ops: the key is allowed to generate DID operations for the DID.
general: the key is to be included in the publicKeys section of the resolved DID Document.
auth: the key is to be included in the authentication section of the resolved DID Document as follows:
- If the general usage value IS NOT present in the usage array, the key descriptor object will be included directly in the authentication section of the resolved DID Document.
- If the general usage value IS present in the usage array, the key descriptor object will be directly included in the publicKeys section of the resolved DID Document, and included by reference in the authentication section.

Closes #194

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>