### PR TITLE
feat: Return resolution result instead of document

### DIFF
--- a/pkg/dochandler/didvalidator/validator_test.go
+++ b/pkg/dochandler/didvalidator/validator_test.go
@@ -134,10 +134,10 @@ func TestTransformDocument(t *testing.T) {
 
 	v := getDefaultValidator()
 
-	transformed, err := v.TransformDocument(doc)
+	result, err := v.TransformDocument(doc)
 	require.NoError(t, err)
 
-	jsonTransformed, err := json.Marshal(transformed)
+	jsonTransformed, err := json.Marshal(result.Document)
 	require.NoError(t, err)
 
 	didDoc, err := document.DidDocumentFromBytes(jsonTransformed)

--- a/pkg/dochandler/docvalidator/validator.go
+++ b/pkg/dochandler/docvalidator/validator.go
@@ -77,6 +77,43 @@ func (v *Validator) IsValidOriginalDocument(payload []byte) error {
 }
 
 // TransformDocument takes internal representation of document and transforms it to required representation
-func (v *Validator) TransformDocument(document document.Document) (document.Document, error) {
-	return document, nil
+func (v *Validator) TransformDocument(internal document.Document) (*document.ResolutionResult, error) {
+	resolutionResult := &document.ResolutionResult{
+		Document:       internal,
+		MethodMetadata: document.MethodMetadata{},
+	}
+
+	processKeys(internal, resolutionResult)
+
+	return resolutionResult, nil
+}
+
+// generic documents will most likely only contain operation keys
+// operation keys are not part of external document but resolution result
+func processKeys(internal document.Document, resolutionResult *document.ResolutionResult) {
+	var operationPublicKeys []document.PublicKey
+
+	var nonOperationsKeys []document.PublicKey
+	for _, pk := range internal.PublicKeys() {
+		pk[document.ControllerProperty] = internal[document.IDProperty]
+		// add did to key id
+		pk[document.IDProperty] = internal.ID() + "#" + pk.ID()
+
+		usages := pk.Usage()
+		delete(pk, document.UsageProperty)
+
+		if document.IsOperationsKey(usages) {
+			operationPublicKeys = append(operationPublicKeys, pk)
+		} else {
+			nonOperationsKeys = append(nonOperationsKeys, pk)
+		}
+	}
+
+	if len(nonOperationsKeys) > 0 {
+		internal[document.PublicKeyProperty] = nonOperationsKeys
+	} else {
+		delete(internal, document.PublicKeyProperty)
+	}
+
+	resolutionResult.MethodMetadata.OperationPublicKeys = operationPublicKeys
 }

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -58,8 +58,12 @@ func (doc DIDDocument) Context() []string {
 
 // PublicKeys are used for digital signatures, encryption and other cryptographic operations
 func (doc DIDDocument) PublicKeys() []PublicKey {
-	entry, ok := doc[PublicKeyProperty]
-	if !ok {
+	return parsePublicKeys(doc[PublicKeyProperty])
+}
+
+// helper function for parsing public keys
+func parsePublicKeys(entry interface{}) []PublicKey {
+	if entry == nil {
 		return nil
 	}
 

--- a/pkg/document/diddocument_test.go
+++ b/pkg/document/diddocument_test.go
@@ -53,6 +53,7 @@ func TestValid(t *testing.T) {
 	require.NotNil(t, jsonld)
 
 	require.Empty(t, doc.Context())
+	require.Equal(t, "whatever", doc.Authentication()[0])
 }
 
 func TestEmptyDoc(t *testing.T) {
@@ -67,6 +68,9 @@ func TestEmptyDoc(t *testing.T) {
 
 	services := doc.Services()
 	require.Equal(t, 0, len(services))
+
+	authentication := doc.Authentication()
+	require.Equal(t, 0, len(authentication))
 }
 
 func TestInvalidLists(t *testing.T) {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -39,6 +39,11 @@ func (doc Document) ID() string {
 	return stringEntry(doc[IDProperty])
 }
 
+// PublicKeys in generic document are used for managing operation keys
+func (doc Document) PublicKeys() []PublicKey {
+	return parsePublicKeys(doc[PublicKeyProperty])
+}
+
 // GetStringValue returns string value for specified key or "" if not found or wrong type
 func (doc Document) GetStringValue(key string) string {
 	return stringEntry(doc[key])

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -25,6 +25,7 @@ func TestFromBytes(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, doc)
 	require.Equal(t, "", doc.ID())
+	require.Equal(t, 1, len(doc.PublicKeys()))
 
 	bytes, err := doc.Bytes()
 	require.Nil(t, err)

--- a/pkg/document/resolution.go
+++ b/pkg/document/resolution.go
@@ -6,16 +6,18 @@ SPDX-License-Identifier: Apache-2.0
 
 package document
 
+import "github.com/trustbloc/sidetree-core-go/pkg/jws"
+
 // ResolutionResult describes resolution result
 type ResolutionResult struct {
-	Context        string
-	DIDDocument    DIDDocument
-	MethodMetadata MethodMetadata
+	Context        string         `json:"@context"`
+	Document       Document       `json:"didDocument"`
+	MethodMetadata MethodMetadata `json:"methodMetadata"`
 }
 
 // MethodMetadata contains document metadata
 type MethodMetadata struct {
-	OperationPublicKeys []PublicKey
-	RecoveryKey         PublicKey
-	Published           bool
+	OperationPublicKeys []PublicKey `json:"operationPublicKeys,omitempty"`
+	RecoveryKey         *jws.JWK    `json:"recoveryKey,omitempty"`
+	Published           bool        `json:"published"`
 }

--- a/pkg/document/testdata/doc.json
+++ b/pkg/document/testdata/doc.json
@@ -26,5 +26,6 @@
         ]
       }
     }
-  ]
+  ],
+  "authentication": ["whatever"]
 }

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -21,6 +21,7 @@ const (
 
 	jwsVerificationKey2020            = "JwsVerificationKey2020"
 	ecdsaSecp256k1VerificationKey2019 = "EcdsaSecp256k1VerificationKey2019"
+	ed25519VerificationKey2018        = "Ed25519VerificationKey2018"
 )
 
 var allowedOps = map[string]string{
@@ -32,6 +33,8 @@ var allowedOps = map[string]string{
 var allowedKeyTypes = map[string]string{
 	jwsVerificationKey2020:            jwsVerificationKey2020,
 	ecdsaSecp256k1VerificationKey2019: ecdsaSecp256k1VerificationKey2019,
+	// TODO: Verify with Troy about spec restrictions
+	ed25519VerificationKey2018: ed25519VerificationKey2018,
 }
 
 // ValidatePublicKeys validates public keys

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -61,7 +61,7 @@ func (m *MockDocumentHandler) Protocol() protocol.Client {
 }
 
 // ProcessOperation mocks process operation
-func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (document.Document, error) {
+func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (*document.ResolutionResult, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -81,11 +81,13 @@ func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (docu
 
 	m.store[operation.ID] = doc
 
-	return doc, nil
+	return &document.ResolutionResult{
+		Document: doc,
+	}, nil
 }
 
 //ResolveDocument mocks resolve document
-func (m *MockDocumentHandler) ResolveDocument(idOrDocument string) (document.Document, error) {
+func (m *MockDocumentHandler) ResolveDocument(idOrDocument string) (*document.ResolutionResult, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -97,7 +99,9 @@ func (m *MockDocumentHandler) ResolveDocument(idOrDocument string) (document.Doc
 		return nil, errors.New("was deactivated")
 	}
 
-	return m.store[idOrDocument], nil
+	return &document.ResolutionResult{
+		Document: m.store[idOrDocument],
+	}, nil
 }
 
 // helper function to insert ID into document

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -48,7 +48,7 @@ func New(name string, store OperationStoreClient) *OperationProcessor {
 // Resolve document based on the given unique suffix
 // Parameters:
 // uniqueSuffix - unique portion of ID to resolve. for example "abc123" in "did:sidetree:abc123"
-func (s *OperationProcessor) Resolve(uniqueSuffix string) (document.Document, error) {
+func (s *OperationProcessor) Resolve(uniqueSuffix string) (*document.ResolutionResult, error) {
 	ops, err := s.store.Get(uniqueSuffix)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,12 @@ func (s *OperationProcessor) Resolve(uniqueSuffix string) (document.Document, er
 		return nil, err
 	}
 
-	return rm.Doc, nil
+	return &document.ResolutionResult{
+		Document: rm.Doc,
+		MethodMetadata: document.MethodMetadata{
+			RecoveryKey: rm.RecoveryKey,
+		},
+	}, nil
 }
 
 func splitOperations(ops []*batch.Operation) (fullOps, updateOps []*batch.Operation) {

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -115,11 +115,11 @@ func TestUpdateDocument(t *testing.T) {
 		require.Nil(t, err)
 
 		p := New("test", store) //Storing operation in the test store
-		doc, err := p.Resolve(uniqueSuffix)
+		result, err := p.Resolve(uniqueSuffix)
 		require.Nil(t, err)
 
 		//updated instance value inside service end point through a json patch
-		require.Equal(t, doc["publicKey"], []interface{}{map[string]interface{}{
+		require.Equal(t, result.Document["publicKey"], []interface{}{map[string]interface{}{
 			"controller":      "controller1",
 			"id":              "key-1",
 			"publicKeyBase58": "GY4GunSXBPBfhLCzDL7iGmP5dR3sBDCJZkkaGK8VgYQf",
@@ -195,11 +195,11 @@ func TestConsecutiveUpdates(t *testing.T) {
 	require.Nil(t, err)
 
 	p := New("test", store)
-	doc, err := p.Resolve(uniqueSuffix)
+	result, err := p.Resolve(uniqueSuffix)
 	require.Nil(t, err)
 
 	//patched twice instance replaced from did:bar:456 to did:sidetree:updateid0  and then to did:sidetree:updateid1
-	require.Equal(t, doc["publicKey"], []interface{}{map[string]interface{}{
+	require.Equal(t, result.Document["publicKey"], []interface{}{map[string]interface{}{
 		"controller":      "controller2",
 		"id":              "key-1",
 		"publicKeyBase58": "GY4GunSXBPBfhLCzDL7iGmP5dR3sBDCJZkkaGK8VgYQf",
@@ -486,11 +486,11 @@ func TestRecover(t *testing.T) {
 	require.Nil(t, err)
 
 	p := New("test", store)
-	doc, err := p.Resolve(uniqueSuffix)
+	result, err := p.Resolve(uniqueSuffix)
 	require.NoError(t, err)
 
 	// test for recovered key
-	docBytes, err := doc.Bytes()
+	docBytes, err := result.Document.Bytes()
 	require.NoError(t, err)
 	require.Contains(t, string(docBytes), "recovered")
 }

--- a/pkg/restapi/diddochandler/restapi_test.go
+++ b/pkg/restapi/diddochandler/restapi_test.go
@@ -54,9 +54,9 @@ func TestRESTAPI(t *testing.T) {
 		didID, err := getID(createRequest.SuffixData)
 		require.NoError(t, err)
 
-		var doc document.Document
-		require.NoError(t, json.Unmarshal(resp, &doc))
-		require.Equal(t, didID, doc["id"])
+		var result document.ResolutionResult
+		require.NoError(t, json.Unmarshal(resp, &result))
+		require.Equal(t, didID, result.Document["id"])
 	})
 	t.Run("Resolve DID doc", func(t *testing.T) {
 		createRequest, err := getCreateRequest()
@@ -69,9 +69,11 @@ func TestRESTAPI(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 
-		var doc document.Document
-		require.NoError(t, json.Unmarshal(resp, &doc))
-		require.Equal(t, didID, doc["id"])
+		var result document.ResolutionResult
+		err = json.Unmarshal(resp, &result)
+		require.NoError(t, err)
+
+		require.Equal(t, didID, result.Document["id"])
 	})
 }
 

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -53,8 +53,10 @@ func TestUpdateHandler_Update(t *testing.T) {
 		body, err := ioutil.ReadAll(rw.Body)
 		require.NoError(t, err)
 
-		doc, err := document.DidDocumentFromBytes(body)
-		require.Contains(t, doc.ID(), id)
+		var result document.ResolutionResult
+		err = json.Unmarshal(body, &result)
+
+		require.Contains(t, result.Document.ID(), id)
 	})
 }
 

--- a/pkg/restapi/dochandler/resolvehandler.go
+++ b/pkg/restapi/dochandler/resolvehandler.go
@@ -23,7 +23,7 @@ var logger = logrus.New()
 // Resolver resolves documents
 type Resolver interface {
 	Namespace() string
-	ResolveDocument(idOrDocument string) (document.Document, error)
+	ResolveDocument(idOrDocument string) (*document.ResolutionResult, error)
 }
 
 // ResolveHandler resolves generic documents
@@ -47,11 +47,11 @@ func (o *ResolveHandler) Resolve(rw http.ResponseWriter, req *http.Request) {
 		common.WriteError(rw, err.(*common.HTTPError).Status(), err)
 		return
 	}
-	logger.Debugf("... resolved DID document for ID [%s]: %s", id, response)
+	logger.Debugf("... resolved DID document for ID [%s]: %s", id, response.Document)
 	common.WriteResponse(rw, http.StatusOK, response)
 }
 
-func (o *ResolveHandler) doResolve(id string) (document.Document, error) {
+func (o *ResolveHandler) doResolve(id string) (*document.ResolutionResult, error) {
 	if !strings.HasPrefix(id, o.resolver.Namespace()) {
 		logger.Errorf("DID ID [%s] does not start with supported namespace [%s]", id, o.resolver.Namespace())
 		return nil, common.NewHTTPError(http.StatusBadRequest, errors.New("must start with supported namespace"))

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -40,7 +40,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		patchData, err := getPatchData()
 		require.NoError(t, err)
 
-		doc, err := docHandler.ProcessOperation(&batch.Operation{
+		result, err := docHandler.ProcessOperation(&batch.Operation{
 			Type:             batch.OperationTypeCreate,
 			ID:               id,
 			PatchData:        patchData,
@@ -48,7 +48,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		getID = func(req *http.Request) string { return doc.ID() }
+		getID = func(req *http.Request) string { return result.Document.ID() }
 		handler := NewResolveHandler(docHandler)
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/document", nil)
@@ -101,7 +101,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		patchData, err := getPatchData()
 		require.NoError(t, err)
 
-		doc, err := docHandler.ProcessOperation(&batch.Operation{
+		result, err := docHandler.ProcessOperation(&batch.Operation{
 			Type:             batch.OperationTypeCreate,
 			ID:               id,
 			PatchData:        patchData,
@@ -111,11 +111,11 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		_, err = docHandler.ProcessOperation(&batch.Operation{
 			Type: batch.OperationTypeDeactivate,
-			ID:   doc.ID(),
+			ID:   result.Document.ID(),
 		})
 		require.NoError(t, err)
 
-		getID = func(req *http.Request) string { return doc.ID() }
+		getID = func(req *http.Request) string { return result.Document.ID() }
 		handler := NewResolveHandler(docHandler)
 
 		rw := httptest.NewRecorder()

--- a/pkg/restapi/dochandler/updatehandler.go
+++ b/pkg/restapi/dochandler/updatehandler.go
@@ -25,7 +25,7 @@ import (
 type Processor interface {
 	Namespace() string
 	Protocol() protocol.Client
-	ProcessOperation(operation *batch.Operation) (document.Document, error)
+	ProcessOperation(operation *batch.Operation) (*document.ResolutionResult, error)
 }
 
 // UpdateHandler handles the creation and update of documents
@@ -56,7 +56,7 @@ func (h *UpdateHandler) Update(rw http.ResponseWriter, req *http.Request) {
 	common.WriteResponse(rw, http.StatusOK, response)
 }
 
-func (h *UpdateHandler) doUpdate(request []byte) (document.Document, error) {
+func (h *UpdateHandler) doUpdate(request []byte) (*document.ResolutionResult, error) {
 	operation, err := h.getOperation(request)
 	if err != nil {
 		logger.Errorf("Error: %s", err)
@@ -64,13 +64,13 @@ func (h *UpdateHandler) doUpdate(request []byte) (document.Document, error) {
 	}
 
 	// operation has been validated, now process it
-	doc, err := h.processor.ProcessOperation(operation)
+	result, err := h.processor.ProcessOperation(operation)
 	if err != nil {
 		logger.Errorf("Error: %s", err)
 		return nil, common.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	return doc, nil
+	return result, nil
 }
 
 func (h *UpdateHandler) getOperation(operationBuffer []byte) (*batch.Operation, error) {

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -68,7 +68,11 @@ func TestUpdateHandler_Update(t *testing.T) {
 		body, err := ioutil.ReadAll(rw.Body)
 		require.NoError(t, err)
 
-		doc, err := document.DidDocumentFromBytes(body)
+		var result document.ResolutionResult
+		err = json.Unmarshal(body, &result)
+		require.NoError(t, err)
+
+		doc := result.Document
 		require.Equal(t, id, doc.ID())
 		require.Equal(t, len(doc.PublicKeys()), 1)
 	})


### PR DESCRIPTION
Resolution result contains:
-context
-document
-method metadata

Method metadata contains:
-operation public keys
-recovery key
-published flag

Closes #207

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>