### PR TITLE
feat: Support assertion key usage

### DIFF
--- a/pkg/dochandler/didvalidator/testdata/doc.json
+++ b/pkg/dochandler/didvalidator/testdata/doc.json
@@ -3,7 +3,7 @@
     {
       "id": "master",
       "type": "EcdsaSecp256k1VerificationKey2019",
-      "usage": ["ops", "general", "auth"],
+      "usage": ["ops", "general", "auth", "assertion"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -37,6 +37,28 @@
       "id": "auth-only",
       "type": "JwsVerificationKey2020",
       "usage": ["auth"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-assertion-general",
+      "type": "JwsVerificationKey2020",
+      "usage": ["assertion", "general"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "assertion-only",
+      "type": "JwsVerificationKey2020",
+      "usage": ["assertion"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/dochandler/didvalidator/validator_test.go
+++ b/pkg/dochandler/didvalidator/validator_test.go
@@ -147,11 +147,14 @@ func TestTransformDocument(t *testing.T) {
 	require.Contains(t, didDoc.Services()[0].ID(), testID)
 	require.Equal(t, didContext, didDoc.Context()[0])
 
-	expectedPublicKeys := []string{"master", "general-only", "dual-auth-general"}
+	expectedPublicKeys := []string{"master", "general-only", "dual-auth-general", "dual-assertion-general"}
 	require.Equal(t, len(expectedPublicKeys), len(didDoc.PublicKeys()))
 
 	expectedAuthenticationKeys := []string{"master", "dual-auth-general", "auth-only"}
 	require.Equal(t, len(expectedAuthenticationKeys), len(didDoc.Authentication()))
+
+	expectedAssertionMethodKeys := []string{"master", "dual-assertion-general", "assertion-only"}
+	require.Equal(t, len(expectedAssertionMethodKeys), len(didDoc.AssertionMethod()))
 }
 
 func getDefaultValidator() *Validator {

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -26,6 +26,9 @@ const (
 	// AuthenticationProperty defines key for authentication property
 	AuthenticationProperty = "authentication"
 
+	// AssertionMethodProperty defines key for assertion method property
+	AssertionMethodProperty = "assertionMethod"
+
 	// ControllerProperty defines key for controller
 	ControllerProperty = "controller"
 
@@ -111,9 +114,14 @@ func (doc DIDDocument) JSONLdObject() map[string]interface{} {
 	return doc
 }
 
-// Authentication return authentication array (mixture of strings and objects)
+// Authentication returns authentication array (mixture of strings and objects)
 func (doc DIDDocument) Authentication() []interface{} {
 	return interfaceArray(doc[AuthenticationProperty])
+}
+
+// AssertionMethod returns assertion method array (mixture of strings and objects)
+func (doc DIDDocument) AssertionMethod() []interface{} {
+	return interfaceArray(doc[AssertionMethodProperty])
 }
 
 // DIDDocumentFromReader creates an instance of DIDDocument by reading a JSON document from Reader

--- a/pkg/document/diddocument_test.go
+++ b/pkg/document/diddocument_test.go
@@ -71,6 +71,9 @@ func TestEmptyDoc(t *testing.T) {
 
 	authentication := doc.Authentication()
 	require.Equal(t, 0, len(authentication))
+
+	assertionMethod := doc.AssertionMethod()
+	require.Equal(t, 0, len(assertionMethod))
 }
 
 func TestInvalidLists(t *testing.T) {

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -16,6 +16,8 @@ const (
 	ops = "ops"
 	// auth defines key usage as authentication key
 	auth = "auth"
+	// assertion defines key usage as assertion key
+	assertion = "assertion"
 	// general defines key usage as general key
 	general = "general"
 
@@ -25,9 +27,10 @@ const (
 )
 
 var allowedOps = map[string]string{
-	ops:     ops,
-	auth:    auth,
-	general: general,
+	ops:       ops,
+	auth:      auth,
+	general:   general,
+	assertion: assertion,
 }
 
 var allowedKeyTypes = map[string]string{
@@ -105,6 +108,11 @@ func IsGeneralKey(usages []string) bool {
 // IsAuthenticationKey returns true if key is an authentication key
 func IsAuthenticationKey(usages []string) bool {
 	return isUsageKey(usages, auth)
+}
+
+// IsAssertionKey returns true if key is an assertion key
+func IsAssertionKey(usages []string) bool {
+	return isUsageKey(usages, assertion)
 }
 
 func isUsageKey(usages []string, mode string) bool {

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -120,6 +120,16 @@ func TestIsAuthenticationKey(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestIsAssertionKey(t *testing.T) {
+	pk := NewPublicKey(map[string]interface{}{})
+	ok := IsAssertionKey(pk.Usage())
+	require.False(t, ok)
+
+	pk["usage"] = []interface{}{assertion}
+	ok = IsAssertionKey(pk.Usage())
+	require.True(t, ok)
+}
+
 func TestIsGeneralKey(t *testing.T) {
 	pk := NewPublicKey(map[string]interface{}{})
 	ok := IsGeneralKey(pk.Usage())
@@ -166,7 +176,7 @@ const tooMuchUsage = `{
     {
       "id": "key1",
       "type": "JwsVerificationKey2020",
-      "usage": ["ops", "general", "auth", "other"],
+      "usage": ["ops", "general", "auth", "assertion", "other"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",


### PR DESCRIPTION
assertion: the key MUST be included in the assertionMethod section of the resolved DID Document, as follows:
If the general usage value IS NOT present in the usage array, the key descriptor object MUST be included directly in the assertionMethod section of the resolved DID Document.
If the general usage value IS present in the usage array, the key descriptor object MUST be directly included in the public keys section of the resolved DID Document, and MUST be included by relative DID URL reference in the assertionMethod section

Closes #215

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>