### PR TITLE
fix: Use base64 encoding without padding

### DIFF
--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -151,7 +151,7 @@ func TestDocumentHandler_ResolveDocument_InitialValue(t *testing.T) {
 	result, err = dochandler.ResolveDocument(docID + initialValuesParam + "payload")
 	require.NotNil(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "illegal base64 data")
+	require.Contains(t, err.Error(), "invalid character")
 
 	// invalid create request - not json
 	result, err = dochandler.ResolveDocument(docID + initialValuesParam + docutil.EncodeToString([]byte("payload")))

--- a/pkg/docutil/doc_test.go
+++ b/pkg/docutil/doc_test.go
@@ -15,20 +15,21 @@ import (
 const (
 	multihashCode uint = 18
 	didMethodName      = "did:sidetree"
-	expectedID         = "did:sidetree:EiDXwKCWKRztaaxdeYXOwnEZU3isKvFBSjpHFSAfHrYHPA=="
-	// encoded payload contains encoded document that corresponds to unique suffix above
-	encodedPayload = "ewogICJAY29udGV4dCI6ICJodHRwczovL3czaWQub3JnL2RpZC92MSIsCiAgInB1YmxpY0tleSI6IFt7CiAgICAiaWQiOiAiI2tleTEiLAogICAgInR5cGUiOiAiU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOCIsCiAgICAicHVibGljS2V5SGV4IjogIjAyZjQ5ODAyZmIzZTA5YzZkZDQzZjE5YWE0MTI5M2QxZTBkYWQwNDRiNjhjZjgxY2Y3MDc5NDk5ZWRmZDBhYTlmMSIKICB9XSwKICAic2VydmljZSI6IFt7CiAgICAiaWQiOiAiSWRlbnRpdHlIdWIiLAogICAgInR5cGUiOiAiSWRlbnRpdHlIdWIiLAogICAgInNlcnZpY2VFbmRwb2ludCI6IHsKICAgICAgIkBjb250ZXh0IjogInNjaGVtYS5pZGVudGl0eS5mb3VuZGF0aW9uL2h1YiIsCiAgICAgICJAdHlwZSI6ICJVc2VyU2VydmljZUVuZHBvaW50IiwKICAgICAgImluc3RhbmNlIjogWyJkaWQ6YmFyOjQ1NiIsICJkaWQ6emF6Ojc4OSJdCiAgICB9CiAgfV0KfQo="
 )
 
 func TestCalculateDID(t *testing.T) {
-	id, err := CalculateID(didMethodName, encodedPayload, multihashCode)
+	payload := []byte("{}")
+
+	id, err := CalculateID(didMethodName, EncodeToString(payload), multihashCode)
 	require.Nil(t, err)
-	require.Equal(t, expectedID, id)
+	require.NotEmpty(t, id)
 }
 
 func TestDidCalculationError(t *testing.T) {
+	payload := []byte("{}")
+
 	// non-supported mulithash code will cause an error
-	id, err := CalculateID(didMethodName, encodedPayload, 5)
+	id, err := CalculateID(didMethodName, EncodeToString(payload), 55)
 	require.NotNil(t, err)
 	require.Empty(t, id)
 	require.Contains(t, err.Error(), "algorithm not supported, unable to compute hash")

--- a/pkg/docutil/encoder.go
+++ b/pkg/docutil/encoder.go
@@ -10,10 +10,10 @@ import "encoding/base64"
 
 //EncodeToString encodes the bytes to string
 func EncodeToString(data []byte) string {
-	return base64.URLEncoding.EncodeToString(data)
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(data)
 }
 
 //DecodeString decodes the encoded content to Bytes
 func DecodeString(encodedContent string) ([]byte, error) {
-	return base64.URLEncoding.DecodeString(encodedContent)
+	return base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(encodedContent)
 }

--- a/pkg/docutil/hash_test.go
+++ b/pkg/docutil/hash_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package docutil
 
 import (
-	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,7 +42,7 @@ func TestIsSupportedMultihash(t *testing.T) {
 	require.False(t, supported)
 
 	// scenario: base64 encoded, however not multihash
-	supported = IsSupportedMultihash(base64.URLEncoding.EncodeToString(sample))
+	supported = IsSupportedMultihash(EncodeToString(sample))
 	require.False(t, supported)
 
 	// scenario: valid encoded multihash
@@ -51,7 +50,7 @@ func TestIsSupportedMultihash(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, hash)
 
-	key := base64.URLEncoding.EncodeToString(hash)
+	key := EncodeToString(hash)
 	supported = IsSupportedMultihash(key)
 	require.True(t, supported)
 }
@@ -61,7 +60,7 @@ func TestIsComputedUsingHashAlgorithm(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, hash)
 
-	key := base64.URLEncoding.EncodeToString(hash)
+	key := EncodeToString(hash)
 	ok := IsComputedUsingHashAlgorithm(key, sha2_256)
 	require.True(t, ok)
 

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -51,7 +51,7 @@ func TestParseCreateOperation(t *testing.T) {
 
 		op, err := ParseCreateOperation(request, p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "invalid character")
 		require.Nil(t, op)
 	})
 	t.Run("parse patch data error", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestParseCreateOperation(t *testing.T) {
 
 		op, err := ParseCreateOperation(request, p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "invalid character")
 		require.Nil(t, op)
 	})
 }

--- a/pkg/operation/deactivate_test.go
+++ b/pkg/operation/deactivate_test.go
@@ -58,7 +58,7 @@ func TestParseDeactivateOperation(t *testing.T) {
 
 		op, err := ParseDeactivateOperation(request, p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "invalid character")
 		require.Nil(t, op)
 	})
 	t.Run("parse signed data error - invalid JSON", func(t *testing.T) {

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -49,7 +49,7 @@ func TestParseRecoverOperation(t *testing.T) {
 
 		op, err := ParseRecoverOperation(request, p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "invalid character")
 		require.Nil(t, op)
 	})
 	t.Run("validate patch data error", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestParseRecoverOperation(t *testing.T) {
 
 		op, err := ParseRecoverOperation(request, p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "invalid character")
 		require.Nil(t, op)
 	})
 	t.Run("validate signed data error", func(t *testing.T) {

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -87,7 +87,7 @@ func TestParseUpdatePatchData(t *testing.T) {
 		parsed, err := parseUpdatePatchData("invalid", sha2_256)
 		require.Error(t, err)
 		require.Nil(t, parsed)
-		require.Contains(t, err.Error(), "illegal base64 data")
+		require.Contains(t, err.Error(), "invalid character")
 	})
 }
 

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -441,7 +440,7 @@ func TestDeactivate_InvalidRecoveryRevealValue(t *testing.T) {
 
 	deactivateOp, err := getDeactivateOperation(privateKey, uniqueSuffix, 1)
 	require.NoError(t, err)
-	deactivateOp.RecoveryRevealValue = base64.URLEncoding.EncodeToString([]byte("invalid"))
+	deactivateOp.RecoveryRevealValue = docutil.EncodeToString([]byte("invalid"))
 	err = store.Put(deactivateOp)
 	require.NoError(t, err)
 
@@ -572,7 +571,7 @@ func TestRecover_InvalidRecoveryRevealValue(t *testing.T) {
 
 	op, err := getRecoverOperation(privateKey, uniqueSuffix, 1)
 	require.NoError(t, err)
-	op.RecoveryRevealValue = base64.URLEncoding.EncodeToString([]byte("invalid"))
+	op.RecoveryRevealValue = docutil.EncodeToString([]byte("invalid"))
 	err = store.Put(op)
 	require.NoError(t, err)
 
@@ -623,7 +622,7 @@ func getUpdateOperationWithSigner(s helper.Signer, uniqueSuffix string, operatio
 		return nil, err
 	}
 
-	updateRevealValue := base64.URLEncoding.EncodeToString([]byte(updateReveal + strconv.Itoa(int(operationNumber))))
+	updateRevealValue := docutil.EncodeToString([]byte(updateReveal + strconv.Itoa(int(operationNumber))))
 
 	nextUpdateCommitmentHash := getEncodedMultihash([]byte(updateReveal + strconv.Itoa(int(operationNumber+1))))
 
@@ -682,7 +681,7 @@ func getDeactivateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string, o
 		Type:                batch.OperationTypeDeactivate,
 		TransactionTime:     0,
 		TransactionNumber:   uint64(operationNumber),
-		RecoveryRevealValue: base64.URLEncoding.EncodeToString([]byte(recoveryReveal)),
+		RecoveryRevealValue: docutil.EncodeToString([]byte(recoveryReveal)),
 		SignedData:          jws,
 	}, nil
 }
@@ -714,7 +713,7 @@ func getRecoverOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string, oper
 		PatchData:                  patchData,
 		EncodedPatchData:           recoverRequest.PatchData,
 		SignedData:                 recoverRequest.SignedData,
-		RecoveryRevealValue:        base64.URLEncoding.EncodeToString([]byte(recoveryReveal)),
+		RecoveryRevealValue:        docutil.EncodeToString([]byte(recoveryReveal)),
 		NextUpdateCommitmentHash:   nextUpdateCommitmentHash,
 		NextRecoveryCommitmentHash: nextRecoveryCommitmentHash,
 		TransactionTime:            0,


### PR DESCRIPTION
Currently our DID contains invalid characters (such as '=' at the end) because we are using base64 encoding with padding. Use base64 URL encoding without padding for generating unique suffix and hashes.

Closes #218

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>