### PR TITLE
feat: convert Ed25519VerificationKey2018 key to base58 during transfo…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ module github.com/trustbloc/sidetree-core-go
 
 require (
 	github.com/btcsuite/btcd v0.20.1-beta
+	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/gorilla/mux v1.7.3
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
+github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -31,24 +31,6 @@ const (
 
 	// AgreementKeyProperty defines key for agreement key property
 	AgreementKeyProperty = "agreementKey"
-
-	// ControllerProperty defines key for controller
-	ControllerProperty = "controller"
-
-	// UsageProperty describes key usage property
-	UsageProperty = "usage"
-
-	// PublicKeyJwkProperty describes external public key JWK
-	PublicKeyJwkProperty = "publicKeyJwk"
-
-	// JwkProperty describes internal public key JWK
-	JwkProperty = "jwk"
-
-	// TypeProperty describes type
-	TypeProperty = "type"
-
-	// ServiceEndpointProperty defines service endpoint
-	ServiceEndpointProperty = "serviceEndpoint"
 )
 
 // DIDDocument Defines DID Document data structure used by Sidetree for basic type safety checks.

--- a/pkg/document/publickey.go
+++ b/pkg/document/publickey.go
@@ -6,6 +6,27 @@ SPDX-License-Identifier: Apache-2.0
 
 package document
 
+const (
+
+	// ControllerProperty defines key for controller
+	ControllerProperty = "controller"
+
+	// UsageProperty describes key usage property
+	UsageProperty = "usage"
+
+	// PublicKeyJwkProperty describes external public key JWK
+	PublicKeyJwkProperty = "publicKeyJwk"
+
+	// JwkProperty describes internal public key JWK
+	JwkProperty = "jwk"
+
+	// TypeProperty describes type
+	TypeProperty = "type"
+
+	// PublicKeyBase58Property defines base 58 encoding for public key
+	PublicKeyBase58Property = "publicKeyBase58"
+)
+
 // PublicKey must include id and type properties, and exactly one value property
 type PublicKey map[string]interface{}
 
@@ -55,6 +76,11 @@ func (pk PublicKey) PublicKeyJwk() JWK {
 		return nil
 	}
 	return NewJWK(json)
+}
+
+// PublicKeyBase58 is base58 encoded public key
+func (pk PublicKey) PublicKeyBase58() string {
+	return stringEntry(pk[PublicKeyBase58Property])
 }
 
 // Usage describes key usage

--- a/pkg/document/publickey_test.go
+++ b/pkg/document/publickey_test.go
@@ -29,6 +29,7 @@ func TestPublicKey(t *testing.T) {
 	require.Empty(t, pk.Usage())
 	require.Empty(t, pk.JWK())
 	require.Empty(t, pk.PublicKeyJwk())
+	require.Empty(t, pk.PublicKeyBase58())
 
 	require.NotEmpty(t, pk.JSONLdObject())
 }

--- a/pkg/document/service.go
+++ b/pkg/document/service.go
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 package document
 
+// ServiceEndpointProperty defines service endpoint
+const ServiceEndpointProperty = "serviceEndpoint"
+
 // Service represents any type of service the entity wishes to advertise
 type Service map[string]interface{}
 

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -25,8 +25,10 @@ const (
 
 	jwsVerificationKey2020            = "JwsVerificationKey2020"
 	ecdsaSecp256k1VerificationKey2019 = "EcdsaSecp256k1VerificationKey2019"
-	ed25519VerificationKey2018        = "Ed25519VerificationKey2018"
 	x25519KeyAgreementKey2019         = "X25519KeyAgreementKey2019"
+
+	// Ed25519VerificationKey2018 requires special handling (convert to base58)
+	Ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
 
 	maxJwkProperties       = 4
 	maxPublicKeyProperties = 4
@@ -44,7 +46,7 @@ var allowedKeyTypes = map[string]string{
 	jwsVerificationKey2020:            jwsVerificationKey2020,
 	ecdsaSecp256k1VerificationKey2019: ecdsaSecp256k1VerificationKey2019,
 	// TODO: Verify with Troy about spec restrictions
-	ed25519VerificationKey2018: ed25519VerificationKey2018,
+	Ed25519VerificationKey2018: Ed25519VerificationKey2018,
 	x25519KeyAgreementKey2019:  x25519KeyAgreementKey2019,
 }
 

--- a/pkg/internal/jws/signature.go
+++ b/pkg/internal/jws/signature.go
@@ -41,25 +41,9 @@ func VerifySignature(jwk *jws.JWK, signature, msg []byte) error {
 }
 
 func verifyEd25519Signature(jwk *jws.JWK, signature, msg []byte) error {
-	jsonBytes, err := json.Marshal(jwk)
+	pubKey, err := GetED25519PublicKey(jwk)
 	if err != nil {
 		return err
-	}
-
-	var internalJWK JWK
-	err = internalJWK.UnmarshalJSON(jsonBytes)
-	if err != nil {
-		return err
-	}
-
-	pubKey, ok := internalJWK.Key.(ed25519.PublicKey)
-	if !ok {
-		return errors.New("unexpected public key type for ed25519")
-	}
-
-	// ed25519 panics if key size is wrong
-	if len(pubKey) != ed25519.PublicKeySize {
-		return errors.New("ed25519: invalid key")
 	}
 
 	verified := ed25519.Verify(pubKey, msg, signature)
@@ -68,6 +52,32 @@ func verifyEd25519Signature(jwk *jws.JWK, signature, msg []byte) error {
 	}
 
 	return nil
+}
+
+// GetED25519PublicKey retunns ed25519 public key
+func GetED25519PublicKey(jwk *jws.JWK) (ed25519.PublicKey, error) {
+	jsonBytes, err := json.Marshal(jwk)
+	if err != nil {
+		return nil, err
+	}
+
+	var internalJWK JWK
+	err = internalJWK.UnmarshalJSON(jsonBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey, ok := internalJWK.Key.(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("unexpected public key type for ed25519")
+	}
+
+	// ed25519 panics if key size is wrong
+	if len(pubKey) != ed25519.PublicKeySize {
+		return nil, errors.New("ed25519: invalid key")
+	}
+
+	return pubKey, nil
 }
 
 func verifyECSignature(jwk *jws.JWK, signature, msg []byte) error {


### PR DESCRIPTION
…rm to external document

As sidetree protocol always inputs jwk AND Ed25519Signature2018 only supports publicKeyBase58, we need to transform the jwk to publicKeyBase58 when composing the DID document.

Closes #223

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>