### PR TITLE
feat: Match latest unique suffix algorithm

### DIFF
--- a/pkg/docutil/doc.go
+++ b/pkg/docutil/doc.go
@@ -22,12 +22,7 @@ func CalculateID(namespace, encoded string, hashAlgorithmAsMultihashCode uint) (
 
 //CalculateUniqueSuffix calculates the unique suffix from an encoded value
 func CalculateUniqueSuffix(encoded string, hashAlgorithmAsMultihashCode uint) (string, error) {
-	value, err := DecodeString(encoded)
-	if err != nil {
-		return "", nil
-	}
-
-	multiHashBytes, err := ComputeMultihash(hashAlgorithmAsMultihashCode, value)
+	multiHashBytes, err := ComputeMultihash(hashAlgorithmAsMultihashCode, []byte(encoded))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/docutil/doc_test.go
+++ b/pkg/docutil/doc_test.go
@@ -13,16 +13,25 @@ import (
 )
 
 const (
-	multihashCode uint = 18
-	didMethodName      = "did:sidetree"
+	multihashCode  uint = 18
+	didMethodName       = "did:sidetree"
+	expectedSuffix      = "EiAd7Z1iVTK7P_I9QQyy-muHI2UGSvxjAIzqxW7odZX2-g"
 )
 
 func TestCalculateDID(t *testing.T) {
-	payload := []byte("{}")
+	payload := []byte(suffixDataString)
 
-	id, err := CalculateID(didMethodName, EncodeToString(payload), multihashCode)
+	did, err := CalculateID(didMethodName, EncodeToString(payload), multihashCode)
 	require.Nil(t, err)
-	require.NotEmpty(t, id)
+	require.Equal(t, did, didMethodName+NamespaceDelimiter+expectedSuffix)
+}
+
+func TestCalculateUniqueSuffix(t *testing.T) {
+	payload := []byte(suffixDataString)
+
+	suffix, err := CalculateUniqueSuffix(EncodeToString(payload), multihashCode)
+	require.Nil(t, err)
+	require.Equal(t, expectedSuffix, suffix)
 }
 
 func TestDidCalculationError(t *testing.T) {
@@ -34,3 +43,5 @@ func TestDidCalculationError(t *testing.T) {
 	require.Empty(t, id)
 	require.Contains(t, err.Error(), "algorithm not supported, unable to compute hash")
 }
+
+const suffixDataString = `{"delta_hash":"EiD0ERt_0QnYAoHw0KqhwYyMbMjT_vlvW3C8BuilAWT1Kw","recovery_key":{"kty":"EC","crv":"secp256k1","x":"FDmlOfldNAm9ThIQTj2-UkaCajsfrJOU0wJ7kl3QJHg","y":"bAGx86GZ41PUbzk_bvOKlrW0rXdmnXQrSop7HQoC12Y"},"recovery_commitment":"EiDrKHSo11DLU1uel6fFxH0B-0BLlyu_OinGPmLNvHyVoA"}`


### PR DESCRIPTION
Currenlty we are doing decode before calculating multihash. Remove decode to match latest spec:
did = Base64URL(Multihash(DATA, 'sha2-256')));

There is no need for canonicalization before calculating did suffix because it is the client that sets suffix_data property of create request.

Closes #238

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>