### PR TITLE
refactor: Update resolution with initial state as per spec

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -14,8 +14,8 @@ type Protocol struct {
 	HashAlgorithmInMultiHashCode uint
 	// MaxOperationsPerBatch defines maximum operations per batch
 	MaxOperationsPerBatch uint
-	// MaxOperationByteSize is maximum size of an operation in bytes
-	MaxOperationByteSize uint
+	// MaxDeltaByteSize is maximum size of the `delta` property in bytes
+	MaxDeltaByteSize uint
 }
 
 // Client defines interface for accessing protocol version/information

--- a/pkg/internal/request/method.go
+++ b/pkg/internal/request/method.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package request
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+)
+
+const methodParamTemplate = "-%s-initial-state"
+
+// GetInitialStateParam returns initial state parameter for namespace (more specifically method)
+func GetInitialStateParam(namespace string) string {
+	method := getMethod(namespace)
+	return fmt.Sprintf(methodParamTemplate, method)
+}
+
+// getMethod returns method from namespace
+func getMethod(namespace string) string {
+	pos := strings.Index(namespace, ":")
+	if pos == -1 || pos+1 == len(namespace) {
+		return ""
+	}
+
+	return namespace[pos+1:]
+}
+
+// GetParts inspects params string and returns did and optional initial state value
+func GetParts(namespace, params string) (string, *model.CreateRequest, error) {
+	initialParam := GetInitialStateParam(namespace)
+	initialMatch := "?" + initialParam + "="
+
+	pos := strings.Index(params, initialMatch)
+	if pos == -1 {
+		// there is no initial-values so params contains only did
+		return params, nil, nil
+	}
+
+	adjustedPos := pos + len(initialMatch)
+	if adjustedPos >= len(params) {
+		return "", nil, errors.New("initial values is present but empty")
+	}
+
+	did := params[0:pos]
+
+	initialStateParts := strings.Split(params[adjustedPos:], ".")
+
+	const twoParts = 2
+	if len(initialStateParts) != twoParts {
+		return "", nil, errors.New("initial state should have two parts: delta and suffix data")
+	}
+
+	initial := &model.CreateRequest{
+		Operation:  model.OperationTypeCreate,
+		Delta:      initialStateParts[0],
+		SuffixData: initialStateParts[1],
+	}
+
+	// return did and initial state
+	return did, initial, nil
+}

--- a/pkg/internal/request/method_test.go
+++ b/pkg/internal/request/method_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+)
+
+const (
+	namespace         = "doc:method"
+	initialStateParam = "?-method-initial-state="
+)
+
+func TestGetMethodInitialParam(t *testing.T) {
+	initialParam := GetInitialStateParam("did:method")
+	require.Equal(t, "-method-initial-state", initialParam)
+
+	// should never happens since namespace is configured
+	initialParam = GetInitialStateParam("did")
+	require.Equal(t, "--initial-state", initialParam)
+
+	// should never happens since namespace is configured
+	initialParam = GetInitialStateParam("did:")
+	require.Equal(t, "--initial-state", initialParam)
+}
+
+func TestGetParts(t *testing.T) {
+	const testDID = "did:method:abc"
+
+	did, initial, err := GetParts(namespace, testDID)
+	require.NoError(t, err)
+	require.Equal(t, testDID, did)
+	require.Empty(t, initial)
+
+	did, initial, err = GetParts(namespace, testDID+initialStateParam)
+	require.Error(t, err)
+	require.Empty(t, did)
+	require.Nil(t, initial)
+	require.Contains(t, err.Error(), "initial values is present but empty")
+
+	did, initial, err = GetParts(namespace, testDID+initialStateParam+"xyz")
+	require.Error(t, err)
+	require.Empty(t, did)
+	require.Nil(t, initial)
+	require.Contains(t, err.Error(), "initial state should have two parts: delta and suffix data")
+
+	did, initial, err = GetParts(namespace, testDID+initialStateParam+"xyz.123")
+	require.NoError(t, err)
+	require.Equal(t, testDID, did)
+	require.Equal(t, initial.Delta, "xyz")
+	require.Equal(t, initial.SuffixData, "123")
+	require.Equal(t, initial.Operation, model.OperationTypeCreate)
+}

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -23,7 +23,7 @@ func NewMockProtocolClient() *MockProtocolClient {
 			StartingBlockChainTime:       0,
 			HashAlgorithmInMultiHashCode: sha2_256,
 			MaxOperationsPerBatch:        2,
-			MaxOperationByteSize:         2000,
+			MaxDeltaByteSize:             2000,
 		},
 	}
 }


### PR DESCRIPTION
Currently we are using create request in resolution with initial value.

Change existing solution to latest spec:
`did:METHOD:<did-suffix>?-METHOD-initial-state=<create-delta-object>.<create-suffix-data-object>`

Closes #240

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>