### PR TITLE
chore: Renamed update REST endpoint to /operations

### DIFF
--- a/pkg/restapi/diddochandler/restapi_test.go
+++ b/pkg/restapi/diddochandler/restapi_test.go
@@ -47,7 +47,7 @@ func TestRESTAPI(t *testing.T) {
 		request, err := json.Marshal(createRequest)
 		require.NoError(t, err)
 
-		resp, err := httpPut(t, clientURL+basePath, request)
+		resp, err := httpPut(t, clientURL+basePath+"/operations", request)
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 

--- a/pkg/restapi/diddochandler/updatehandler.go
+++ b/pkg/restapi/diddochandler/updatehandler.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package diddochandler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
@@ -16,20 +17,20 @@ import (
 // UpdateHandler handles the creation and update of DID documents
 type UpdateHandler struct {
 	*dochandler.UpdateHandler
-	basePath string
+	path string
 }
 
 // NewUpdateHandler returns a new DID document update handler
 func NewUpdateHandler(basePath string, processor dochandler.Processor) *UpdateHandler {
 	return &UpdateHandler{
 		UpdateHandler: dochandler.NewUpdateHandler(processor),
-		basePath:      basePath,
+		path:          fmt.Sprintf("%s/operations", basePath),
 	}
 }
 
 // Path returns the context path
 func (h *UpdateHandler) Path() string {
-	return h.basePath
+	return h.path
 }
 
 // Method returns the HTTP method

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -33,7 +33,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
 		handler := NewUpdateHandler(basePath, docHandler)
-		require.Equal(t, basePath, handler.Path())
+		require.Equal(t, basePath+"/operations", handler.Path())
 		require.Equal(t, http.MethodPost, handler.Method())
 		require.NotNil(t, handler.Handler())
 
@@ -43,7 +43,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		rw := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader(request))
+		req := httptest.NewRequest(http.MethodPost, "/document/operations", bytes.NewReader(request))
 		handler.Update(rw, req)
 		require.Equal(t, http.StatusOK, rw.Code)
 
@@ -75,7 +75,7 @@ func TestUpdateHandler_Update_Error(t *testing.T) {
 		require.NoError(t, err)
 
 		rw := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader(request))
+		req := httptest.NewRequest(http.MethodPost, "/document/operations", bytes.NewReader(request))
 		handler.Update(rw, req)
 		require.Equal(t, http.StatusBadRequest, rw.Code)
 


### PR DESCRIPTION
closes #244

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>