### PR TITLE
chore: Rename resolution endpoint to /identifiers

### DIFF
--- a/pkg/restapi/diddochandler/handler.go
+++ b/pkg/restapi/diddochandler/handler.go
@@ -1,0 +1,41 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package diddochandler
+
+import (
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+)
+
+// handler resolves DID documents
+type handler struct {
+	path       string
+	method     string
+	reqHandler common.HTTPRequestHandler
+}
+
+func newHandler(path, method string, reqHandler common.HTTPRequestHandler) *handler {
+	return &handler{
+		path:       path,
+		method:     method,
+		reqHandler: reqHandler,
+	}
+}
+
+// Path returns the context path
+func (h *handler) Path() string {
+	return h.path
+}
+
+// Method returns the HTTP method
+func (h *handler) Method() string {
+	return h.method
+}
+
+// Handler returns the handler
+func (h *handler) Handler() common.HTTPRequestHandler {
+	return h.reqHandler
+}

--- a/pkg/restapi/diddochandler/resolvehandler.go
+++ b/pkg/restapi/diddochandler/resolvehandler.go
@@ -7,37 +7,24 @@ SPDX-License-Identifier: Apache-2.0
 package diddochandler
 
 import (
+	"fmt"
 	"net/http"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/dochandler"
 )
 
 // ResolveHandler resolves DID documents
 type ResolveHandler struct {
-	*dochandler.ResolveHandler
-	basePath string
+	*handler
 }
 
 // NewResolveHandler returns a new DID document resolve handler
 func NewResolveHandler(basePath string, resolver dochandler.Resolver) *ResolveHandler {
 	return &ResolveHandler{
-		ResolveHandler: dochandler.NewResolveHandler(resolver),
-		basePath:       basePath,
+		handler: newHandler(
+			fmt.Sprintf("%s/identifiers/{id}", basePath),
+			http.MethodGet,
+			dochandler.NewResolveHandler(resolver).Resolve,
+		),
 	}
-}
-
-// Path returns the context path
-func (h *ResolveHandler) Path() string {
-	return h.basePath + "/{id}"
-}
-
-// Method returns the HTTP method
-func (h *ResolveHandler) Method() string {
-	return http.MethodGet
-}
-
-// Handler returns the handler
-func (h *ResolveHandler) Handler() common.HTTPRequestHandler {
-	return h.Resolve
 }

--- a/pkg/restapi/diddochandler/resolvehandler_test.go
+++ b/pkg/restapi/diddochandler/resolvehandler_test.go
@@ -19,13 +19,13 @@ import (
 func TestResolveHandler_Resolve(t *testing.T) {
 	docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
 	handler := NewResolveHandler(basePath, docHandler)
-	require.Equal(t, basePath+"/{id}", handler.Path())
+	require.Equal(t, basePath+"/identifiers/{id}", handler.Path())
 	require.Equal(t, http.MethodGet, handler.Method())
 	require.NotNil(t, handler.Handler())
 
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/document", nil)
-	handler.Resolve(rw, req)
+	req := httptest.NewRequest(http.MethodGet, "/document/identifiers", nil)
+	handler.Handler()(rw, req)
 	require.Equal(t, http.StatusBadRequest, rw.Code)
 	require.Contains(t, rw.Body.String(), "must start with supported namespace")
 }

--- a/pkg/restapi/diddochandler/restapi_test.go
+++ b/pkg/restapi/diddochandler/restapi_test.go
@@ -65,7 +65,7 @@ func TestRESTAPI(t *testing.T) {
 		didID, err := getID(createRequest.SuffixData)
 		require.NoError(t, err)
 
-		resp, err := httpGet(t, clientURL+basePath+"/"+didID)
+		resp, err := httpGet(t, clientURL+basePath+"/identifiers/"+didID)
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 

--- a/pkg/restapi/diddochandler/updatehandler.go
+++ b/pkg/restapi/diddochandler/updatehandler.go
@@ -10,35 +10,21 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/dochandler"
 )
 
 // UpdateHandler handles the creation and update of DID documents
 type UpdateHandler struct {
-	*dochandler.UpdateHandler
-	path string
+	*handler
 }
 
 // NewUpdateHandler returns a new DID document update handler
 func NewUpdateHandler(basePath string, processor dochandler.Processor) *UpdateHandler {
 	return &UpdateHandler{
-		UpdateHandler: dochandler.NewUpdateHandler(processor),
-		path:          fmt.Sprintf("%s/operations", basePath),
+		handler: newHandler(
+			fmt.Sprintf("%s/operations", basePath),
+			http.MethodPost,
+			dochandler.NewUpdateHandler(processor).Update,
+		),
 	}
-}
-
-// Path returns the context path
-func (h *UpdateHandler) Path() string {
-	return h.path
-}
-
-// Method returns the HTTP method
-func (h *UpdateHandler) Method() string {
-	return http.MethodPost
-}
-
-// Handler returns the handler
-func (h *UpdateHandler) Handler() common.HTTPRequestHandler {
-	return h.Update
 }

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -44,7 +44,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/document/operations", bytes.NewReader(request))
-		handler.Update(rw, req)
+		handler.Handler()(rw, req)
 		require.Equal(t, http.StatusOK, rw.Code)
 
 		id, err := getID(createRequest.SuffixData)
@@ -76,7 +76,7 @@ func TestUpdateHandler_Update_Error(t *testing.T) {
 
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/document/operations", bytes.NewReader(request))
-		handler.Update(rw, req)
+		handler.Handler()(rw, req)
 		require.Equal(t, http.StatusBadRequest, rw.Code)
 
 		body, err := ioutil.ReadAll(rw.Body)


### PR DESCRIPTION
Also refactored the handlers due to linter complaints about duplicate code.

closes #251

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>