### PR TITLE
feat: Kid should not be provided for recovery and deactivate

### DIFF
--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -39,6 +39,19 @@ func TestParseRecoverOperation(t *testing.T) {
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "unexpected end of JSON input")
 	})
+	t.Run("validate recover request", func(t *testing.T) {
+		recoverRequest, err := getDefaultRecoverRequest()
+		require.NoError(t, err)
+
+		recoverRequest.DidSuffix = ""
+		request, err := json.Marshal(recoverRequest)
+		require.NoError(t, err)
+
+		op, err := ParseRecoverOperation(request, p)
+		require.Error(t, err)
+		require.Nil(t, op)
+		require.Contains(t, err.Error(), "missing did suffix")
+	})
 	t.Run("parse patch data error", func(t *testing.T) {
 		recoverRequest, err := getDefaultRecoverRequest()
 		require.NoError(t, err)

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -37,6 +37,19 @@ func TestParseUpdateOperation(t *testing.T) {
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "unexpected end of JSON input")
 	})
+	t.Run("validate update request error", func(t *testing.T) {
+		req, err := getDefaultUpdateRequest()
+		require.NoError(t, err)
+		req.DidSuffix = ""
+
+		payload, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		schema, err := ParseUpdateOperation(payload, p)
+		require.Error(t, err)
+		require.Nil(t, schema)
+		require.Contains(t, err.Error(), "missing did suffix")
+	})
 	t.Run("invalid next update commitment hash", func(t *testing.T) {
 		delta, err := getUpdateDelta()
 		require.NoError(t, err)
@@ -55,7 +68,7 @@ func TestParseUpdateOperation(t *testing.T) {
 	})
 }
 
-func TestValidateUpdatedelta(t *testing.T) {
+func TestValidateUpdateDelta(t *testing.T) {
 	t.Run("invalid next update commitment hash", func(t *testing.T) {
 		delta, err := getUpdateDelta()
 		require.NoError(t, err)
@@ -68,7 +81,7 @@ func TestValidateUpdatedelta(t *testing.T) {
 	})
 }
 
-func TestParseUpdatedelta(t *testing.T) {
+func TestParseUpdateDelta(t *testing.T) {
 	t.Run("invalid next update commitment", func(t *testing.T) {
 		delta, err := getUpdateDelta()
 		require.NoError(t, err)

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -253,7 +253,7 @@ func getDeactivateRequestInfo(uniqueSuffix string) *helper.DeactivateRequestInfo
 	return &helper.DeactivateRequestInfo{
 		DidSuffix:           uniqueSuffix,
 		RecoveryRevealValue: recoveryReveal,
-		Signer:              ecsigner.New(privateKey, "ES256", "recovery"),
+		Signer:              ecsigner.New(privateKey, "ES256", ""),
 	}
 }
 
@@ -276,7 +276,7 @@ func getRecoverRequestInfo(uniqueSuffix string) *helper.RecoverRequestInfo {
 		NextRecoveryRevealValue: []byte("newRecoveryReveal"),
 		NextUpdateRevealValue:   []byte("newUpdateReveal"),
 		MultihashCode:           sha2_256,
-		Signer:                  ecsigner.New(privateKey, "ES256", "recovery"),
+		Signer:                  ecsigner.New(privateKey, "ES256", ""),
 	}
 }
 

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -139,5 +139,5 @@ type Protected struct {
 
 	// kid
 	// Required: true
-	Kid string `json:"kid"`
+	Kid string `json:"kid,omitempty"`
 }

--- a/pkg/util/ecsigner/signer.go
+++ b/pkg/util/ecsigner/signer.go
@@ -33,8 +33,11 @@ func New(privKey *ecdsa.PrivateKey, alg, kid string) *Signer {
 // Headers provides required JWS protected headers. It provides information about signing key and algorithm.
 func (signer *Signer) Headers() jws.Headers {
 	headers := make(jws.Headers)
-	headers[jws.HeaderKeyID] = signer.kid
 	headers[jws.HeaderAlgorithm] = signer.alg
+
+	if signer.kid != "" {
+		headers[jws.HeaderKeyID] = signer.kid
+	}
 
 	return headers
 }

--- a/pkg/util/edsigner/signer.go
+++ b/pkg/util/edsigner/signer.go
@@ -28,8 +28,11 @@ func New(privKey ed25519.PrivateKey, alg, kid string) *Signer {
 // Headers provides required JWS protected headers. It provides information about signing key and algorithm.
 func (signer *Signer) Headers() jws.Headers {
 	headers := make(jws.Headers)
-	headers[jws.HeaderKeyID] = signer.kid
 	headers[jws.HeaderAlgorithm] = signer.alg
+
+	if signer.kid != "" {
+		headers[jws.HeaderKeyID] = signer.kid
+	}
 
 	return headers
 }


### PR DESCRIPTION
Kid must not be provided for recovery and deactivate
Kid must be provided for update

Added signer validation in helper and accomodated helper signers for those scenarios

Also, included two more tests of operation validation (server side)

Closes #249

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>