### PR TITLE
feat: Add signed model for update

### DIFF
--- a/pkg/dochandler/didvalidator/validator.go
+++ b/pkg/dochandler/didvalidator/validator.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	didSuffix            = "did_suffix"
-	didContext           = "https://w3id.org/did/v1"
+	didContext           = "https://www.w3.org/ns/did/v1"
+	sidetreeContext      = "https://identity.foundation/sidetree/context-v1.jsonld"
 	didResolutionContext = "https://www.w3.org/ns/did-resolution/v1"
 )
 
@@ -104,7 +105,7 @@ func (v *Validator) TransformDocument(doc document.Document) (*document.Resoluti
 	external := document.DidDocumentFromJSONLDObject(make(document.DIDDocument))
 
 	// add context and id
-	external[document.ContextProperty] = []interface{}{didContext}
+	external[document.ContextProperty] = []interface{}{didContext, sidetreeContext}
 	external[document.IDProperty] = internal.ID()
 
 	result := &document.ResolutionResult{

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/dochandler/docvalidator"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
@@ -355,7 +356,7 @@ func getCreateRequest() (*model.CreateRequest, error) {
 		return nil, err
 	}
 
-	suffixDataBytes, err := docutil.MarshalCanonical(getSuffixData())
+	suffixDataBytes, err := canonicalizer.MarshalCanonical(getSuffixData())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/canonicalizer/canonicalizer.go
+++ b/pkg/internal/canonicalizer/canonicalizer.go
@@ -1,0 +1,23 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package canonicalizer
+
+import (
+	"encoding/json"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/jsoncanonicalizer"
+)
+
+// MarshalCanonical is using JCS RFC canonicalization
+func MarshalCanonical(value interface{}) ([]byte, error) {
+	jsonLiteralValByte, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsoncanonicalizer.Transform(jsonLiteralValByte)
+}

--- a/pkg/internal/canonicalizer/canonicalizer_test.go
+++ b/pkg/internal/canonicalizer/canonicalizer_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package canonicalizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalCanonical(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		test := struct {
+			Beta  string `json:"beta"`
+			Alpha string `json:"alpha"`
+		}{
+			Beta:  "beta",
+			Alpha: "alpha",
+		}
+
+		result, err := MarshalCanonical(test)
+		require.NoError(t, err)
+		require.Equal(t, string(result), `{"alpha":"alpha","beta":"beta"}`)
+	})
+
+	t.Run("marshal error", func(t *testing.T) {
+		var c chan int
+		result, err := MarshalCanonical(c)
+		require.Error(t, err)
+		require.Empty(t, result)
+		require.Contains(t, err.Error(), "json: unsupported type: chan int")
+	})
+}

--- a/pkg/internal/signutil/signature.go
+++ b/pkg/internal/signutil/signature.go
@@ -1,0 +1,71 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package signutil
+
+import (
+	"errors"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
+	internaljws "github.com/trustbloc/sidetree-core-go/pkg/internal/jws"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+)
+
+// Signer defines JWS Signer interface that will be used to sign required data in Sidetree request
+type Signer interface {
+	// Sign signs data and returns signature value
+	Sign(data []byte) ([]byte, error)
+
+	// Headers provides required JWS protected headers. It provides information about signing key and algorithm.
+	Headers() jws.Headers
+}
+
+//SignModel signs model
+func SignModel(model interface{}, signer Signer) (*model.JWS, error) {
+	// first you normalize model
+	signedDataBytes, err := canonicalizer.MarshalCanonical(model)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := docutil.EncodeToString(signedDataBytes)
+
+	return signPayload(payload, signer)
+}
+
+func signPayload(payload string, signer Signer) (*model.JWS, error) {
+	alg, ok := signer.Headers().Algorithm()
+	if !ok || alg == "" {
+		return nil, errors.New("signing algorithm is required")
+	}
+
+	protected := &model.Header{
+		Alg: alg,
+	}
+
+	kid, ok := signer.Headers().KeyID()
+	if ok {
+		protected.Kid = kid
+	}
+
+	jwsSignature, err := internaljws.NewJWS(signer.Headers(), nil, []byte(payload), signer)
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := jwsSignature.SerializeCompact(false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.JWS{
+		Protected: protected,
+		Signature: signature,
+		Payload:   payload,
+	}, nil
+}

--- a/pkg/internal/signutil/signature_test.go
+++ b/pkg/internal/signutil/signature_test.go
@@ -1,0 +1,107 @@
+package signutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	internal "github.com/trustbloc/sidetree-core-go/pkg/internal/jws"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
+	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
+	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+)
+
+func TestSignModel(t *testing.T) {
+	t.Run("marshal error", func(t *testing.T) {
+		ch := make(chan int)
+		request, err := SignModel(ch, nil)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "unsupported type: chan int")
+	})
+	t.Run("success", func(t *testing.T) {
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		signer := ecsigner.New(privateKey, "ES256", "key-1")
+
+		test := struct {
+			message string
+		}{
+			message: "test",
+		}
+
+		request, err := SignModel(test, signer)
+		require.NoError(t, err)
+		require.NotEmpty(t, request)
+	})
+}
+
+func TestSignPayload(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	jwk, err := pubkey.GetPublicKeyJWK(&privateKey.PublicKey)
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		signer := ecsigner.New(privateKey, "ES256", "key-1")
+
+		message := "test"
+		jwsSignature, err := signPayload(message, signer)
+		require.NoError(t, err)
+		require.NotEmpty(t, jwsSignature)
+
+		_, err = internal.ParseJWS(jwsSignature.Signature, jwk)
+		require.NoError(t, err)
+	})
+	t.Run("signing algorithm required", func(t *testing.T) {
+		signer := ecsigner.New(privateKey, "", "kid")
+
+		jws, err := signPayload("test", signer)
+		require.Error(t, err)
+		require.Empty(t, jws)
+		require.Contains(t, err.Error(), "signing algorithm is required")
+	})
+	t.Run("kid is required", func(t *testing.T) {
+		jws, err := signPayload("", NewMockSigner(errors.New("test error"), true))
+		require.Error(t, err)
+		require.Empty(t, jws)
+		require.Contains(t, err.Error(), "test error")
+	})
+}
+
+// MockSigner implements signer interface
+type MockSigner struct {
+	Recovery bool
+	Err      error
+}
+
+// NewMockSigner creates new mock signer (default to recovery signer)
+func NewMockSigner(err error, recovery bool) *MockSigner {
+	return &MockSigner{Err: err, Recovery: recovery}
+}
+
+// Headers provides required JWS protected headers. It provides information about signing key and algorithm.
+func (ms *MockSigner) Headers() jws.Headers {
+	headers := make(jws.Headers)
+	headers[jws.HeaderAlgorithm] = "alg"
+	if !ms.Recovery {
+		headers[jws.HeaderKeyID] = "kid"
+	}
+
+	return headers
+}
+
+// Sign signs msg and returns mock signature value
+func (ms *MockSigner) Sign(msg []byte) ([]byte, error) {
+	if ms.Err != nil {
+		return nil, ms.Err
+	}
+
+	return []byte("signature"), nil
+}

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
@@ -163,12 +164,12 @@ func getCreateRequest() (*model.CreateRequest, error) {
 		return nil, err
 	}
 
-	deltaBytes, err := docutil.MarshalCanonical(delta)
+	deltaBytes, err := canonicalizer.MarshalCanonical(delta)
 	if err != nil {
 		return nil, err
 	}
 
-	suffixDataBytes, err := docutil.MarshalCanonical(getSuffixData())
+	suffixDataBytes, err := canonicalizer.MarshalCanonical(getSuffixData())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/deactivate_test.go
+++ b/pkg/operation/deactivate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -113,7 +114,7 @@ func TestParseDeactivateOperation(t *testing.T) {
 }
 
 func getDeactivateRequest(signedData *model.DeactivateSignedDataModel) (*model.DeactivateRequest, error) {
-	signedDataBytes, err := docutil.MarshalCanonical(signedData)
+	signedDataBytes, err := canonicalizer.MarshalCanonical(signedData)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
@@ -247,12 +248,12 @@ func TestValidateRecoverRequest(t *testing.T) {
 }
 
 func getRecoverRequest(delta *model.DeltaModel, signedData *model.RecoverSignedDataModel) (*model.RecoverRequest, error) {
-	deltaBytes, err := docutil.MarshalCanonical(delta)
+	deltaBytes, err := canonicalizer.MarshalCanonical(delta)
 	if err != nil {
 		return nil, err
 	}
 
-	signedDataBytes, err := docutil.MarshalCanonical(signedData)
+	signedDataBytes, err := canonicalizer.MarshalCanonical(signedData)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
@@ -91,12 +92,12 @@ func getCreateRequest() (*model.CreateRequest, error) {
 		return nil, err
 	}
 
-	deltaBytes, err := docutil.MarshalCanonical(delta)
+	deltaBytes, err := canonicalizer.MarshalCanonical(delta)
 	if err != nil {
 		return nil, err
 	}
 
-	suffixDataBytes, err := docutil.MarshalCanonical(getSuffixData())
+	suffixDataBytes, err := canonicalizer.MarshalCanonical(getSuffixData())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/request"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
@@ -170,12 +171,12 @@ func getCreateRequest() (*model.CreateRequest, error) {
 		return nil, err
 	}
 
-	deltaBytes, err := docutil.MarshalCanonical(delta)
+	deltaBytes, err := canonicalizer.MarshalCanonical(delta)
 	if err != nil {
 		return nil, err
 	}
 
-	suffixDataBytes, err := docutil.MarshalCanonical(getSuffixData())
+	suffixDataBytes, err := canonicalizer.MarshalCanonical(getSuffixData())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/helper/create.go
+++ b/pkg/restapi/helper/create.go
@@ -7,11 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package helper
 
 import (
-	"encoding/json"
 	"errors"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/internal/jsoncanonicalizer"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
@@ -71,7 +70,7 @@ func NewCreateRequest(info *CreateRequestInfo) ([]byte, error) {
 		RecoveryCommitment: mhNextRecoveryCommitmentHash,
 	}
 
-	suffixDataBytes, err := MarshalCanonical(suffixData)
+	suffixDataBytes, err := canonicalizer.MarshalCanonical(suffixData)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +81,7 @@ func NewCreateRequest(info *CreateRequestInfo) ([]byte, error) {
 		SuffixData: docutil.EncodeToString(suffixDataBytes),
 	}
 
-	return MarshalCanonical(schema)
+	return canonicalizer.MarshalCanonical(schema)
 }
 
 func validateCreateRequest(info *CreateRequestInfo) error {
@@ -121,15 +120,5 @@ func getDeltaBytes(mhCode uint, reveal []byte, patches []patch.Patch) ([]byte, e
 		Patches:          patches,
 	}
 
-	return MarshalCanonical(delta)
-}
-
-// MarshalCanonical is using JCS RFC canonicalization
-func MarshalCanonical(value interface{}) ([]byte, error) {
-	jsonLiteralValByte, err := json.Marshal(value)
-	if err != nil {
-		return nil, err
-	}
-
-	return jsoncanonicalizer.Transform(jsonLiteralValByte)
+	return canonicalizer.MarshalCanonical(delta)
 }

--- a/pkg/restapi/helper/recover.go
+++ b/pkg/restapi/helper/recover.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
@@ -78,7 +80,7 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 		RecoveryCommitment: mhNextRecoveryCommitmentHash,
 	}
 
-	jws, err := signModel(signedDataModel, info.Signer)
+	jws, err := signutil.SignModel(signedDataModel, info.Signer)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +93,7 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 		SignedData:          jws,
 	}
 
-	return MarshalCanonical(schema)
+	return canonicalizer.MarshalCanonical(schema)
 }
 
 func validateRecoverRequest(info *RecoverRequestInfo) error {

--- a/pkg/restapi/helper/update.go
+++ b/pkg/restapi/helper/update.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
@@ -54,7 +56,11 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 		return nil, err
 	}
 
-	jws, err := signPayload(mhDelta, info.Signer)
+	signedDataModel := model.UpdateSignedDataModel{
+		DeltaHash: mhDelta,
+	}
+
+	jws, err := signutil.SignModel(signedDataModel, info.Signer)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +73,7 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 		SignedData:        jws,
 	}
 
-	return MarshalCanonical(schema)
+	return canonicalizer.MarshalCanonical(schema)
 }
 
 func validateUpdateRequest(info *UpdateRequestInfo) error {

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -84,6 +84,13 @@ type DeactivateRequest struct {
 	SignedData *JWS `json:"signed_data"`
 }
 
+// UpdateSignedDataModel defines signed data model for update
+type UpdateSignedDataModel struct {
+
+	// Hash of the unsigned delta object
+	DeltaHash string `json:"delta_hash"`
+}
+
 // RecoverSignedDataModel defines signed data model for recovery
 type RecoverSignedDataModel struct {
 


### PR DESCRIPTION
Included:
- add signed model for update, not just string (DELTA_HASH)
- remove option to update document using recovery key (doc has to have at least one ops key)
- check delta against signed delta hash for update and recovery
- validate info against signed data for deactivate
- organize tests for processor (move common code to internal: signing utility, canonicalization)
- update document context as per latest spec

Closes #250

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>