### PR TITLE
refactor: Remove 'replace' patch

### DIFF
--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -39,8 +39,6 @@ func applyPatch(doc document.Document, p patch.Patch) (document.Document, error)
 
 	action := p.GetAction()
 	switch action {
-	case patch.Replace:
-		return applyRecover(p.GetValue(patch.DocumentKey))
 	case patch.JSONPatch:
 		return applyJSON(doc, p.GetValue(patch.PatchesKey))
 	case patch.AddPublicKeys:
@@ -54,16 +52,6 @@ func applyPatch(doc document.Document, p patch.Patch) (document.Document, error)
 	}
 
 	return nil, fmt.Errorf("action '%s' is not supported", action)
-}
-
-func applyRecover(newDoc interface{}) (document.Document, error) {
-	log.Debugf("applying recover patch: %v", newDoc)
-	docBytes, err := json.Marshal(newDoc)
-	if err != nil {
-		return nil, err
-	}
-
-	return document.FromBytes(docBytes)
 }
 
 func applyJSON(doc document.Document, entry interface{}) (document.Document, error) {

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -19,12 +19,12 @@ const invalid = "invalid"
 
 func TestApplyPatches(t *testing.T) {
 	t.Run("action not supported", func(t *testing.T) {
-		replace, err := patch.NewReplacePatch("{}")
+		replace, err := patch.NewAddServiceEndpointsPatch("{}")
 		require.NoError(t, err)
 
 		replace["action"] = invalid
 
-		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+		doc, err := ApplyPatches(make(document.Document), []patch.Patch{replace})
 		require.Error(t, err)
 		require.Nil(t, doc)
 		require.Contains(t, err.Error(), "not supported")
@@ -33,10 +33,10 @@ func TestApplyPatches(t *testing.T) {
 
 func TestApplyPatches_Replace(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		replace, err := patch.NewReplacePatch(testDoc)
+		patches, err := patch.PatchesFromDocument(testDoc)
 		require.NoError(t, err)
 
-		doc, err := ApplyPatches(nil, []patch.Patch{replace})
+		doc, err := ApplyPatches(make(document.Document), patches)
 		require.NoError(t, err)
 		require.NotNil(t, doc)
 	})
@@ -345,12 +345,12 @@ func TestApplyPatches_RemoveServiceEndpoints(t *testing.T) {
 }
 
 func setupDefaultDoc() (document.Document, error) {
-	replace, err := patch.NewReplacePatch(testDoc)
+	patches, err := patch.PatchesFromDocument(testDoc)
 	if err != nil {
 		return nil, err
 	}
 
-	return ApplyPatches(nil, []patch.Patch{replace})
+	return ApplyPatches(make(document.Document), patches)
 }
 
 const invalidPatches = `[

--- a/pkg/dochandler/docvalidator/validator.go
+++ b/pkg/dochandler/docvalidator/validator.go
@@ -73,6 +73,11 @@ func (v *Validator) IsValidOriginalDocument(payload []byte) error {
 		return errors.New("document must NOT have the id property")
 	}
 
+	// Sidetree rule: validate public keys
+	if err := document.ValidatePublicKeys(doc.PublicKeys()); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/dochandler/docvalidator/validator_test.go
+++ b/pkg/dochandler/docvalidator/validator_test.go
@@ -37,6 +37,14 @@ func TestValidatoIsValidOriginalDocumentError(t *testing.T) {
 	require.Contains(t, err.Error(), "document must NOT have the id property")
 }
 
+func TestIsValidOriginalDocument_PublicKeyErrors(t *testing.T) {
+	v := getDefaultValidator()
+
+	err := v.IsValidOriginalDocument(pubKeyNoID)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "public key id is missing")
+}
+
 func TestValidatorIsValidPayload(t *testing.T) {
 	store := mocks.NewMockOperationStore(nil)
 	v := New(store)
@@ -144,3 +152,5 @@ const validDocWithOpsKeys = `
     }
   ]
 }`
+
+var pubKeyNoID = []byte(`{ "publicKey": [{"id": "", "type": "JwsVerificationKey2020"}]}`)

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -286,5 +286,5 @@ func getSuffix(namespace, idOrDocument string) (string, error) {
 }
 
 func getInitialDocument(patches []patch.Patch) (document.Document, error) {
-	return composer.ApplyPatches(nil, patches)
+	return composer.ApplyPatches(make(document.Document), patches)
 }

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -76,7 +76,11 @@ func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (*doc
 		return nil, nil
 	}
 
-	doc := m.store[operation.ID]
+	doc, ok := m.store[operation.ID]
+	if !ok { // create operation
+		doc = make(document.Document)
+	}
+
 	doc, err := composer.ApplyPatches(doc, operation.Delta.Patches)
 	if err != nil {
 		return nil, err
@@ -139,7 +143,7 @@ func (m *MockDocumentHandler) resolveWithInitialState(idOrDocument string) (*doc
 		return nil, err
 	}
 
-	doc, err := composer.ApplyPatches(nil, delta.Patches)
+	doc, err := composer.ApplyPatches(make(document.Document), delta.Patches)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -203,13 +203,13 @@ func getCreateRequestBytes() ([]byte, error) {
 }
 
 func getDelta() (*model.DeltaModel, error) {
-	replacePatch, err := patch.NewReplacePatch(validDoc)
+	patches, err := patch.PatchesFromDocument(validDoc)
 	if err != nil {
 		return nil, err
 	}
 
 	return &model.DeltaModel{
-		Patches:          []patch.Patch{replacePatch},
+		Patches:          patches,
 		UpdateCommitment: computeMultihash("updateReveal"),
 	}, nil
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -162,7 +162,7 @@ func (s *OperationProcessor) applyCreateOperation(operation *batch.Operation, rm
 		return nil, errors.New("create has to be the first operation")
 	}
 
-	doc, err := composer.ApplyPatches(nil, operation.Delta.Patches)
+	doc, err := composer.ApplyPatches(make(document.Document), operation.Delta.Patches)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +364,7 @@ func (s *OperationProcessor) applyRecoverOperation(operation *batch.Operation, r
 		return nil, fmt.Errorf("recover delta doesn't match delta hash: %s", err.Error())
 	}
 
-	doc, err := composer.ApplyPatches(rm.Doc, operation.Delta.Patches)
+	doc, err := composer.ApplyPatches(make(document.Document), operation.Delta.Patches)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -896,13 +896,13 @@ func getCreateRequest(privateKey *ecdsa.PrivateKey) (*model.CreateRequest, error
 }
 
 func getReplaceDelta(doc string) (*model.DeltaModel, error) {
-	replace, err := patch.NewReplacePatch(doc)
+	patches, err := patch.PatchesFromDocument(doc)
 	if err != nil {
 		return nil, err
 	}
 
 	return &model.DeltaModel{
-		Patches:          []patch.Patch{replace},
+		Patches:          patches,
 		UpdateCommitment: getEncodedMultihash([]byte("updateReveal")),
 	}, nil
 }

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -110,13 +110,13 @@ func getCreateRequest() (*model.CreateRequest, error) {
 }
 
 func getDelta() (*model.DeltaModel, error) {
-	replace, err := patch.NewReplacePatch(validDoc)
+	patches, err := patch.PatchesFromDocument(validDoc)
 	if err != nil {
 		return nil, err
 	}
 
 	return &model.DeltaModel{
-		Patches:          []patch.Patch{replace},
+		Patches:          patches,
 		UpdateCommitment: computeMultihash("updateReveal"),
 	}, nil
 }

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -208,13 +208,13 @@ func getCreateRequest() (*model.CreateRequest, error) {
 }
 
 func getDelta() (*model.DeltaModel, error) {
-	replace, err := patch.NewReplacePatch(validDoc)
+	patches, err := patch.PatchesFromDocument(validDoc)
 	if err != nil {
 		return nil, err
 	}
 
 	return &model.DeltaModel{
-		Patches:          []patch.Patch{replace},
+		Patches:          patches,
 		UpdateCommitment: computeMultihash("updateReveal"),
 	}, nil
 }

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -13,7 +13,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -100,12 +99,9 @@ func TestUpdateHandler_Update(t *testing.T) {
 		recover, err := helper.NewRecoverRequest(getRecoverRequestInfo(uniqueSuffix))
 		require.NoError(t, err)
 
-		fmt.Println(string(recover))
-
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/document", bytes.NewReader(recover))
 		handler.Update(rw, req)
-		fmt.Println(req.Body)
 		require.Equal(t, http.StatusOK, rw.Code)
 		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})

--- a/pkg/restapi/helper/create.go
+++ b/pkg/restapi/helper/create.go
@@ -43,12 +43,11 @@ func NewCreateRequest(info *CreateRequestInfo) ([]byte, error) {
 		return nil, err
 	}
 
-	replace, err := patch.NewReplacePatch(info.OpaqueDocument)
+	patches, err := patch.PatchesFromDocument(info.OpaqueDocument)
 	if err != nil {
 		return nil, err
 	}
 
-	patches := []patch.Patch{replace}
 	deltaBytes, err := getDeltaBytes(info.MultihashCode, info.NextUpdateRevealValue, patches)
 	if err != nil {
 		return nil, err

--- a/pkg/restapi/helper/recover.go
+++ b/pkg/restapi/helper/recover.go
@@ -53,12 +53,11 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 		return nil, err
 	}
 
-	replacePatch, err := patch.NewReplacePatch(info.OpaqueDocument)
+	patches, err := patch.PatchesFromDocument(info.OpaqueDocument)
 	if err != nil {
 		return nil, err
 	}
 
-	patches := []patch.Patch{replacePatch}
 	deltaBytes, err := getDeltaBytes(info.MultihashCode, info.NextUpdateRevealValue, patches)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
 and replace it with add-public-keys, add-service-endpoints and ietf-json- patch
    
 Process opaque document such that:
 - public keys are handled with add public keys patch
 - services are handled with add services patch
 - everything else is handled by generic JSON patch
    
'replace' patch is no longer supported


Closes #265

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>