### PR TITLE
chore: ietf-json-patch should not update keys and services

### DIFF
--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -356,7 +356,7 @@ func setupDefaultDoc() (document.Document, error) {
 const invalidPatches = `[
 	{
       "op": "invalid",
-      "path": "/service",
+      "path": "/test",
       "value": "new value"
 	}
 ]`
@@ -364,7 +364,7 @@ const invalidPatches = `[
 const patches = `[
 	{
       "op": "replace",
-      "path": "/service",
+      "path": "/test",
       "value": "new value"
 	}
 ]`

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -94,6 +94,24 @@ func TestIETFPatch(t *testing.T) {
 		require.NotNil(t, patch)
 		require.Equal(t, patch.GetAction(), JSONPatch)
 	})
+	t.Run("error - path not found", func(t *testing.T) {
+		patch, err := FromBytes([]byte(ietfPatchNoPath))
+		require.Error(t, err)
+		require.Nil(t, patch)
+		require.Equal(t, err.Error(), "ietf-json-patch: path not found")
+	})
+	t.Run("error - cannot update services", func(t *testing.T) {
+		patch, err := FromBytes([]byte(ietfServicesPatch))
+		require.Error(t, err)
+		require.Nil(t, patch)
+		require.Equal(t, err.Error(), "ietf-json-patch: cannot modify services")
+	})
+	t.Run("error - cannot update public keys", func(t *testing.T) {
+		patch, err := FromBytes([]byte(ietfPublicKeysPatch))
+		require.Error(t, err)
+		require.Nil(t, patch)
+		require.Equal(t, err.Error(), "ietf-json-patch: cannot modify public keys")
+	})
 	t.Run("missing patches", func(t *testing.T) {
 		patch, err := FromBytes([]byte(`{"action": "ietf-json-patch"}`))
 		require.Error(t, err)
@@ -272,16 +290,42 @@ const ietfPatch = `{
   "action": "ietf-json-patch",
   "patches": [{
       "op": "replace",
+      "path": "/name",
+      "value": "value"
+	}]
+}`
+
+const ietfPatchNoPath = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
+      "value": "value"
+	}]
+}`
+
+const ietfServicesPatch = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
       "path": "/service",
       "value": "new value"
+	}]
+}`
+
+const ietfPublicKeysPatch = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
+      "path": "/publicKey/0/type",
+      "value": "new type"
 	}]
 }`
 
 const patches = `[
 	{
       "op": "replace",
-      "path": "/service",
-      "value": "new value"
+      "path": "/some/object/0",
+      "value": "value"
 	}
 ]`
 

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -117,7 +117,7 @@ func TestUpdateDocument(t *testing.T) {
 
 		// check if service type value is updated (done via json patch)
 		didDoc := document.DidDocumentFromJSONLDObject(result.Document)
-		require.Equal(t, "special1", didDoc.Services()[0].Type())
+		require.Equal(t, "special1", didDoc["test"])
 
 		// test consecutive update
 		updateOp, err = getUpdateOperation(privateKey, uniqueSuffix, 2)
@@ -130,7 +130,7 @@ func TestUpdateDocument(t *testing.T) {
 
 		// check if service type value is updated again (done via json patch)
 		didDoc = document.DidDocumentFromJSONLDObject(result.Document)
-		require.Equal(t, "special2", didDoc.Services()[0].Type())
+		require.Equal(t, "special2", didDoc["test"])
 	})
 
 	t.Run("missing signed data error", func(t *testing.T) {
@@ -624,7 +624,7 @@ func TestOpsWithTxnGreaterThan(t *testing.T) {
 func getUpdateOperationWithSigner(s helper.Signer, uniqueSuffix string, operationNumber uint) (*batch.Operation, error) {
 	p := map[string]interface{}{
 		"op":    "replace",
-		"path":  "/service/0/type",
+		"path":  "/test",
 		"value": "special" + strconv.Itoa(int(operationNumber)),
 	}
 


### PR DESCRIPTION
ietf-json-patch should not update public keys and services sections

Closes #253

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>