### PR TITLE
chore: Add validation for remove public keys and remove services

### DIFF
--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -190,6 +190,19 @@ func TestApplyPatches_RemovePublicKeys(t *testing.T) {
 		require.Nil(t, doc)
 		require.Contains(t, err.Error(), "expected array")
 	})
+	t.Run("invalid public key ids", func(t *testing.T) {
+		doc, err := setupDefaultDoc()
+		require.NoError(t, err)
+
+		removePublicKeys, err := patch.NewRemovePublicKeysPatch(removeKeys)
+		require.NoError(t, err)
+		removePublicKeys["public_keys"] = []interface{}{"a&b"}
+
+		doc, err = ApplyPatches(doc, []patch.Patch{removePublicKeys})
+		require.Error(t, err)
+		require.Nil(t, doc)
+		require.Contains(t, err.Error(), "id contains invalid characters")
+	})
 	t.Run("success - add and remove same key; doc stays at two keys", func(t *testing.T) {
 		doc, err := setupDefaultDoc()
 		require.NoError(t, err)
@@ -320,6 +333,19 @@ func TestApplyPatches_RemoveServiceEndpoints(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, doc)
 		require.Contains(t, err.Error(), "expected array")
+	})
+	t.Run("invalid service ids", func(t *testing.T) {
+		doc, err := setupDefaultDoc()
+		require.NoError(t, err)
+
+		removeServices, err := patch.NewRemoveServiceEndpointsPatch(removeServices)
+		require.NoError(t, err)
+		removeServices["ids"] = []interface{}{"svc", "a&b"}
+
+		doc, err = ApplyPatches(doc, []patch.Patch{removeServices})
+		require.Error(t, err)
+		require.Nil(t, doc)
+		require.Contains(t, err.Error(), "id contains invalid characters")
 	})
 	t.Run("success - add and remove same service; doc stays at two services", func(t *testing.T) {
 		doc, err := setupDefaultDoc()

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -178,7 +178,7 @@ func TestDocumentHandler_ResolveDocument_Interop(t *testing.T) {
 	result, err := dochandler.ResolveDocument(interopResolveDidWithInitialState)
 	require.Error(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "bad request: validate initial document: action 'replace' is not supported")
+	require.Contains(t, err.Error(), "bad request: action 'replace' is not supported")
 }
 
 func TestDocumentHandler_ResolveDocument_InitialValue_MaxDeltaSizeError(t *testing.T) {

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -15,7 +15,7 @@ import (
 
 // nolint:gochecknoglobals
 var (
-	asciiRegex = regexp.MustCompile("[A-Za-z0-9_-]+")
+	asciiRegex = regexp.MustCompile("^[A-Za-z0-9_-]+$")
 )
 
 const (
@@ -146,14 +146,15 @@ func validateKID(kid string) error {
 		return errors.New("public key id is missing")
 	}
 
-	if err := validateID(kid); err != nil {
+	if err := ValidateID(kid); err != nil {
 		return fmt.Errorf("public key: %s", err.Error())
 	}
 
 	return nil
 }
 
-func validateID(id string) error {
+// ValidateID validates id
+func ValidateID(id string) error {
 	if len(id) > maxIDLength {
 		return fmt.Errorf("id exceeds maximum length: %d", maxIDLength)
 	}
@@ -203,7 +204,7 @@ func validateServiceID(id string) error {
 		return errors.New("service id is missing")
 	}
 
-	if err := validateID(id); err != nil {
+	if err := ValidateID(id); err != nil {
 		return fmt.Errorf("service: %s", err.Error())
 	}
 

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -179,16 +179,16 @@ func TestValidateServices(t *testing.T) {
 
 func TestValidateID(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		err := validateID("recovered")
+		err := ValidateID("recovered")
 		require.NoError(t, err)
 	})
 	t.Run("error - id not ASCII encoded character", func(t *testing.T) {
-		err := validateID("****")
+		err := ValidateID("a****")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "id contains invalid characters")
 	})
 	t.Run("error - exceeded maximum length", func(t *testing.T) {
-		err := validateID("1234567890abcdefghijk")
+		err := ValidateID("1234567890abcdefghijk")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "id exceeds maximum length: 20")
 	})

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -112,6 +112,12 @@ func validateDelta(delta *model.DeltaModel, code uint) error {
 		return errors.New("missing patches")
 	}
 
+	for _, p := range delta.Patches {
+		if err := p.Validate(); err != nil {
+			return err
+		}
+	}
+
 	if !docutil.IsComputedUsingHashAlgorithm(delta.UpdateCommitment, uint64(code)) {
 		return errors.New("next update commitment hash is not computed with the latest supported hash algorithm")
 	}

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -113,9 +113,11 @@ func TestValidateSuffixData(t *testing.T) {
 }
 
 func TestParseDelta(t *testing.T) {
+	// reference encoded delta fails because it contains 'replace' patch
 	delta, err := parseDelta(refEncodedDelta, sha2_256)
-	require.NoError(t, err)
-	require.NotNil(t, delta)
+	require.Error(t, err)
+	require.Nil(t, delta)
+	require.Contains(t, err.Error(), "action 'replace' is not supported")
 }
 
 func TestValidateDelta(t *testing.T) {

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -163,6 +163,10 @@ func NewRemovePublicKeysPatch(publicKeyIds string) (Patch, error) {
 		return nil, errors.New("missing public key ids")
 	}
 
+	if err := validateIds(ids); err != nil {
+		return nil, err
+	}
+
 	patch := make(Patch)
 	patch[ActionKey] = RemovePublicKeys
 	patch[PublicKeys] = getGenericArray(ids)
@@ -193,6 +197,10 @@ func NewRemoveServiceEndpointsPatch(serviceEndpointIds string) (Patch, error) {
 
 	if len(ids) == 0 {
 		return nil, errors.New("missing service ids")
+	}
+
+	if err := validateIds(ids); err != nil {
+		return nil, err
 	}
 
 	patch := make(Patch)
@@ -406,8 +414,12 @@ func (p Patch) validateAddPublicKeys() error {
 }
 
 func (p Patch) validateRemovePublicKeys() error {
-	_, err := p.getRequiredArray(PublicKeys)
-	return err
+	genericArr, err := p.getRequiredArray(PublicKeys)
+	if err != nil {
+		return err
+	}
+
+	return validateIds(document.StringArray(genericArr))
 }
 
 func (p Patch) validateAddServiceEndpoints() error {
@@ -421,8 +433,22 @@ func (p Patch) validateAddServiceEndpoints() error {
 }
 
 func (p Patch) validateRemoveServiceEndpoints() error {
-	_, err := p.getRequiredArray(ServiceEndpointIdsKey)
-	return err
+	genericArr, err := p.getRequiredArray(ServiceEndpointIdsKey)
+	if err != nil {
+		return err
+	}
+
+	return validateIds(document.StringArray(genericArr))
+}
+
+func validateIds(ids []string) error {
+	for _, id := range ids {
+		if err := document.ValidateID(id); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func getStringArray(arr string) ([]string, error) {

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -183,6 +183,13 @@ func TestRemovePublicKeysPatch(t *testing.T) {
 		require.Nil(t, p)
 		require.Contains(t, err.Error(), "missing public key ids")
 	})
+	t.Run("invalid public key ids", func(t *testing.T) {
+		const ids = `["a123*b456"]`
+		p, err := NewRemovePublicKeysPatch(ids)
+		require.Error(t, err)
+		require.Nil(t, p)
+		require.Contains(t, err.Error(), "id contains invalid characters")
+	})
 	t.Run("error - ids not string array", func(t *testing.T) {
 		const ids = `[0, 1]`
 		p, err := NewRemovePublicKeysPatch(ids)
@@ -247,6 +254,13 @@ func TestRemoveServiceEndpointsPatch(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, p)
 		require.Contains(t, err.Error(), "missing service ids")
+	})
+	t.Run("invalid service ids", func(t *testing.T) {
+		const ids = `["a123*b456"]`
+		p, err := NewRemoveServiceEndpointsPatch(ids)
+		require.Error(t, err)
+		require.Nil(t, p)
+		require.Contains(t, err.Error(), "id contains invalid characters")
 	})
 	t.Run("error - ids not string array", func(t *testing.T) {
 		const ids = `[0, 1]`


### PR DESCRIPTION
-- add validation for remove public keys and remove services (helper, operation processor)
-- add validation of all patches when parsing operation deltas ( this is server side validation before accepting operation request)

Also, fix regex for validate ID

Closes #175

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>