### PR TITLE
chore: Remove service validation for exact properties

### DIFF
--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -43,7 +43,6 @@ const (
 
 	maxJwkProperties       = 4
 	maxPublicKeyProperties = 4
-	maxServiceProperties   = 3
 
 	// public keys, services id length
 	maxIDLength = 20
@@ -179,10 +178,6 @@ func ValidateServices(services []Service) error {
 
 func validateService(service Service) error {
 	// expected fields are type, id, and serviceEndpoint
-
-	if len(service) != maxServiceProperties {
-		return errors.New("invalid number of service properties")
-	}
 
 	if err := validateServiceID(service.ID()); err != nil {
 		return err

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -110,6 +110,13 @@ func TestValidateServices(t *testing.T) {
 		err = ValidateServices(doc.Services())
 		require.Nil(t, err)
 	})
+	t.Run("success - service can have extra property", func(t *testing.T) {
+		doc, err := DidDocumentFromBytes([]byte(serviceDocExtraProperty))
+		require.NoError(t, err)
+
+		err = ValidateServices(doc.Services())
+		require.NoError(t, err)
+	})
 	t.Run("error - missing service id", func(t *testing.T) {
 		doc, err := DidDocumentFromBytes([]byte(serviceDocNoID))
 		require.NoError(t, err)
@@ -134,14 +141,6 @@ func TestValidateServices(t *testing.T) {
 		err = ValidateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service endpoint is missing")
-	})
-	t.Run("error - service has unknown property", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocExtraProperty))
-		require.NoError(t, err)
-
-		err = ValidateServices(doc.Services())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid number of service properties")
 	})
 	t.Run("error - service id too long", func(t *testing.T) {
 		doc, err := DidDocumentFromBytes([]byte(serviceDocLongID))


### PR DESCRIPTION
Currently for service we are checking that we have only id, type and serviceEndpoint properties. Remove this restriction.

Closes #274

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>