### PR TITLE
chore: Remove duplicate/unused fields from operation model

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -37,8 +37,6 @@ type Operation struct {
 	// encoded delta
 	EncodedDelta string `json:"encodedDelta"`
 
-	//HashAlgorithmInMultiHashCode
-	HashAlgorithmInMultiHashCode uint `json:"hashAlgorithmInMultiHashCode"`
 	//The logical blockchain time that this operation was anchored on the blockchain
 	TransactionTime uint64 `json:"transactionTime"`
 	//The transaction number of the transaction this operation was batched within
@@ -50,11 +48,6 @@ type Operation struct {
 	UpdateRevealValue string `json:"updateRevealValue"`
 	// Reveal value for this recovery/deactivate operation
 	RecoveryRevealValue string `json:"recoveryRevealValue"`
-
-	// Hash of reveal value for the next update operation
-	UpdateCommitment string `json:"updateCommitment"`
-	// Hash of reveal value for next recovery/deactivate operation
-	RecoveryCommitment string `json:"recoveryCommitment"`
 }
 
 // OperationType defines valid values for operation type

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -376,14 +376,13 @@ func getCreateOperationWithInitialState(suffixData, delta string) (*batchapi.Ope
 	}
 
 	return &batchapi.Operation{
-		OperationBuffer:              payload,
-		Delta:                        deltaModel,
-		EncodedDelta:                 delta,
-		Type:                         batchapi.OperationTypeCreate,
-		HashAlgorithmInMultiHashCode: sha2_256,
-		UniqueSuffix:                 uniqueSuffix,
-		ID:                           namespace + docutil.NamespaceDelimiter + uniqueSuffix,
-		SuffixData:                   suffixDataModel,
+		Type:            batchapi.OperationTypeCreate,
+		UniqueSuffix:    uniqueSuffix,
+		ID:              namespace + docutil.NamespaceDelimiter + uniqueSuffix,
+		OperationBuffer: payload,
+		Delta:           deltaModel,
+		EncodedDelta:    delta,
+		SuffixData:      suffixDataModel,
 	}, nil
 }
 
@@ -523,11 +522,10 @@ func getUpdateOperation() *batchapi.Operation {
 	}
 
 	return &batchapi.Operation{
-		OperationBuffer:              payload,
-		Type:                         batchapi.OperationTypeUpdate,
-		HashAlgorithmInMultiHashCode: sha2_256,
-		UniqueSuffix:                 request.DidSuffix,
-		ID:                           namespace + docutil.NamespaceDelimiter + request.DidSuffix,
+		OperationBuffer: payload,
+		Type:            batchapi.OperationTypeUpdate,
+		UniqueSuffix:    request.DidSuffix,
+		ID:              namespace + docutil.NamespaceDelimiter + request.DidSuffix,
 	}
 }
 

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -43,15 +43,12 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 	}
 
 	return &batch.Operation{
-		OperationBuffer:              request,
-		Type:                         batch.OperationTypeCreate,
-		UniqueSuffix:                 uniqueSuffix,
-		Delta:                        delta,
-		EncodedDelta:                 schema.Delta,
-		UpdateCommitment:             delta.UpdateCommitment,
-		RecoveryCommitment:           suffixData.RecoveryCommitment,
-		HashAlgorithmInMultiHashCode: code,
-		SuffixData:                   suffixData,
+		OperationBuffer: request,
+		Type:            batch.OperationTypeCreate,
+		UniqueSuffix:    uniqueSuffix,
+		Delta:           delta,
+		EncodedDelta:    schema.Delta,
+		SuffixData:      suffixData,
 	}, nil
 }
 

--- a/pkg/operation/deactivate.go
+++ b/pkg/operation/deactivate.go
@@ -29,12 +29,11 @@ func ParseDeactivateOperation(request []byte, p protocol.Protocol) (*batch.Opera
 	}
 
 	return &batch.Operation{
-		Type:                         batch.OperationTypeDeactivate,
-		OperationBuffer:              request,
-		UniqueSuffix:                 schema.DidSuffix,
-		RecoveryRevealValue:          schema.RecoveryRevealValue,
-		HashAlgorithmInMultiHashCode: p.HashAlgorithmInMultiHashCode,
-		SignedData:                   schema.SignedData,
+		Type:                batch.OperationTypeDeactivate,
+		OperationBuffer:     request,
+		UniqueSuffix:        schema.DidSuffix,
+		RecoveryRevealValue: schema.RecoveryRevealValue,
+		SignedData:          schema.SignedData,
 	}, nil
 }
 

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -31,22 +31,19 @@ func ParseRecoverOperation(request []byte, protocol protocol.Protocol) (*batch.O
 		return nil, err
 	}
 
-	signedData, err := parseSignedDataForRecovery(schema.SignedData.Payload, code)
+	_, err = parseSignedDataForRecovery(schema.SignedData.Payload, code)
 	if err != nil {
 		return nil, err
 	}
 
 	return &batch.Operation{
-		OperationBuffer:              request,
-		Type:                         batch.OperationTypeRecover,
-		UniqueSuffix:                 schema.DidSuffix,
-		Delta:                        delta,
-		EncodedDelta:                 schema.Delta,
-		RecoveryRevealValue:          schema.RecoveryRevealValue,
-		UpdateCommitment:             delta.UpdateCommitment,
-		RecoveryCommitment:           signedData.RecoveryCommitment,
-		HashAlgorithmInMultiHashCode: code,
-		SignedData:                   schema.SignedData,
+		OperationBuffer:     request,
+		Type:                batch.OperationTypeRecover,
+		UniqueSuffix:        schema.DidSuffix,
+		Delta:               delta,
+		EncodedDelta:        schema.Delta,
+		RecoveryRevealValue: schema.RecoveryRevealValue,
+		SignedData:          schema.SignedData,
 	}, nil
 }
 

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -29,15 +29,13 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 	}
 
 	return &batch.Operation{
-		Type:                         batch.OperationTypeUpdate,
-		OperationBuffer:              request,
-		UniqueSuffix:                 schema.DidSuffix,
-		Delta:                        delta,
-		EncodedDelta:                 schema.Delta,
-		UpdateRevealValue:            schema.UpdateRevealValue,
-		UpdateCommitment:             delta.UpdateCommitment,
-		HashAlgorithmInMultiHashCode: protocol.HashAlgorithmInMultiHashCode,
-		SignedData:                   schema.SignedData,
+		Type:              batch.OperationTypeUpdate,
+		OperationBuffer:   request,
+		UniqueSuffix:      schema.DidSuffix,
+		Delta:             delta,
+		EncodedDelta:      schema.Delta,
+		UpdateRevealValue: schema.UpdateRevealValue,
+		SignedData:        schema.SignedData,
 	}, nil
 }
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -171,8 +171,8 @@ func (s *OperationProcessor) applyCreateOperation(operation *batch.Operation, rm
 		Doc:                            doc,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		UpdateCommitment:               operation.UpdateCommitment,
-		RecoveryCommitment:             operation.RecoveryCommitment,
+		UpdateCommitment:               operation.Delta.UpdateCommitment,
+		RecoveryCommitment:             operation.SuffixData.RecoveryCommitment,
 		RecoveryKey:                    operation.SuffixData.RecoveryKey,
 	}, nil
 }
@@ -229,7 +229,7 @@ func (s *OperationProcessor) applyUpdateOperation(operation *batch.Operation, rm
 		Doc:                            doc,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		UpdateCommitment:               operation.UpdateCommitment,
+		UpdateCommitment:               operation.Delta.UpdateCommitment,
 		RecoveryCommitment:             rm.RecoveryCommitment,
 		RecoveryKey:                    rm.RecoveryKey}, nil
 }
@@ -373,8 +373,8 @@ func (s *OperationProcessor) applyRecoverOperation(operation *batch.Operation, r
 		Doc:                            doc,
 		LastOperationTransactionTime:   operation.TransactionTime,
 		LastOperationTransactionNumber: operation.TransactionNumber,
-		UpdateCommitment:               operation.UpdateCommitment,
-		RecoveryCommitment:             operation.RecoveryCommitment,
+		UpdateCommitment:               operation.Delta.UpdateCommitment,
+		RecoveryCommitment:             signedDataModel.RecoveryCommitment,
 		RecoveryKey:                    signedDataModel.RecoveryKey}, nil
 }
 


### PR DESCRIPTION
Update and recovery commitment are already part of delta and signed model.
Hash is part of protocol.

Closes #282

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>