### PR TITLE
refactor: Batch Writer - parse/validate operation buffer

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -68,8 +68,9 @@ const (
 	OperationTypeRecover OperationType = "recover"
 )
 
-// OperationInfo contains the unique suffix as well as the operation payload
+// OperationInfo contains the unique suffix and namespace as well as the operation buffer
 type OperationInfo struct {
 	Data         []byte
 	UniqueSuffix string
+	Namespace    string
 }

--- a/pkg/batch/opqueue/memqueue_test.go
+++ b/pkg/batch/opqueue/memqueue_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	op1 = &batch.OperationInfo{UniqueSuffix: "op1", Data: []byte("op1")}
-	op2 = &batch.OperationInfo{UniqueSuffix: "op2", Data: []byte("op2")}
-	op3 = &batch.OperationInfo{UniqueSuffix: "op3", Data: []byte("op3")}
+	op1 = &batch.OperationInfo{Namespace: "ns", UniqueSuffix: "op1", Data: []byte("op1")}
+	op2 = &batch.OperationInfo{Namespace: "ns", UniqueSuffix: "op2", Data: []byte("op2")}
+	op3 = &batch.OperationInfo{Namespace: "ns", UniqueSuffix: "op3", Data: []byte("op3")}
 )
 
 func TestMemQueue(t *testing.T) {

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -232,14 +232,10 @@ func (r *DocumentHandler) transformToExternalDoc(internal document.Document, id 
 
 // helper namespace for adding operations to the batch
 func (r *DocumentHandler) addToBatch(operation *batch.Operation) error {
-	opBytes, err := docutil.MarshalCanonical(operation)
-	if err != nil {
-		return err
-	}
-
 	return r.writer.Add(&batch.OperationInfo{
+		Namespace:    r.namespace,
 		UniqueSuffix: operation.UniqueSuffix,
-		Data:         opBytes,
+		Data:         operation.OperationBuffer,
 	})
 }
 

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -1,0 +1,56 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+)
+
+// ParseOperation parses and validates operation
+func ParseOperation(namespace string, operationBuffer []byte, protocol protocol.Protocol) (*batch.Operation, error) {
+	schema := &operationSchema{}
+	err := json.Unmarshal(operationBuffer, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	var op *batch.Operation
+	var parseErr error
+	switch schema.Operation {
+	case model.OperationTypeCreate:
+		op, parseErr = ParseCreateOperation(operationBuffer, protocol)
+	case model.OperationTypeUpdate:
+		op, parseErr = ParseUpdateOperation(operationBuffer, protocol)
+	case model.OperationTypeDeactivate:
+		op, parseErr = ParseDeactivateOperation(operationBuffer, protocol)
+	case model.OperationTypeRecover:
+		op, parseErr = ParseRecoverOperation(operationBuffer, protocol)
+	default:
+		return nil, fmt.Errorf("operation type [%s] not implemented", schema.Operation)
+	}
+
+	if parseErr != nil {
+		return nil, parseErr
+	}
+
+	op.ID = namespace + docutil.NamespaceDelimiter + op.UniqueSuffix
+
+	return op, nil
+}
+
+// operationSchema is used to get operation type
+type operationSchema struct {
+
+	// operation
+	Operation model.OperationType `json:"type"`
+}

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+)
+
+const namespace = "did:sidetree"
+
+func TestGetOperation(t *testing.T) {
+	p := protocol.Protocol{
+		HashAlgorithmInMultiHashCode: sha2_256,
+	}
+
+	t.Run("create", func(t *testing.T) {
+		operation, err := getCreateRequestBytes()
+		require.NoError(t, err)
+
+		op, err := ParseOperation(namespace, operation, p)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+	})
+	t.Run("update", func(t *testing.T) {
+		operation, err := getUpdateRequestBytes()
+		require.NoError(t, err)
+
+		op, err := ParseOperation(namespace, operation, p)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+	})
+	t.Run("deactivate", func(t *testing.T) {
+		operation, err := getDeactivateRequestBytes()
+		require.NoError(t, err)
+
+		op, err := ParseOperation(namespace, operation, p)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+	})
+	t.Run("recover", func(t *testing.T) {
+		operation, err := getRecoverRequestBytes()
+		require.NoError(t, err)
+
+		op, err := ParseOperation(namespace, operation, p)
+		require.NoError(t, err)
+		require.NotNil(t, op)
+	})
+	t.Run("operation parsing error", func(t *testing.T) {
+		// set-up invalid hash algorithm in protocol configuration
+		invalid := protocol.Protocol{
+			HashAlgorithmInMultiHashCode: 55,
+		}
+
+		operation, err := getRecoverRequestBytes()
+		require.NoError(t, err)
+
+		op, err := ParseOperation(namespace, operation, invalid)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "next update commitment hash is not computed with the latest supported hash algorithm")
+		require.Nil(t, op)
+	})
+	t.Run("unsupported operation type error", func(t *testing.T) {
+		operation := getUnsupportedRequest()
+		op, err := ParseOperation(namespace, operation, p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not implemented")
+		require.Nil(t, op)
+	})
+}
+
+func getUnsupportedRequest() []byte {
+	schema := &operationSchema{
+		Operation: "unsupported",
+	}
+
+	payload, err := json.Marshal(schema)
+	if err != nil {
+		panic(err)
+	}
+
+	return payload
+}


### PR DESCRIPTION
Batch writer should take as input operation buffer (sidetree request) instead of operation model and parse/validate operation buffer before creating chunk, map and anchor files.

Modify current batch writer code to accept and parse operation buffer (request).
Move common operation parsing code from update handler to operation package.

Closes #284

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>