### PR TITLE
chore: Allow specific optional service properties

### DIFF
--- a/pkg/dochandler/didvalidator/testdata/doc.json
+++ b/pkg/dochandler/didvalidator/testdata/doc.json
@@ -148,6 +148,8 @@
     {
       "id": "hub",
       "type": "IdentityHub",
+      "routingKeys": "routingKeysValue",
+      "recipientKeys": "recipientKeysValue",
       "serviceEndpoint": "https://example.com/hub/"
     }
   ]

--- a/pkg/dochandler/didvalidator/validator.go
+++ b/pkg/dochandler/didvalidator/validator.go
@@ -144,6 +144,13 @@ func processServices(internal document.DIDDocument, resolutionResult *document.R
 		externalService[document.TypeProperty] = sv.Type()
 		externalService[document.ServiceEndpointProperty] = sv.Endpoint()
 
+		for _, prop := range document.GetOptionalServiceProperties() {
+			value, ok := sv[prop]
+			if ok {
+				externalService[prop] = value
+			}
+		}
+
 		services = append(services, externalService)
 	}
 

--- a/pkg/dochandler/didvalidator/validator_test.go
+++ b/pkg/dochandler/didvalidator/validator_test.go
@@ -160,6 +160,8 @@ func TestTransformDocument(t *testing.T) {
 	service := didDoc.Services()[0]
 	require.Contains(t, service.ID(), testID)
 	require.NotEmpty(t, service.Endpoint())
+	require.Equal(t, "recipientKeysValue", service["recipientKeys"])
+	require.Equal(t, "routingKeysValue", service["routingKeys"])
 	require.Equal(t, "IdentityHub", service.Type())
 
 	// validate public keys

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -98,6 +98,30 @@ var allowedKeyTypes = map[string]existenceMap{
 	invocation: allowedKeyTypesVerification,
 }
 
+const (
+	recipientKeys = "recipientKeys"
+	routingKeys   = "routingKeys"
+)
+
+// GetOptionalServiceProperties returns allowed optional properties
+// Note that id, type and service endpoint are required properties
+func GetOptionalServiceProperties() []string {
+	return []string{recipientKeys, routingKeys}
+}
+
+func validateServiceProperty(property string) error {
+	required := []string{IDProperty, TypeProperty, ServiceEndpointProperty}
+	optional := GetOptionalServiceProperties()
+	allowed := append(required, optional...)
+	for _, prop := range allowed {
+		if property == prop {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("property '%s' is not allowed for service", property)
+}
+
 // ValidatePublicKeys validates public keys
 func ValidatePublicKeys(pubKeys []PublicKey) error {
 	ids := make(map[string]string)
@@ -189,6 +213,12 @@ func validateService(service Service) error {
 
 	if err := validateServiceEndpoint(service.Endpoint()); err != nil {
 		return err
+	}
+
+	for key := range service {
+		if err := validateServiceProperty(key); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -110,8 +110,8 @@ func TestValidateServices(t *testing.T) {
 		err = ValidateServices(doc.Services())
 		require.Nil(t, err)
 	})
-	t.Run("success - service can have extra property", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocExtraProperty))
+	t.Run("success - service can have allowed optional property", func(t *testing.T) {
+		doc, err := DidDocumentFromBytes([]byte(serviceDocOptionalProperty))
 		require.NoError(t, err)
 
 		err = ValidateServices(doc.Services())
@@ -125,7 +125,6 @@ func TestValidateServices(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service id is missing")
 	})
-
 	t.Run("error - missing service type", func(t *testing.T) {
 		doc, err := DidDocumentFromBytes([]byte(serviceDocNoType))
 		require.NoError(t, err)
@@ -173,6 +172,14 @@ func TestValidateServices(t *testing.T) {
 		err = ValidateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service endpoint is not valid URI")
+	})
+	t.Run("success - service property not allowed", func(t *testing.T) {
+		doc, err := DidDocumentFromBytes([]byte(serviceDocPropertyNotAllowed))
+		require.NoError(t, err)
+
+		err = ValidateServices(doc.Services())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "property 'test' is not allowed for service")
 	})
 }
 
@@ -641,7 +648,16 @@ const serviceDocNoServiceEndpoint = `{
 	}]
 }`
 
-const serviceDocExtraProperty = `{
+const serviceDocOptionalProperty = `{
+	"service": [{
+		"id": "vcs",
+		"routingKeys": "value",
+		"type": "VerifiableCredentialService",
+		"serviceEndpoint": "https://example.com/vc/"
+	}]
+}`
+
+const serviceDocPropertyNotAllowed = `{
 	"service": [{
 		"id": "vcs",
 		"test": "value",


### PR DESCRIPTION
Allow specific optional service properties to be accepted in add service patch and return those properties in external document.

Closes #288

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>