### PR TITLE
refactor: Don't return removed operations from queue

### DIFF
--- a/pkg/batch/cutter/cutter.go
+++ b/pkg/batch/cutter/cutter.go
@@ -19,9 +19,9 @@ var logger = logrus.New()
 type OperationQueue interface {
 	// Add adds the given operation to the tail of the queue and returns the new length of the queue
 	Add(data *batch.OperationInfo) (uint, error)
-	// Remove removes (up to) the given number of operations from the head of the queue. The operation are returned
-	// along with the new length of the queue.
-	Remove(num uint) ([]*batch.OperationInfo, uint, error)
+	// Remove removes (up to) the given number of items from the head of the queue.
+	// Returns the actual number of items that were removed and the new length of the queue.
+	Remove(num uint) (uint, uint, error)
 	// Peek returns (up to) the given number of operations from the head of the queue but does not remove them.
 	Peek(num uint) ([]*batch.OperationInfo, error)
 	// Len returns the number of operation in the queue

--- a/pkg/batch/opqueue/memqueue.go
+++ b/pkg/batch/opqueue/memqueue.go
@@ -41,8 +41,9 @@ func (q *MemQueue) Peek(num uint) ([]*batch.OperationInfo, error) {
 	return q.items[0:n], nil
 }
 
-// Remove removes (up to) the given number of items from the head of the queue and returns the new length of the queue.
-func (q *MemQueue) Remove(num uint) ([]*batch.OperationInfo, uint, error) {
+// Remove removes (up to) the given number of items from the head of the queue.
+// Returns the actual number of items that were removed and the new length of the queue.
+func (q *MemQueue) Remove(num uint) (uint, uint, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
@@ -54,7 +55,7 @@ func (q *MemQueue) Remove(num uint) ([]*batch.OperationInfo, uint, error) {
 	items := q.items[0:n]
 	q.items = q.items[n:]
 
-	return items, uint(len(q.items)), nil
+	return uint(len(items)), uint(len(q.items)), nil
 }
 
 // Len returns the length of the queue.

--- a/pkg/batch/opqueue/memqueue_test.go
+++ b/pkg/batch/opqueue/memqueue_test.go
@@ -55,10 +55,9 @@ func TestMemQueue(t *testing.T) {
 	require.Equal(t, ops[1], op2)
 	require.Equal(t, ops[2], op3)
 
-	ops, l, err = q.Remove(1)
+	n, l, err := q.Remove(1)
 	require.NoError(t, err)
-	require.Len(t, ops, 1)
-	require.Equal(t, ops[0], op1)
+	require.Equal(t, uint(1), n)
 	require.Equal(t, uint(2), l)
 
 	ops, err = q.Peek(1)
@@ -66,10 +65,8 @@ func TestMemQueue(t *testing.T) {
 	require.Len(t, ops, 1)
 	require.Equal(t, ops[0], op2)
 
-	ops, l, err = q.Remove(5)
+	n, l, err = q.Remove(5)
 	require.NoError(t, err)
-	require.Len(t, ops, 2)
-	require.Equal(t, ops[0], op2)
-	require.Equal(t, ops[1], op3)
+	require.Equal(t, uint(2), n)
 	require.Zero(t, l)
 }

--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -320,7 +320,7 @@ func TestProcessError(t *testing.T) {
 		const numOperations = 3
 		q.LenReturns(numOperations)
 		q.PeekReturns(generateOperations(numOperations), nil)
-		q.RemoveReturns(nil, 1, errExpected)
+		q.RemoveReturns(0, 1, errExpected)
 
 		ctx := newMockContext()
 		ctx.ProtocolClient.Protocol.MaxOperationsPerBatch = 2

--- a/pkg/mocks/operationqueue.gen.go
+++ b/pkg/mocks/operationqueue.gen.go
@@ -21,18 +21,18 @@ type OperationQueue struct {
 		result1 uint
 		result2 error
 	}
-	RemoveStub        func(num uint) ([]*batch.OperationInfo, uint, error)
+	RemoveStub        func(num uint) (uint, uint, error)
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
 		num uint
 	}
 	removeReturns struct {
-		result1 []*batch.OperationInfo
+		result1 uint
 		result2 uint
 		result3 error
 	}
 	removeReturnsOnCall map[int]struct {
-		result1 []*batch.OperationInfo
+		result1 uint
 		result2 uint
 		result3 error
 	}
@@ -113,7 +113,7 @@ func (fake *OperationQueue) AddReturnsOnCall(i int, result1 uint, result2 error)
 	}{result1, result2}
 }
 
-func (fake *OperationQueue) Remove(num uint) ([]*batch.OperationInfo, uint, error) {
+func (fake *OperationQueue) Remove(num uint) (uint, uint, error) {
 	fake.removeMutex.Lock()
 	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
 	fake.removeArgsForCall = append(fake.removeArgsForCall, struct {
@@ -142,26 +142,26 @@ func (fake *OperationQueue) RemoveArgsForCall(i int) uint {
 	return fake.removeArgsForCall[i].num
 }
 
-func (fake *OperationQueue) RemoveReturns(result1 []*batch.OperationInfo, result2 uint, result3 error) {
+func (fake *OperationQueue) RemoveReturns(result1 uint, result2 uint, result3 error) {
 	fake.RemoveStub = nil
 	fake.removeReturns = struct {
-		result1 []*batch.OperationInfo
+		result1 uint
 		result2 uint
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *OperationQueue) RemoveReturnsOnCall(i int, result1 []*batch.OperationInfo, result2 uint, result3 error) {
+func (fake *OperationQueue) RemoveReturnsOnCall(i int, result1 uint, result2 uint, result3 error) {
 	fake.RemoveStub = nil
 	if fake.removeReturnsOnCall == nil {
 		fake.removeReturnsOnCall = make(map[int]struct {
-			result1 []*batch.OperationInfo
+			result1 uint
 			result2 uint
 			result3 error
 		})
 	}
 	fake.removeReturnsOnCall[i] = struct {
-		result1 []*batch.OperationInfo
+		result1 uint
 		result2 uint
 		result3 error
 	}{result1, result2, result3}


### PR DESCRIPTION
The operation queue interface is changed such that Remove function no longer returns the operations that were removed since this could impact performance in the case of a persistent queue implementation.

closes #117

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>