### PR TITLE
feat: transaction handler

### DIFF
--- a/pkg/api/cas/client.go
+++ b/pkg/api/cas/client.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cas
+
+// Client defines interface for accessing the underlying content addressable storage
+type Client interface {
+	// Write writes the given content to CASClient.
+	// returns the SHA256 hash in base64url encoding which represents the address of the content.
+	Write(content []byte) (string, error)
+
+	// Read reads the content of the given address in CASClient.
+	// returns the content of the given address.
+	Read(address string) ([]byte, error)
+}

--- a/pkg/api/txn/sidetree.go
+++ b/pkg/api/txn/sidetree.go
@@ -1,0 +1,14 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package txn
+
+// SidetreeTxn defines info about sidetree transaction
+type SidetreeTxn struct {
+	TransactionTime   uint64
+	TransactionNumber uint64
+	AnchorAddress     string
+}

--- a/pkg/txnhandler/handler.go
+++ b/pkg/txnhandler/handler.go
@@ -1,0 +1,331 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package txnhandler
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler/models"
+)
+
+// Handler creates batch files(chunk, map, anchor) from batch operations
+type Handler struct {
+	cas      cas.Client
+	protocol protocol.Client
+}
+
+// New returns new transaction handler
+func New(cas cas.Client, p protocol.Client) *Handler {
+	return &Handler{cas: cas, protocol: p}
+}
+
+// PrepareTxnFiles will create batch files(chunk, map, anchor) from batch operations,
+// store those files in CAS and return anchor string
+func (h *Handler) PrepareTxnFiles(ops []*batch.Operation) (string, error) {
+	deactivateOps := getOperations(batch.OperationTypeDeactivate, ops)
+
+	// special case: if all ops are deactivate don't create chunk and map files
+	mapFileAddr := ""
+	if len(deactivateOps) != len(ops) {
+		chunkFileAddr, err := h.createChunkFile(ops)
+		if err != nil {
+			return "", err
+		}
+
+		mapFileAddr, err = h.createMapFile([]string{chunkFileAddr}, ops)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	anchorAddr, err := h.createAnchorFile(mapFileAddr, ops)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: Create anchor string issue-293 - for now return anchor address
+	return anchorAddr, nil
+}
+
+// GetTxnOperations will read batch files(Chunk, map, anchor) and assemble batch Operations from those files
+func (h *Handler) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Operation, error) {
+	// TODO: parse anchor file address from address string - issue-293
+	anchorAddress := txn.AnchorAddress
+
+	// TODO: get protocol based on Sidetree transaction - for now use current
+	p := h.protocol.Current()
+
+	af, err := h.getAnchorFile(anchorAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	if af.MapFileHash == "" {
+		// if there's no map file that means that we have only deactivate operations in the batch
+		anchorOps, e := parseAnchorOperations(af, h.protocol.Current())
+		if e != nil {
+			return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
+		}
+
+		return anchorOps.Deactivate, nil
+	}
+
+	mf, err := h.getMapFile(af.MapFileHash)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse map file: key[%s]", af.MapFileHash)
+	}
+
+	chunkAddress := mf.Chunks[0].ChunkFileURI
+	cf, err := h.getChunkFile(chunkAddress)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse chunk file: key[%s]", chunkAddress)
+	}
+
+	return assembleBatchOperations(af, mf, cf, p)
+}
+
+func assembleBatchOperations(af *models.AnchorFile, mf *models.MapFile, cf *models.ChunkFile, p protocol.Protocol) ([]*batch.Operation, error) {
+	anchorOps, err := parseAnchorOperations(af, p)
+	if err != nil {
+		return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
+	}
+
+	log.Debugf("successfully parsed anchor operations: create[%d], recover[%d], deactivate[%d]",
+		len(anchorOps.Create), len(anchorOps.Recover), len(anchorOps.Deactivate))
+
+	mapOps := parseMapOperations(mf)
+
+	log.Debugf("successfully parsed map operations: update[%d]", len(mapOps.Update))
+
+	var operations []*batch.Operation
+	operations = append(operations, anchorOps.Create...)
+	operations = append(operations, anchorOps.Recover...)
+	operations = append(operations, mapOps.Update...)
+	operations = append(operations, anchorOps.Deactivate...)
+
+	// TODO: Add checks here to makes sure that file sizes match - part of validation tickets
+
+	for i, delta := range cf.Deltas {
+		deltaModel, err := operation.ParseDelta(delta, p.HashAlgorithmInMultiHashCode)
+		if err != nil {
+			return nil, fmt.Errorf("parse delta: %s", err.Error())
+		}
+
+		operations[i].EncodedDelta = delta
+		operations[i].Delta = deltaModel
+	}
+
+	return operations, nil
+}
+
+// createAnchorFile will create anchor file from operations and map file and write it to CAS
+// returns anchor file address
+func (h *Handler) createAnchorFile(mapAddress string, ops []*batch.Operation) (string, error) {
+	anchorFile := models.CreateAnchorFile(mapAddress, ops)
+
+	return h.writeModelToCAS(anchorFile, "anchor")
+}
+
+// createChunkFile will create chunk file from operations and write it to CAS
+// returns chunk file address
+func (h *Handler) createChunkFile(ops []*batch.Operation) (string, error) {
+	chunkFile := models.CreateChunkFile(ops)
+
+	return h.writeModelToCAS(chunkFile, "chunk")
+}
+
+// createMapFile will create map file from operations and chunk file URIs and write it to CAS
+// returns map file address
+func (h *Handler) createMapFile(uri []string, ops []*batch.Operation) (string, error) {
+	mapFile := models.CreateMapFile(uri, ops)
+
+	return h.writeModelToCAS(mapFile, "map")
+}
+
+// getAnchorFile will download anchor file from cas and parse it into anchor file model
+func (h *Handler) getAnchorFile(address string) (*models.AnchorFile, error) {
+	content, err := h.cas.Read(address)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve content for anchor file[%s]", address)
+	}
+
+	af, err := models.ParseAnchorFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: verify anchor file - issue-294
+	return af, nil
+}
+
+// getMapFile will download map file from cas and parse it into map file model
+func (h *Handler) getMapFile(address string) (*models.MapFile, error) {
+	content, err := h.cas.Read(address)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve content for map file[%s]", address)
+	}
+
+	mf, err := models.ParseMapFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: verify map file - issue-295
+	return mf, nil
+}
+
+// getChunkFile will download chunk file from cas and parse it into chunk file model
+func (h *Handler) getChunkFile(address string) (*models.ChunkFile, error) {
+	content, err := h.cas.Read(address)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve content for chunk file[%s]", address)
+	}
+
+	cf, err := models.ParseChunkFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: verify chunk file - issue-296
+	return cf, nil
+}
+
+func (h *Handler) writeModelToCAS(model interface{}, alias string) (string, error) {
+	bytes, err := docutil.MarshalCanonical(model)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal %s file: %s", alias, err.Error())
+	}
+
+	log.Debugf("%s file: %s", alias, string(bytes))
+
+	// make file available in CAS
+	address, err := h.cas.Write(bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to store %s file: %s", alias, err.Error())
+	}
+
+	return address, nil
+}
+
+// anchorOperations contains parsed operations from anchor file
+type anchorOperations struct {
+	Create     []*batch.Operation
+	Recover    []*batch.Operation
+	Deactivate []*batch.Operation
+	Suffixes   []string
+}
+
+func parseAnchorOperations(af *models.AnchorFile, p protocol.Protocol) (*anchorOperations, error) { //nolint: funlen
+	var suffixes []string
+
+	var createOps []*batch.Operation
+	for _, op := range af.Operations.Create {
+		suffix, err := docutil.CalculateUniqueSuffix(op.SuffixData, p.HashAlgorithmInMultiHashCode)
+		if err != nil {
+			return nil, err
+		}
+
+		suffixModel, err := operation.ParseSuffixData(op.SuffixData, p.HashAlgorithmInMultiHashCode)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: they are assembling operation buffer in reference implementation (might be easier for version manager)
+		create := &batch.Operation{
+			Type:              batch.OperationTypeCreate,
+			Namespace:         op.Namespace,
+			UniqueSuffix:      suffix,
+			ID:                op.Namespace + docutil.NamespaceDelimiter + suffix,
+			EncodedSuffixData: op.SuffixData,
+			SuffixData:        suffixModel,
+		}
+
+		suffixes = append(suffixes, suffix)
+		createOps = append(createOps, create)
+	}
+
+	var recoverOps []*batch.Operation
+	for _, op := range af.Operations.Recover {
+		recover := &batch.Operation{
+			Type:         batch.OperationTypeRecover,
+			Namespace:    op.Namespace,
+			UniqueSuffix: op.DidSuffix,
+			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
+			SignedData:   op.SignedData,
+		}
+
+		suffixes = append(suffixes, op.DidSuffix)
+		recoverOps = append(recoverOps, recover)
+	}
+
+	var deactivateOps []*batch.Operation
+	for _, op := range af.Operations.Deactivate {
+		deactivate := &batch.Operation{
+			Type:         batch.OperationTypeDeactivate,
+			Namespace:    op.Namespace,
+			UniqueSuffix: op.DidSuffix,
+			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
+			SignedData:   op.SignedData,
+		}
+
+		suffixes = append(suffixes, op.DidSuffix)
+		deactivateOps = append(deactivateOps, deactivate)
+	}
+
+	return &anchorOperations{
+		Create:     createOps,
+		Recover:    recoverOps,
+		Deactivate: deactivateOps,
+		Suffixes:   suffixes,
+	}, nil
+}
+
+// MapOperations contains parsed operations from map file
+type MapOperations struct {
+	Update   []*batch.Operation
+	Suffixes []string
+}
+
+func parseMapOperations(mf *models.MapFile) *MapOperations {
+	var suffixes []string
+
+	var updateOps []*batch.Operation
+	for _, op := range mf.Operations.Update {
+		update := &batch.Operation{
+			Type:         batch.OperationTypeUpdate,
+			Namespace:    op.Namespace,
+			UniqueSuffix: op.DidSuffix,
+			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
+			SignedData:   op.SignedData,
+		}
+
+		suffixes = append(suffixes, op.DidSuffix)
+		updateOps = append(updateOps, update)
+	}
+
+	return &MapOperations{Update: updateOps, Suffixes: suffixes}
+}
+
+func getOperations(filter batch.OperationType, ops []*batch.Operation) []*batch.Operation {
+	var result []*batch.Operation
+	for _, op := range ops {
+		if op.Type == filter {
+			result = append(result, op)
+		}
+	}
+
+	return result
+}

--- a/pkg/txnhandler/handler_test.go
+++ b/pkg/txnhandler/handler_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package txnhandler
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
+	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+	"github.com/trustbloc/sidetree-core-go/pkg/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
+	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler/models"
+	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
+	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+)
+
+const sha2_256 = 18
+
+func TestNew(t *testing.T) {
+	handler := New(mocks.NewMockCasClient(nil), mocks.NewMockProtocolClient())
+	require.NotNil(t, handler)
+}
+
+func TestHandler_PrepareTxnFiles(t *testing.T) {
+	const createOpsNum = 2
+	const recoverOpsNum = 1
+	const deactivateOpsNum = 1
+	const updateOpsNum = 1
+
+	t.Run("success", func(t *testing.T) {
+		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+		handler := New(mocks.NewMockCasClient(nil), mocks.NewMockProtocolClient())
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		bytes, err := handler.cas.Read(anchor)
+		require.NoError(t, err)
+		require.NotNil(t, bytes)
+
+		var af models.AnchorFile
+		err = json.Unmarshal(bytes, &af)
+		require.NoError(t, err)
+		require.NotNil(t, af)
+		require.Equal(t, createOpsNum, len(af.Operations.Create))
+		require.Equal(t, recoverOpsNum, len(af.Operations.Recover))
+		require.Equal(t, deactivateOpsNum, len(af.Operations.Deactivate))
+		require.Equal(t, 0, len(af.Operations.Update))
+
+		bytes, err = handler.cas.Read(af.MapFileHash)
+		require.NoError(t, err)
+		require.NotNil(t, bytes)
+
+		var mf models.MapFile
+		err = json.Unmarshal(bytes, &mf)
+		require.NoError(t, err)
+		require.NotNil(t, mf)
+		require.Equal(t, updateOpsNum, len(mf.Operations.Update))
+		require.Equal(t, 0, len(mf.Operations.Create))
+		require.Equal(t, 0, len(mf.Operations.Recover))
+		require.Equal(t, 0, len(mf.Operations.Deactivate))
+
+		bytes, err = handler.cas.Read(mf.Chunks[0].ChunkFileURI)
+		require.NoError(t, err)
+		require.NotNil(t, bytes)
+
+		var cf models.ChunkFile
+		err = json.Unmarshal(bytes, &cf)
+		require.NoError(t, err)
+		require.NotNil(t, cf)
+		require.Equal(t, createOpsNum+recoverOpsNum+updateOpsNum, len(cf.Deltas))
+	})
+
+	t.Run("error - write to CAS error for chunk file", func(t *testing.T) {
+		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+		handler := New(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClient())
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.Error(t, err)
+		require.Empty(t, anchor)
+		require.Contains(t, err.Error(), "failed to store chunk file: CAS error")
+	})
+
+	t.Run("error - write to CAS error for anchor file", func(t *testing.T) {
+		ops := getTestOperations(0, 0, deactivateOpsNum, 0)
+
+		handler := New(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClient())
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.Error(t, err)
+		require.Empty(t, anchor)
+		require.Contains(t, err.Error(), "failed to store anchor file: CAS error")
+	})
+}
+
+func TestHandler_GetTxnOperations(t *testing.T) {
+	const createOpsNum = 2
+	const updateOpsNum = 3
+	const deactivateOpsNum = 2
+	const recoverOpsNum = 2
+
+	t.Run("success", func(t *testing.T) {
+		handler := New(mocks.NewMockCasClient(nil), mocks.NewMockProtocolClient())
+
+		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		txnOps, err := handler.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     anchor,
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, createOpsNum+updateOpsNum+deactivateOpsNum+recoverOpsNum, len(txnOps))
+	})
+
+	t.Run("error - read from CAS error", func(t *testing.T) {
+		handler := New(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClient())
+
+		txnOps, err := handler.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     "anchor",
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.Error(t, err)
+		require.Nil(t, txnOps)
+		require.Contains(t, err.Error(), "failed to retrieve content for anchor file[anchor]")
+	})
+
+	t.Run("error - parse anchor operations error", func(t *testing.T) {
+		pc := mocks.NewMockProtocolClient()
+		pc.Protocol = protocol.Protocol{
+			HashAlgorithmInMultiHashCode: 55,
+		}
+		handler := New(mocks.NewMockCasClient(nil), pc)
+
+		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		txnOps, err := handler.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     anchor,
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.Error(t, err)
+		require.Nil(t, txnOps)
+		require.Contains(t, err.Error(), "parse anchor operations: algorithm not supported")
+	})
+
+	t.Run("success - deactivate only", func(t *testing.T) {
+		const deactivateOpsNum = 2
+
+		var ops []*batch.Operation
+		ops = append(ops, generateOperations(deactivateOpsNum, batch.OperationTypeDeactivate)...)
+
+		handler := New(mocks.NewMockCasClient(nil),
+			mocks.NewMockProtocolClient())
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		txnOps, err := handler.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     anchor,
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, deactivateOpsNum, len(txnOps))
+	})
+}
+
+func TestWriteModelToCAS(t *testing.T) {
+	handler := New(mocks.NewMockCasClient(nil),
+		mocks.NewMockProtocolClient())
+
+	t.Run("success", func(t *testing.T) {
+		address, err := handler.writeModelToCAS(&models.AnchorFile{}, "alias")
+		require.NoError(t, err)
+		require.NotEmpty(t, address)
+	})
+
+	t.Run("error - marshal fails", func(t *testing.T) {
+		address, err := handler.writeModelToCAS("test", "alias")
+		require.Error(t, err)
+		require.Empty(t, address)
+		require.Contains(t, err.Error(), "failed to marshal alias file")
+	})
+
+	t.Run("error - CAS error", func(t *testing.T) {
+		handlerWithCASError := New(mocks.NewMockCasClient(errors.New("CAS error")),
+			mocks.NewMockProtocolClient())
+
+		address, err := handlerWithCASError.writeModelToCAS(&models.AnchorFile{}, "alias")
+		require.Error(t, err)
+		require.Empty(t, address)
+		require.Contains(t, err.Error(), "failed to store alias file: CAS error")
+	})
+}
+
+func getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum int) []*batch.Operation {
+	var ops []*batch.Operation
+	ops = append(ops, generateOperations(createOpsNum, batch.OperationTypeCreate)...)
+	ops = append(ops, generateOperations(recoverOpsNum, batch.OperationTypeRecover)...)
+	ops = append(ops, generateOperations(deactivateOpsNum, batch.OperationTypeDeactivate)...)
+	ops = append(ops, generateOperations(updateOpsNum, batch.OperationTypeUpdate)...)
+
+	return ops
+}
+
+func generateOperations(numOfOperations int, opType batch.OperationType) (ops []*batch.Operation) {
+	for j := 1; j <= numOfOperations; j++ {
+		op, err := generateOperation(j, opType)
+		if err != nil {
+			panic(err)
+		}
+
+		ops = append(ops, op)
+	}
+	return
+}
+
+func generateOperation(num int, opType batch.OperationType) (*batch.Operation, error) {
+	switch opType {
+	case batch.OperationTypeCreate:
+		return generateCreateOperation(num)
+	case batch.OperationTypeRecover:
+		return generateRecoverOperation(num)
+	case batch.OperationTypeDeactivate:
+		return generateDeactivateOperation(num)
+	case batch.OperationTypeUpdate:
+		return generateUpdateOperation(num)
+	}
+
+	return nil, errors.New("operation type not supported")
+}
+
+func generateCreateOperation(num int) (*batch.Operation, error) {
+	doc := fmt.Sprintf(`{"test":%d}`, num)
+	info := &helper.CreateRequestInfo{OpaqueDocument: doc,
+		RecoveryKey: &jws.JWK{
+			Crv: "crv",
+			Kty: "kty",
+			X:   "x",
+		},
+		MultihashCode: sha2_256}
+
+	request, err := helper.NewCreateRequest(info)
+	if err != nil {
+		return nil, err
+	}
+
+	return operation.ParseOperation("ns", request, mocks.NewMockProtocolClient().Current())
+}
+
+func generateRecoverOperation(num int) (*batch.Operation, error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	jwk, err := pubkey.GetPublicKeyJWK(&privKey.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &helper.RecoverRequestInfo{
+		DidSuffix:      fmt.Sprintf("did:sidetree:recover-%d", num),
+		OpaqueDocument: `{"test":"value"}`,
+		RecoveryKey:    jwk,
+		MultihashCode:  sha2_256,
+		Signer:         ecsigner.New(privKey, "ES256", "")}
+
+	request, err := helper.NewRecoverRequest(info)
+	if err != nil {
+		return nil, err
+	}
+	return operation.ParseOperation("did:sidetree", request, mocks.NewMockProtocolClient().Current())
+}
+
+func generateDeactivateOperation(num int) (*batch.Operation, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &helper.DeactivateRequestInfo{
+		DidSuffix: fmt.Sprintf("did:sidetree:deactivate-%d", num),
+		Signer:    ecsigner.New(privateKey, "ES256", "")}
+
+	request, err := helper.NewDeactivateRequest(info)
+	if err != nil {
+		return nil, err
+	}
+
+	return operation.ParseOperation("did:sidetree", request, mocks.NewMockProtocolClient().Current())
+}
+
+func generateUpdateOperation(num int) (*batch.Operation, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	testPatch, err := getTestPatch()
+	if err != nil {
+		return nil, err
+	}
+
+	info := &helper.UpdateRequestInfo{
+		DidSuffix:     fmt.Sprintf("did:sidetree:update-%d", num),
+		Signer:        ecsigner.New(privateKey, "ES256", "key-1"),
+		Patch:         testPatch,
+		MultihashCode: sha2_256,
+	}
+
+	request, err := helper.NewUpdateRequest(info)
+	if err != nil {
+		return nil, err
+	}
+
+	return operation.ParseOperation("did:sidetree", request, mocks.NewMockProtocolClient().Current())
+}
+
+func getTestPatch() (patch.Patch, error) {
+	return patch.NewJSONPatch(`[{"op": "replace", "path": "/name", "value": "Jane"}]`)
+}

--- a/pkg/txnhandler/models/anchor.go
+++ b/pkg/txnhandler/models/anchor.go
@@ -1,0 +1,106 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+)
+
+// AnchorFile defines the schema of an anchor file
+type AnchorFile struct {
+	// MapFileHash is encoded hash of the map file
+	MapFileHash string `json:"mapFileHash,omitempty"`
+
+	// Operations contain proving data for create, recover and deactivate operations
+	Operations Operations `json:"Operations"`
+}
+
+//CreateOperation contains create operation data
+type CreateOperation struct {
+	// Encoded suffix data object
+	SuffixData string `json:"suffix_data"`
+
+	// Namespace refers to document namespace
+	// Note: namespace is an optional attribute (currently not part of spec)
+	Namespace string `json:"namespace"`
+}
+
+//SignedOperation contains operation proving data
+type SignedOperation struct {
+	// Namespace refers to document namespace
+	// Note: namespace is an optional attribute (currently not part of spec)
+	Namespace string `json:"namespace"`
+
+	//The suffix of the DID
+	DidSuffix string `json:"did_suffix"`
+
+	// Compact JWS
+	SignedData string `json:"signed_data"`
+}
+
+// Operations contains operation proving data
+type Operations struct {
+	Create     []CreateOperation `json:"create,omitempty"`
+	Update     []SignedOperation `json:"update,omitempty"`
+	Recover    []SignedOperation `json:"recover,omitempty"`
+	Deactivate []SignedOperation `json:"deactivate,omitempty"`
+}
+
+// CreateAnchorFile will create anchor file from provided operations
+// returns anchor file model
+func CreateAnchorFile(mapAddress string, ops []*batch.Operation) *AnchorFile {
+	return &AnchorFile{
+		MapFileHash: mapAddress,
+		Operations: Operations{
+			Create:     getCreateOperations(ops),
+			Recover:    getSignedOperations(batch.OperationTypeRecover, ops),
+			Deactivate: getSignedOperations(batch.OperationTypeDeactivate, ops),
+		},
+	}
+}
+
+func getCreateOperations(ops []*batch.Operation) []CreateOperation {
+	var result []CreateOperation
+	for _, op := range ops {
+		if op.Type == batch.OperationTypeCreate {
+			create := CreateOperation{SuffixData: op.EncodedSuffixData}
+
+			result = append(result, create)
+		}
+	}
+
+	return result
+}
+
+// ParseAnchorFile will parse anchor model from content
+func ParseAnchorFile(content []byte) (*AnchorFile, error) {
+	af, err := getAnchorFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Verify anchor file - issue-294
+	return af, nil
+}
+
+// getAnchorFile creates new anchor file struct from bytes
+var getAnchorFile = func(bytes []byte) (*AnchorFile, error) {
+	return unmarshalAnchorFile(bytes)
+}
+
+// unmarshalAnchorFile creates new anchor file struct from bytes
+func unmarshalAnchorFile(bytes []byte) (*AnchorFile, error) {
+	file := &AnchorFile{}
+	err := json.Unmarshal(bytes, file)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/pkg/txnhandler/models/anchor_test.go
+++ b/pkg/txnhandler/models/anchor_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+)
+
+func TestCreateAnchorFile(t *testing.T) {
+	const createOpsNum = 2
+	const updateOpsNum = 2
+	const deactivateOpsNum = 2
+	const recoverOpsNum = 2
+
+	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+	af := CreateAnchorFile("address", ops)
+	require.NotNil(t, af)
+	require.Equal(t, createOpsNum, len(af.Operations.Create))
+	require.Equal(t, 0, len(af.Operations.Update))
+	require.Equal(t, deactivateOpsNum, len(af.Operations.Deactivate))
+	require.Equal(t, recoverOpsNum, len(af.Operations.Recover))
+}
+
+func TestParseAnchorFile(t *testing.T) {
+	const createOpsNum = 5
+	const updateOpsNum = 4
+	const deactivateOpsNum = 3
+	const recoverOpsNum = 1
+
+	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+	model := CreateAnchorFile("address", ops)
+
+	bytes, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	parsed, err := ParseAnchorFile(bytes)
+	require.NoError(t, err)
+
+	require.Equal(t, createOpsNum, len(parsed.Operations.Create))
+	require.Equal(t, 0, len(parsed.Operations.Update))
+	require.Equal(t, deactivateOpsNum, len(parsed.Operations.Deactivate))
+	require.Equal(t, recoverOpsNum, len(parsed.Operations.Recover))
+}
+
+func getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum int) []*batch.Operation {
+	var ops []*batch.Operation
+	ops = append(ops, generateOperations(createOpsNum, batch.OperationTypeCreate)...)
+	ops = append(ops, generateOperations(recoverOpsNum, batch.OperationTypeRecover)...)
+	ops = append(ops, generateOperations(deactivateOpsNum, batch.OperationTypeDeactivate)...)
+	ops = append(ops, generateOperations(updateOpsNum, batch.OperationTypeUpdate)...)
+
+	return ops
+}
+
+func generateOperations(numOfOperations int, opType batch.OperationType) (ops []*batch.Operation) {
+	for j := 1; j <= numOfOperations; j++ {
+		ops = append(ops, generateOperation(j, opType))
+	}
+	return
+}
+
+func generateOperation(num int, opType batch.OperationType) *batch.Operation {
+	return &batch.Operation{
+		Type:              opType,
+		UniqueSuffix:      fmt.Sprintf("%s-%d", opType, num),
+		Namespace:         "did:sidetree",
+		EncodedSuffixData: "suffix-data",
+		EncodedDelta:      "delta",
+		SignedData:        "signed-data",
+	}
+}

--- a/pkg/txnhandler/models/chunk.go
+++ b/pkg/txnhandler/models/chunk.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+)
+
+// ChunkFile defines chunk file schema
+type ChunkFile struct {
+	// Deltas included in this chunk file, each delta is an encoded string
+	Deltas []string `json:"deltas"`
+}
+
+// CreateChunkFile will combine all operation deltas into chunk file
+// returns chunk file model
+func CreateChunkFile(ops []*batch.Operation) *ChunkFile {
+	var deltas []string
+
+	deltas = append(deltas, getDeltas(batch.OperationTypeCreate, ops)...)
+	deltas = append(deltas, getDeltas(batch.OperationTypeRecover, ops)...)
+	deltas = append(deltas, getDeltas(batch.OperationTypeUpdate, ops)...)
+
+	return &ChunkFile{Deltas: deltas}
+}
+
+// ParseChunkFile will parse chunk file model from content
+func ParseChunkFile(content []byte) (*ChunkFile, error) {
+	cf, err := getChunkFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Verify chunk file - issue-296
+	return cf, nil
+}
+
+func getDeltas(filter batch.OperationType, ops []*batch.Operation) []string {
+	var deltas []string
+	for _, op := range ops {
+		if op.Type == filter {
+			deltas = append(deltas, op.EncodedDelta)
+		}
+	}
+
+	return deltas
+}
+
+// get chunk file struct from bytes
+var getChunkFile = func(bytes []byte) (*ChunkFile, error) {
+	return unmarshalChunkFile(bytes)
+}
+
+// unmarshal chunk file bytes into chunk file model
+func unmarshalChunkFile(bytes []byte) (*ChunkFile, error) {
+	file := &ChunkFile{}
+	err := json.Unmarshal(bytes, file)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/pkg/txnhandler/models/chunk_test.go
+++ b/pkg/txnhandler/models/chunk_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandler_CreateChunkFile(t *testing.T) {
+	const createOpsNum = 5
+	const updateOpsNum = 4
+	const deactivateOpsNum = 3
+	const recoverOpsNum = 1
+
+	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+	chunk := CreateChunkFile(ops)
+	require.NotNil(t, chunk)
+	require.Equal(t, createOpsNum+updateOpsNum+recoverOpsNum, len(chunk.Deltas))
+}
+
+func TestParseChunkFile(t *testing.T) {
+	const createOpsNum = 5
+	const updateOpsNum = 4
+	const deactivateOpsNum = 3
+	const recoverOpsNum = 1
+
+	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+	model := CreateChunkFile(ops)
+	bytes, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	parsed, err := ParseChunkFile(bytes)
+	require.NoError(t, err)
+
+	require.Equal(t, createOpsNum+updateOpsNum+recoverOpsNum, len(parsed.Deltas))
+}

--- a/pkg/txnhandler/models/map.go
+++ b/pkg/txnhandler/models/map.go
@@ -1,0 +1,90 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+)
+
+// MapFile defines the schema for map file and its related operations
+type MapFile struct {
+	Chunks     []Chunk    `json:"chunks"`
+	Operations Operations `json:"Operations,omitempty"`
+}
+
+// Chunk holds chunk file URI
+type Chunk struct {
+	ChunkFileURI string `json:"chunk_file_uri"`
+}
+
+// CreateMapFile will create map file model from operations and chunk file URI
+// returns chunk file model
+func CreateMapFile(uri []string, ops []*batch.Operation) *MapFile {
+	return &MapFile{
+		Chunks: getChunks(uri),
+		Operations: Operations{
+			Update: getSignedOperations(batch.OperationTypeUpdate, ops),
+		},
+	}
+}
+
+// ParseMapFile will parse map file model from content
+func ParseMapFile(content []byte) (*MapFile, error) {
+	mf, err := getMapFile(content)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Verify map file - issue-295
+	return mf, nil
+}
+
+func getChunks(uris []string) []Chunk {
+	var chunks []Chunk
+	for _, uri := range uris {
+		chunks = append(chunks, Chunk{
+			ChunkFileURI: uri,
+		})
+	}
+
+	return chunks
+}
+
+func getSignedOperations(filter batch.OperationType, ops []*batch.Operation) []SignedOperation {
+	var result []SignedOperation
+	for _, op := range ops {
+		if op.Type == filter {
+			upd := SignedOperation{
+				DidSuffix:  op.UniqueSuffix,
+				SignedData: op.SignedData,
+				Namespace:  op.Namespace,
+			}
+
+			result = append(result, upd)
+		}
+	}
+
+	return result
+}
+
+//  get map file struct from bytes
+var getMapFile = func(bytes []byte) (*MapFile, error) {
+	return unmarshalMapFile(bytes)
+}
+
+// unmarshal map file bytes into map file model
+func unmarshalMapFile(bytes []byte) (*MapFile, error) {
+	file := &MapFile{}
+	err := json.Unmarshal(bytes, file)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}

--- a/pkg/txnhandler/models/map_test.go
+++ b/pkg/txnhandler/models/map_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandler_CreateMapFile(t *testing.T) {
+	const createOpsNum = 2
+	const updateOpsNum = 2
+	const deactivateOpsNum = 2
+	const recoverOpsNum = 2
+
+	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+	chunks := []string{"chunk_uri"}
+	batch := CreateMapFile(chunks, ops)
+	require.NotNil(t, batch)
+	require.Equal(t, updateOpsNum, len(batch.Operations.Update))
+	require.Equal(t, 0, len(batch.Operations.Create))
+	require.Equal(t, 0, len(batch.Operations.Deactivate))
+	require.Equal(t, 0, len(batch.Operations.Recover))
+}
+
+func TestHandler_ParseMapFile(t *testing.T) {
+	const createOpsNum = 2
+	const updateOpsNum = 2
+	const deactivateOpsNum = 2
+	const recoverOpsNum = 2
+
+	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+	chunks := []string{"chunk_uri"}
+	model := CreateMapFile(chunks, ops)
+
+	bytes, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	parsed, err := ParseMapFile(bytes)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(parsed.Operations.Create))
+	require.Equal(t, updateOpsNum, len(parsed.Operations.Update))
+	require.Equal(t, 0, len(parsed.Operations.Deactivate))
+	require.Equal(t, 0, len(parsed.Operations.Recover))
+}


### PR DESCRIPTION
Transaction handler will:
-- prepare batch files(map, chunk, anchor) from batch operations for Sidetree transaction
-- parse operations from Sidetree transaction batch files(map, chunk, anchor) during observations time

Also, moved CAS interface and Sidetree txn definition to common api section

Closes #304

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>