### PR TITLE
refactor: Enable protocol client per namespace for observer

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -24,3 +24,8 @@ type Client interface {
 	// Current returns latest version of protocol
 	Current() Protocol
 }
+
+// ClientProvider returns a protocol client for the given namespace
+type ClientProvider interface {
+	ForNamespace(namespace string) (Client, error)
+}

--- a/pkg/batch/writer.go
+++ b/pkg/batch/writer.go
@@ -112,7 +112,7 @@ func New(name string, context Context, options ...Option) (*Writer, error) {
 	if rOpts.OpsHandler != nil {
 		txnHandler = rOpts.OpsHandler
 	} else {
-		txnHandler = txnhandler.New(context.CAS(), context.Protocol())
+		txnHandler = txnhandler.NewOperationHandler(context.CAS())
 	}
 
 	return &Writer{

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -7,8 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package mocks
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 )
+
+// DefaultNS is default namespace used in mocks
+const DefaultNS = "did:sidetree"
 
 // MockProtocolClient mocks protocol for testing purposes.
 type MockProtocolClient struct {
@@ -31,4 +36,29 @@ func NewMockProtocolClient() *MockProtocolClient {
 // Current mocks getting last protocol version
 func (m *MockProtocolClient) Current() protocol.Protocol {
 	return m.Protocol
+}
+
+// NewMockProtocolClientProvider creates new mock protocol client provider
+func NewMockProtocolClientProvider() *MockProtocolClientProvider {
+	m := make(map[string]protocol.Client)
+
+	m[DefaultNS] = NewMockProtocolClient()
+	return &MockProtocolClientProvider{
+		ProtocolClients: m,
+	}
+}
+
+// MockProtocolClientProvider implements mock protocol client provider
+type MockProtocolClientProvider struct {
+	ProtocolClients map[string]protocol.Client
+}
+
+// ForNamespace will return protocol client for that namespace
+func (m *MockProtocolClientProvider) ForNamespace(namespace string) (protocol.Client, error) {
+	pc, ok := m.ProtocolClients[namespace]
+	if !ok {
+		return nil, errors.Errorf("protocol client not found for namespace [%s]", namespace)
+	}
+
+	return pc, nil
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler"
 )
 
 var logger = logrus.New()
@@ -118,7 +117,6 @@ func (o *Observer) process(txns []txn.SidetreeTxn) {
 // TxnProcessor processes Sidetree transactions by persisting them to an operation store
 type TxnProcessor struct {
 	*Providers
-	txnhandler.Handler
 }
 
 // NewTxnProcessor returns a new document operation processor

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -37,7 +37,7 @@ func TestStartObserver(t *testing.T) {
 
 		providers := &Providers{
 			Ledger:           mockLedger{registerForSidetreeTxnValue: sidetreeTxnCh},
-			TxnOpsProvider:   txnhandler.New(&mockDCAS{readFunc: readFunc}, mocks.NewMockProtocolClient()),
+			TxnOpsProvider:   txnhandler.NewOperationProvider(&mockDCAS{readFunc: readFunc}, mocks.NewMockProtocolClientProvider()),
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 

--- a/pkg/txnhandler/handler.go
+++ b/pkg/txnhandler/handler.go
@@ -9,32 +9,27 @@ package txnhandler
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler/models"
 )
 
-// Handler creates batch files(chunk, map, anchor) from batch operations
-type Handler struct {
-	cas      cas.Client
-	protocol protocol.Client
+// OperationHandler creates batch files(chunk, map, anchor) from batch operations
+type OperationHandler struct {
+	cas cas.Client
 }
 
-// New returns new transaction handler
-func New(cas cas.Client, p protocol.Client) *Handler {
-	return &Handler{cas: cas, protocol: p}
+// NewOperationHandler returns new operations handler
+func NewOperationHandler(cas cas.Client) *OperationHandler {
+	return &OperationHandler{cas: cas}
 }
 
 // PrepareTxnFiles will create batch files(chunk, map, anchor) from batch operations,
 // store those files in CAS and return anchor string
-func (h *Handler) PrepareTxnFiles(ops []*batch.Operation) (string, error) {
+func (h *OperationHandler) PrepareTxnFiles(ops []*batch.Operation) (string, error) {
 	deactivateOps := getOperations(batch.OperationTypeDeactivate, ops)
 
 	// special case: if all ops are deactivate don't create chunk and map files
@@ -60,80 +55,9 @@ func (h *Handler) PrepareTxnFiles(ops []*batch.Operation) (string, error) {
 	return anchorAddr, nil
 }
 
-// GetTxnOperations will read batch files(Chunk, map, anchor) and assemble batch Operations from those files
-func (h *Handler) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Operation, error) {
-	// TODO: parse anchor file address from address string - issue-293
-	anchorAddress := txn.AnchorAddress
-
-	// TODO: get protocol based on Sidetree transaction - for now use current
-	p := h.protocol.Current()
-
-	af, err := h.getAnchorFile(anchorAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	if af.MapFileHash == "" {
-		// if there's no map file that means that we have only deactivate operations in the batch
-		anchorOps, e := parseAnchorOperations(af, h.protocol.Current())
-		if e != nil {
-			return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
-		}
-
-		return anchorOps.Deactivate, nil
-	}
-
-	mf, err := h.getMapFile(af.MapFileHash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse map file: key[%s]", af.MapFileHash)
-	}
-
-	chunkAddress := mf.Chunks[0].ChunkFileURI
-	cf, err := h.getChunkFile(chunkAddress)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse chunk file: key[%s]", chunkAddress)
-	}
-
-	return assembleBatchOperations(af, mf, cf, p)
-}
-
-func assembleBatchOperations(af *models.AnchorFile, mf *models.MapFile, cf *models.ChunkFile, p protocol.Protocol) ([]*batch.Operation, error) {
-	anchorOps, err := parseAnchorOperations(af, p)
-	if err != nil {
-		return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
-	}
-
-	log.Debugf("successfully parsed anchor operations: create[%d], recover[%d], deactivate[%d]",
-		len(anchorOps.Create), len(anchorOps.Recover), len(anchorOps.Deactivate))
-
-	mapOps := parseMapOperations(mf)
-
-	log.Debugf("successfully parsed map operations: update[%d]", len(mapOps.Update))
-
-	var operations []*batch.Operation
-	operations = append(operations, anchorOps.Create...)
-	operations = append(operations, anchorOps.Recover...)
-	operations = append(operations, mapOps.Update...)
-	operations = append(operations, anchorOps.Deactivate...)
-
-	// TODO: Add checks here to makes sure that file sizes match - part of validation tickets
-
-	for i, delta := range cf.Deltas {
-		deltaModel, err := operation.ParseDelta(delta, p.HashAlgorithmInMultiHashCode)
-		if err != nil {
-			return nil, fmt.Errorf("parse delta: %s", err.Error())
-		}
-
-		operations[i].EncodedDelta = delta
-		operations[i].Delta = deltaModel
-	}
-
-	return operations, nil
-}
-
 // createAnchorFile will create anchor file from operations and map file and write it to CAS
 // returns anchor file address
-func (h *Handler) createAnchorFile(mapAddress string, ops []*batch.Operation) (string, error) {
+func (h *OperationHandler) createAnchorFile(mapAddress string, ops []*batch.Operation) (string, error) {
 	anchorFile := models.CreateAnchorFile(mapAddress, ops)
 
 	return h.writeModelToCAS(anchorFile, "anchor")
@@ -141,7 +65,7 @@ func (h *Handler) createAnchorFile(mapAddress string, ops []*batch.Operation) (s
 
 // createChunkFile will create chunk file from operations and write it to CAS
 // returns chunk file address
-func (h *Handler) createChunkFile(ops []*batch.Operation) (string, error) {
+func (h *OperationHandler) createChunkFile(ops []*batch.Operation) (string, error) {
 	chunkFile := models.CreateChunkFile(ops)
 
 	return h.writeModelToCAS(chunkFile, "chunk")
@@ -149,61 +73,13 @@ func (h *Handler) createChunkFile(ops []*batch.Operation) (string, error) {
 
 // createMapFile will create map file from operations and chunk file URIs and write it to CAS
 // returns map file address
-func (h *Handler) createMapFile(uri []string, ops []*batch.Operation) (string, error) {
+func (h *OperationHandler) createMapFile(uri []string, ops []*batch.Operation) (string, error) {
 	mapFile := models.CreateMapFile(uri, ops)
 
 	return h.writeModelToCAS(mapFile, "map")
 }
 
-// getAnchorFile will download anchor file from cas and parse it into anchor file model
-func (h *Handler) getAnchorFile(address string) (*models.AnchorFile, error) {
-	content, err := h.cas.Read(address)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve content for anchor file[%s]", address)
-	}
-
-	af, err := models.ParseAnchorFile(content)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: verify anchor file - issue-294
-	return af, nil
-}
-
-// getMapFile will download map file from cas and parse it into map file model
-func (h *Handler) getMapFile(address string) (*models.MapFile, error) {
-	content, err := h.cas.Read(address)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve content for map file[%s]", address)
-	}
-
-	mf, err := models.ParseMapFile(content)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: verify map file - issue-295
-	return mf, nil
-}
-
-// getChunkFile will download chunk file from cas and parse it into chunk file model
-func (h *Handler) getChunkFile(address string) (*models.ChunkFile, error) {
-	content, err := h.cas.Read(address)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve content for chunk file[%s]", address)
-	}
-
-	cf, err := models.ParseChunkFile(content)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: verify chunk file - issue-296
-	return cf, nil
-}
-
-func (h *Handler) writeModelToCAS(model interface{}, alias string) (string, error) {
+func (h *OperationHandler) writeModelToCAS(model interface{}, alias string) (string, error) {
 	bytes, err := docutil.MarshalCanonical(model)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal %s file: %s", alias, err.Error())
@@ -218,114 +94,4 @@ func (h *Handler) writeModelToCAS(model interface{}, alias string) (string, erro
 	}
 
 	return address, nil
-}
-
-// anchorOperations contains parsed operations from anchor file
-type anchorOperations struct {
-	Create     []*batch.Operation
-	Recover    []*batch.Operation
-	Deactivate []*batch.Operation
-	Suffixes   []string
-}
-
-func parseAnchorOperations(af *models.AnchorFile, p protocol.Protocol) (*anchorOperations, error) { //nolint: funlen
-	var suffixes []string
-
-	var createOps []*batch.Operation
-	for _, op := range af.Operations.Create {
-		suffix, err := docutil.CalculateUniqueSuffix(op.SuffixData, p.HashAlgorithmInMultiHashCode)
-		if err != nil {
-			return nil, err
-		}
-
-		suffixModel, err := operation.ParseSuffixData(op.SuffixData, p.HashAlgorithmInMultiHashCode)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO: they are assembling operation buffer in reference implementation (might be easier for version manager)
-		create := &batch.Operation{
-			Type:              batch.OperationTypeCreate,
-			Namespace:         op.Namespace,
-			UniqueSuffix:      suffix,
-			ID:                op.Namespace + docutil.NamespaceDelimiter + suffix,
-			EncodedSuffixData: op.SuffixData,
-			SuffixData:        suffixModel,
-		}
-
-		suffixes = append(suffixes, suffix)
-		createOps = append(createOps, create)
-	}
-
-	var recoverOps []*batch.Operation
-	for _, op := range af.Operations.Recover {
-		recover := &batch.Operation{
-			Type:         batch.OperationTypeRecover,
-			Namespace:    op.Namespace,
-			UniqueSuffix: op.DidSuffix,
-			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
-			SignedData:   op.SignedData,
-		}
-
-		suffixes = append(suffixes, op.DidSuffix)
-		recoverOps = append(recoverOps, recover)
-	}
-
-	var deactivateOps []*batch.Operation
-	for _, op := range af.Operations.Deactivate {
-		deactivate := &batch.Operation{
-			Type:         batch.OperationTypeDeactivate,
-			Namespace:    op.Namespace,
-			UniqueSuffix: op.DidSuffix,
-			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
-			SignedData:   op.SignedData,
-		}
-
-		suffixes = append(suffixes, op.DidSuffix)
-		deactivateOps = append(deactivateOps, deactivate)
-	}
-
-	return &anchorOperations{
-		Create:     createOps,
-		Recover:    recoverOps,
-		Deactivate: deactivateOps,
-		Suffixes:   suffixes,
-	}, nil
-}
-
-// MapOperations contains parsed operations from map file
-type MapOperations struct {
-	Update   []*batch.Operation
-	Suffixes []string
-}
-
-func parseMapOperations(mf *models.MapFile) *MapOperations {
-	var suffixes []string
-
-	var updateOps []*batch.Operation
-	for _, op := range mf.Operations.Update {
-		update := &batch.Operation{
-			Type:         batch.OperationTypeUpdate,
-			Namespace:    op.Namespace,
-			UniqueSuffix: op.DidSuffix,
-			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
-			SignedData:   op.SignedData,
-		}
-
-		suffixes = append(suffixes, op.DidSuffix)
-		updateOps = append(updateOps, update)
-	}
-
-	return &MapOperations{Update: updateOps, Suffixes: suffixes}
-}
-
-func getOperations(filter batch.OperationType, ops []*batch.Operation) []*batch.Operation {
-	var result []*batch.Operation
-	for _, op := range ops {
-		if op.Type == filter {
-			result = append(result, op)
-		}
-	}
-
-	return result
 }

--- a/pkg/txnhandler/models/anchor.go
+++ b/pkg/txnhandler/models/anchor.go
@@ -69,7 +69,7 @@ func getCreateOperations(ops []*batch.Operation) []CreateOperation {
 	var result []CreateOperation
 	for _, op := range ops {
 		if op.Type == batch.OperationTypeCreate {
-			create := CreateOperation{SuffixData: op.EncodedSuffixData}
+			create := CreateOperation{SuffixData: op.EncodedSuffixData, Namespace: op.Namespace}
 
 			result = append(result, create)
 		}

--- a/pkg/txnhandler/provider.go
+++ b/pkg/txnhandler/provider.go
@@ -1,0 +1,287 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package txnhandler
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler/models"
+)
+
+// DCAS interface to access content addressable storage
+type DCAS interface {
+	Read(key string) ([]byte, error)
+}
+
+// OperationProvider assembles batch operations from batch files
+type OperationProvider struct {
+	cas DCAS
+	pcp protocol.ClientProvider
+}
+
+// NewOperationProvider returns new operation provider
+func NewOperationProvider(cas DCAS, pcp protocol.ClientProvider) *OperationProvider {
+	return &OperationProvider{cas: cas, pcp: pcp}
+}
+
+// GetTxnOperations will read batch files(Chunk, map, anchor) and assemble batch Operations from those files
+func (h *OperationProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Operation, error) {
+	// TODO: parse anchor file address from address string - issue-293
+	anchorAddress := txn.AnchorAddress
+
+	af, err := h.getAnchorFile(anchorAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	if af.MapFileHash == "" {
+		// if there's no map file that means that we have only deactivate operations in the batch
+		anchorOps, e := h.parseAnchorOperations(af, txn)
+		if e != nil {
+			return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
+		}
+
+		return anchorOps.Deactivate, nil
+	}
+
+	mf, err := h.getMapFile(af.MapFileHash)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse map file: key[%s]", af.MapFileHash)
+	}
+
+	chunkAddress := mf.Chunks[0].ChunkFileURI
+	cf, err := h.getChunkFile(chunkAddress)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse chunk file: key[%s]", chunkAddress)
+	}
+
+	return h.assembleBatchOperations(af, mf, cf, txn)
+}
+
+func (h *OperationProvider) assembleBatchOperations(af *models.AnchorFile, mf *models.MapFile, cf *models.ChunkFile, txn *txn.SidetreeTxn) ([]*batch.Operation, error) {
+	anchorOps, err := h.parseAnchorOperations(af, txn)
+	if err != nil {
+		return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
+	}
+
+	log.Debugf("successfully parsed anchor operations: create[%d], recover[%d], deactivate[%d]",
+		len(anchorOps.Create), len(anchorOps.Recover), len(anchorOps.Deactivate))
+
+	mapOps := parseMapOperations(mf)
+
+	log.Debugf("successfully parsed map operations: update[%d]", len(mapOps.Update))
+
+	var operations []*batch.Operation
+	operations = append(operations, anchorOps.Create...)
+	operations = append(operations, anchorOps.Recover...)
+	operations = append(operations, mapOps.Update...)
+	operations = append(operations, anchorOps.Deactivate...)
+
+	// TODO: Add checks here to makes sure that file sizes match - part of validation tickets
+
+	for i, delta := range cf.Deltas {
+		p, err := h.getProtocol(operations[i].Namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		deltaModel, err := operation.ParseDelta(delta, p.HashAlgorithmInMultiHashCode)
+		if err != nil {
+			return nil, fmt.Errorf("parse delta: %s", err.Error())
+		}
+
+		operations[i].EncodedDelta = delta
+		operations[i].Delta = deltaModel
+	}
+
+	return operations, nil
+}
+
+// getAnchorFile will download anchor file from cas and parse it into anchor file model
+func (h *OperationProvider) getAnchorFile(address string) (*models.AnchorFile, error) {
+	content, err := h.cas.Read(address)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve content for anchor file[%s]", address)
+	}
+
+	af, err := models.ParseAnchorFile(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse content for anchor file[%s]", address)
+	}
+
+	// TODO: verify anchor file - issue-294
+	return af, nil
+}
+
+// getMapFile will download map file from cas and parse it into map file model
+func (h *OperationProvider) getMapFile(address string) (*models.MapFile, error) {
+	content, err := h.cas.Read(address)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve content for map file[%s]", address)
+	}
+
+	mf, err := models.ParseMapFile(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse content for map file[%s]", address)
+	}
+
+	// TODO: verify map file - issue-295
+	return mf, nil
+}
+
+// getChunkFile will download chunk file from cas and parse it into chunk file model
+func (h *OperationProvider) getChunkFile(address string) (*models.ChunkFile, error) {
+	content, err := h.cas.Read(address)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve content for chunk file[%s]", address)
+	}
+
+	cf, err := models.ParseChunkFile(content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse content for chunk file[%s]", address)
+	}
+
+	// TODO: verify chunk file - issue-296
+	return cf, nil
+}
+
+// anchorOperations contains parsed operations from anchor file
+type anchorOperations struct {
+	Create     []*batch.Operation
+	Recover    []*batch.Operation
+	Deactivate []*batch.Operation
+	Suffixes   []string
+}
+
+func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *txn.SidetreeTxn) (*anchorOperations, error) { //nolint: funlen
+	log.Debugf("parsing anchor operations for anchor address: %s", txn.AnchorAddress)
+
+	var suffixes []string
+
+	var createOps []*batch.Operation
+	for _, op := range af.Operations.Create {
+		p, err := h.getProtocol(op.Namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		suffix, err := docutil.CalculateUniqueSuffix(op.SuffixData, p.HashAlgorithmInMultiHashCode)
+		if err != nil {
+			return nil, err
+		}
+
+		suffixModel, err := operation.ParseSuffixData(op.SuffixData, p.HashAlgorithmInMultiHashCode)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: they are assembling operation buffer in reference implementation (might be easier for version manager)
+		create := &batch.Operation{
+			Type:              batch.OperationTypeCreate,
+			Namespace:         op.Namespace,
+			UniqueSuffix:      suffix,
+			ID:                op.Namespace + docutil.NamespaceDelimiter + suffix,
+			EncodedSuffixData: op.SuffixData,
+			SuffixData:        suffixModel,
+		}
+
+		suffixes = append(suffixes, suffix)
+		createOps = append(createOps, create)
+	}
+
+	var recoverOps []*batch.Operation
+	for _, op := range af.Operations.Recover {
+		recover := &batch.Operation{
+			Type:         batch.OperationTypeRecover,
+			Namespace:    op.Namespace,
+			UniqueSuffix: op.DidSuffix,
+			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
+			SignedData:   op.SignedData,
+		}
+
+		suffixes = append(suffixes, op.DidSuffix)
+		recoverOps = append(recoverOps, recover)
+	}
+
+	var deactivateOps []*batch.Operation
+	for _, op := range af.Operations.Deactivate {
+		deactivate := &batch.Operation{
+			Type:         batch.OperationTypeDeactivate,
+			Namespace:    op.Namespace,
+			UniqueSuffix: op.DidSuffix,
+			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
+			SignedData:   op.SignedData,
+		}
+
+		suffixes = append(suffixes, op.DidSuffix)
+		deactivateOps = append(deactivateOps, deactivate)
+	}
+
+	return &anchorOperations{
+		Create:     createOps,
+		Recover:    recoverOps,
+		Deactivate: deactivateOps,
+		Suffixes:   suffixes,
+	}, nil
+}
+
+func (h *OperationProvider) getProtocol(namespace string) (*protocol.Protocol, error) {
+	pc, err := h.pcp.ForNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: get protocol based on Sidetree transaction - for now use current
+	p := pc.Current()
+
+	return &p, nil
+}
+
+// MapOperations contains parsed operations from map file
+type MapOperations struct {
+	Update   []*batch.Operation
+	Suffixes []string
+}
+
+func parseMapOperations(mf *models.MapFile) *MapOperations {
+	var suffixes []string
+
+	var updateOps []*batch.Operation
+	for _, op := range mf.Operations.Update {
+		update := &batch.Operation{
+			Type:         batch.OperationTypeUpdate,
+			Namespace:    op.Namespace,
+			UniqueSuffix: op.DidSuffix,
+			ID:           op.Namespace + docutil.NamespaceDelimiter + op.DidSuffix,
+			SignedData:   op.SignedData,
+		}
+
+		suffixes = append(suffixes, op.DidSuffix)
+		updateOps = append(updateOps, update)
+	}
+
+	return &MapOperations{Update: updateOps, Suffixes: suffixes}
+}
+
+func getOperations(filter batch.OperationType, ops []*batch.Operation) []*batch.Operation {
+	var result []*batch.Operation
+	for _, op := range ops {
+		if op.Type == filter {
+			result = append(result, op)
+		}
+	}
+
+	return result
+}

--- a/pkg/txnhandler/provider_test.go
+++ b/pkg/txnhandler/provider_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package txnhandler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
+	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
+)
+
+func TestNewOperationProvider(t *testing.T) {
+	handler := NewOperationProvider(mocks.NewMockCasClient(nil), mocks.NewMockProtocolClientProvider())
+	require.NotNil(t, handler)
+}
+
+func TestHandler_GetTxnOperations(t *testing.T) {
+	const createOpsNum = 2
+	const updateOpsNum = 3
+	const deactivateOpsNum = 2
+	const recoverOpsNum = 2
+
+	t.Run("success", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		handler := NewOperationHandler(cas)
+
+		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+
+		txnOps, err := provider.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     anchor,
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, createOpsNum+updateOpsNum+deactivateOpsNum+recoverOpsNum, len(txnOps))
+	})
+
+	t.Run("error - read from CAS error", func(t *testing.T) {
+		handler := NewOperationProvider(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClientProvider())
+
+		txnOps, err := handler.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     "anchor",
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.Error(t, err)
+		require.Nil(t, txnOps)
+		require.Contains(t, err.Error(), "failed to retrieve content for anchor file[anchor]")
+	})
+
+	t.Run("error - parse anchor operations error", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		handler := NewOperationHandler(cas)
+
+		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		pc := mocks.NewMockProtocolClient()
+		pc.Protocol = protocol.Protocol{
+			HashAlgorithmInMultiHashCode: 55,
+		}
+
+		pcp := mocks.NewMockProtocolClientProvider()
+		pcp.ProtocolClients[mocks.DefaultNS] = pc
+		provider := NewOperationProvider(cas, pcp)
+
+		txnOps, err := provider.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     anchor,
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.Error(t, err)
+		require.Nil(t, txnOps)
+		require.Contains(t, err.Error(), "parse anchor operations: algorithm not supported")
+	})
+
+	t.Run("success - deactivate only", func(t *testing.T) {
+		const deactivateOpsNum = 2
+
+		var ops []*batch.Operation
+		ops = append(ops, generateOperations(deactivateOpsNum, batch.OperationTypeDeactivate)...)
+
+		cas := mocks.NewMockCasClient(nil)
+		handler := NewOperationHandler(cas)
+
+		anchor, err := handler.PrepareTxnFiles(ops)
+		require.NoError(t, err)
+		require.NotEmpty(t, anchor)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+
+		txnOps, err := provider.GetTxnOperations(&txn.SidetreeTxn{
+			AnchorAddress:     anchor,
+			TransactionNumber: 1,
+			TransactionTime:   1,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, deactivateOpsNum, len(txnOps))
+	})
+}
+
+func TestHandler_GetAnchorFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		address, err := cas.Write([]byte("{}"))
+		require.NoError(t, err)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+		file, err := provider.getAnchorFile(address)
+		require.NoError(t, err)
+		require.NotNil(t, file)
+	})
+
+	t.Run("error - read from CAS error", func(t *testing.T) {
+		provider := NewOperationProvider(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClientProvider())
+		file, err := provider.getAnchorFile("address")
+		require.Error(t, err)
+		require.Nil(t, file)
+		require.Contains(t, err.Error(), "failed to retrieve content for anchor file[address]: CAS error")
+	})
+
+	t.Run("error - parse anchor file error (invalid JSON)", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		address, err := cas.Write([]byte("invalid"))
+		require.NoError(t, err)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+		file, err := provider.getAnchorFile(address)
+		require.Error(t, err)
+		require.Nil(t, file)
+		require.Contains(t, err.Error(), "failed to parse content for anchor file")
+	})
+}
+
+func TestHandler_GetMapFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		address, err := cas.Write([]byte("{}"))
+		require.NoError(t, err)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+		file, err := provider.getMapFile(address)
+		require.NoError(t, err)
+		require.NotNil(t, file)
+	})
+
+	t.Run("error - read from CAS error", func(t *testing.T) {
+		provider := NewOperationProvider(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClientProvider())
+		file, err := provider.getMapFile("address")
+		require.Error(t, err)
+		require.Nil(t, file)
+		require.Contains(t, err.Error(), "failed to retrieve content for map file[address]: CAS error")
+	})
+
+	t.Run("error - parse anchor file error (invalid JSON)", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		address, err := cas.Write([]byte("invalid"))
+		require.NoError(t, err)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+		file, err := provider.getMapFile(address)
+		require.Error(t, err)
+		require.Nil(t, file)
+		require.Contains(t, err.Error(), "failed to parse content for map file")
+	})
+}
+
+func TestHandler_GetChunkFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		address, err := cas.Write([]byte("{}"))
+		require.NoError(t, err)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+		file, err := provider.getChunkFile(address)
+		require.NoError(t, err)
+		require.NotNil(t, file)
+	})
+
+	t.Run("error - read from CAS error", func(t *testing.T) {
+		provider := NewOperationProvider(mocks.NewMockCasClient(errors.New("CAS error")), mocks.NewMockProtocolClientProvider())
+		file, err := provider.getChunkFile("address")
+		require.Error(t, err)
+		require.Nil(t, file)
+		require.Contains(t, err.Error(), "failed to retrieve content for chunk file[address]: CAS error")
+	})
+
+	t.Run("error - parse chunk file error (invalid JSON)", func(t *testing.T) {
+		cas := mocks.NewMockCasClient(nil)
+		address, err := cas.Write([]byte("invalid"))
+		require.NoError(t, err)
+
+		provider := NewOperationProvider(cas, mocks.NewMockProtocolClientProvider())
+		file, err := provider.getChunkFile(address)
+		require.Error(t, err)
+		require.Nil(t, file)
+		require.Contains(t, err.Error(), "failed to parse content for chunk file")
+	})
+}


### PR DESCRIPTION
Since transaction processor requires protocol client per namespace split transaction handler into two components:
-- operation handler (creates batch files from batch operations) - called by batch writer
-- operation processor (creates batch operations from batch files) - called by observer

Closes #308

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>