### PR TITLE
fix: Nil pointer when logging parse anchor operations error

### DIFF
--- a/pkg/txnhandler/provider.go
+++ b/pkg/txnhandler/provider.go
@@ -50,7 +50,7 @@ func (h *OperationProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Ope
 		// if there's no map file that means that we have only deactivate operations in the batch
 		anchorOps, e := h.parseAnchorOperations(af, txn)
 		if e != nil {
-			return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
+			return nil, fmt.Errorf("parse anchor operations: %s", e.Error())
 		}
 
 		return anchorOps.Deactivate, nil


### PR DESCRIPTION
Wrong error is being logged thus causing nil pointer

Closes #310

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>