### PR TITLE
feat: Add compression for batch files

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -16,6 +16,14 @@ type Protocol struct {
 	MaxOperationsPerBatch uint
 	// MaxDeltaByteSize is maximum size of the `delta` property in bytes
 	MaxDeltaByteSize uint
+	// CompressionAlgorithm is file compression algorithm
+	CompressionAlgorithm string
+	// MaxAnchorFileSize is maximum allowed size (in bytes) of anchor file stored in CAS
+	MaxAnchorFileSize uint
+	// MaxMapFileSize is maximum allowed size (in bytes) of map file stored in CAS
+	MaxMapFileSize uint
+	// MaxChunkFileSize is maximum allowed size (in bytes) of chunk file stored in CAS
+	MaxChunkFileSize uint
 }
 
 // Client defines interface for accessing protocol version/information

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -15,6 +15,9 @@ import (
 // DefaultNS is default namespace used in mocks
 const DefaultNS = "did:sidetree"
 
+// maximum batch files size in bytes
+const maxBatchFileSize = 20000
+
 // MockProtocolClient mocks protocol for testing purposes.
 type MockProtocolClient struct {
 	Protocol protocol.Protocol
@@ -29,6 +32,10 @@ func NewMockProtocolClient() *MockProtocolClient {
 			HashAlgorithmInMultiHashCode: sha2_256,
 			MaxOperationsPerBatch:        2,
 			MaxDeltaByteSize:             2000,
+			CompressionAlgorithm:         "GZIP",
+			MaxChunkFileSize:             maxBatchFileSize,
+			MaxMapFileSize:               maxBatchFileSize,
+			MaxAnchorFileSize:            maxBatchFileSize,
 		},
 	}
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -30,6 +30,12 @@ type TxnOpsProvider interface {
 	GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Operation, error)
 }
 
+// DecompressionProvider defines an interface for decompressing data using specified algorithm
+type DecompressionProvider interface {
+	// Decompress will decompress compressed data using specified algorithm
+	Decompress(alg string, data []byte) ([]byte, error)
+}
+
 // OperationStore interface to access operation store
 type OperationStore interface {
 	Put(ops []*batch.Operation) error
@@ -52,10 +58,11 @@ type OperationFilterProvider interface {
 
 // Providers contains all of the providers required by the TxnProcessor
 type Providers struct {
-	Ledger           Ledger
-	TxnOpsProvider   TxnOpsProvider
-	OpStoreProvider  OperationStoreProvider
-	OpFilterProvider OperationFilterProvider
+	Ledger                Ledger
+	TxnOpsProvider        TxnOpsProvider
+	OpStoreProvider       OperationStoreProvider
+	OpFilterProvider      OperationFilterProvider
+	DecompressionProvider DecompressionProvider
 }
 
 // Observer receives transactions over a channel and processes them by storing them to an operation store

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
+	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/txnhandler"
 )
@@ -37,7 +38,7 @@ func TestStartObserver(t *testing.T) {
 
 		providers := &Providers{
 			Ledger:           mockLedger{registerForSidetreeTxnValue: sidetreeTxnCh},
-			TxnOpsProvider:   txnhandler.NewOperationProvider(&mockDCAS{readFunc: readFunc}, mocks.NewMockProtocolClientProvider()),
+			TxnOpsProvider:   txnhandler.NewOperationProvider(&mockDCAS{readFunc: readFunc}, mocks.NewMockProtocolClientProvider(), compression.New(compression.WithDefaultAlgorithms())),
 			OpFilterProvider: &NoopOperationFilterProvider{},
 		}
 
@@ -47,7 +48,7 @@ func TestStartObserver(t *testing.T) {
 		o.Start()
 		defer o.Stop()
 
-		sidetreeTxnCh <- []txn.SidetreeTxn{{TransactionTime: 20, TransactionNumber: 2, AnchorString: "1.address"}}
+		sidetreeTxnCh <- []txn.SidetreeTxn{{Namespace: mocks.DefaultNS, TransactionTime: 20, TransactionNumber: 2, AnchorString: "1.address"}}
 		time.Sleep(200 * time.Millisecond)
 		rw.RLock()
 		require.True(t, isCalled)


### PR DESCRIPTION
Add batch file compression/decompression to transaction handler:
-- compress batch files before storing them to CAS (batch writer)
-- decompress batch files upon retrieving them from CAS (observer)
-- check for maximum batch file size
Protocol:
-- add compression algorithm and maximum batch sizes

Closes: #318

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>