### PR TITLE
chore: Add common validations for batch files

### DIFF
--- a/pkg/txnhandler/provider.go
+++ b/pkg/txnhandler/provider.go
@@ -80,7 +80,16 @@ func (h *OperationProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Ope
 		return nil, err
 	}
 
-	return h.assembleBatchOperations(af, mf, cf, txn)
+	txnOps, err := h.assembleBatchOperations(af, mf, cf, txn)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(txnOps) != anchorData.NumberOfOperations {
+		return nil, fmt.Errorf("number of txn ops[%d] doesn't match anchor string num of ops[%d]", len(txnOps), anchorData.NumberOfOperations)
+	}
+
+	return txnOps, nil
 }
 
 func (h *OperationProvider) assembleBatchOperations(af *models.AnchorFile, mf *models.MapFile, cf *models.ChunkFile, txn *txn.SidetreeTxn) ([]*batch.Operation, error) {


### PR DESCRIPTION
Add following check when creating anchor, map, chunk files for Sidetree transaction:
- there can be only one operation per suffix in all batch files combined per transaction (log subsequent operations as warning and ignore them)

Add following check when processing Sidetree transaction operations during observation:
- if there is an operation with same suffix already in transaction do not process subsequent operations with same suffix. This should never happen because of check during batch file creation. Ignored operations should be logged as warning but not be stored for future processing.

Add following check for Sidetree transaction during observation:
- number of operations in anchor string has to match number of operations in anchor + map file

Closes #320

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>