### PR TITLE
fix: Increase unit-test sleep time

### DIFF
--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -352,7 +352,7 @@ func TestStartWithExistingItems(t *testing.T) {
 	writer.Start()
 	defer writer.Stop()
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 	require.Equal(t, numBatchesExpected, len(ctx.BlockchainClient.GetAnchors()))
 }
 


### PR DESCRIPTION
Batch cutting time has increased due to more processing (compression, validation etc) so we have to increase sleep time in TestStartWithExistingItems. Test is failing more often in CI recently (it never fails locally).

Closes #322

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>