### PR TITLE
feat: Generate commitment from public JWK

### DIFF
--- a/pkg/commitment/hash.go
+++ b/pkg/commitment/hash.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package commitment
+
+import (
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
+)
+
+//Calculate will calculate commitment hash from JWK
+func Calculate(jwk *jws.JWK, multihashCode uint) (string, error) {
+	data, err := canonicalizer.MarshalCanonical(jwk)
+	if err != nil {
+		return "", err
+	}
+
+	multiHashBytes, err := docutil.ComputeMultihash(multihashCode, data)
+	if err != nil {
+		return "", err
+	}
+
+	return docutil.EncodeToString(multiHashBytes), nil
+}

--- a/pkg/commitment/hash_test.go
+++ b/pkg/commitment/hash_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package commitment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
+)
+
+const (
+	sha2_256 uint = 18
+)
+
+func TestCalculate(t *testing.T) {
+	jwk := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+		Y:   "y",
+	}
+
+	t.Run("success", func(t *testing.T) {
+		commitment, err := Calculate(jwk, sha2_256)
+		require.NoError(t, err)
+		require.NotEmpty(t, commitment)
+	})
+
+	t.Run(" error - multihash not supported", func(t *testing.T) {
+		commitment, err := Calculate(jwk, 55)
+		require.Error(t, err)
+		require.Empty(t, commitment)
+		require.Contains(t, err.Error(), "algorithm not supported, unable to compute hash")
+	})
+
+	t.Run("error - canonicalization failed", func(t *testing.T) {
+		commitment, err := Calculate(nil, sha2_256)
+		require.Error(t, err)
+		require.Empty(t, commitment)
+		require.Contains(t, err.Error(), "Expected '{' but got 'n'")
+	})
+}

--- a/pkg/dochandler/didvalidator/validator.go
+++ b/pkg/dochandler/didvalidator/validator.go
@@ -184,7 +184,6 @@ func processKeys(internal document.DIDDocument, resolutionResult *document.Resol
 	var invocationKey []interface{}
 
 	var publicKeys []document.PublicKey
-	var operationPublicKeys []document.PublicKey
 
 	// add controller to public key
 	for _, pk := range internal.PublicKeys() {
@@ -207,10 +206,6 @@ func processKeys(internal document.DIDDocument, resolutionResult *document.Resol
 		}
 
 		usages := pk.Usage()
-		if document.IsOperationsKey(usages) {
-			operationPublicKeys = append(operationPublicKeys, externalPK)
-		}
-
 		if document.IsGeneralKey(usages) {
 			publicKeys = append(publicKeys, externalPK)
 
@@ -270,8 +265,6 @@ func processKeys(internal document.DIDDocument, resolutionResult *document.Resol
 	if len(invocationKey) > 0 {
 		resolutionResult.Document[document.InvocationKeyProperty] = invocationKey
 	}
-
-	resolutionResult.MethodMetadata.OperationPublicKeys = operationPublicKeys
 
 	return nil
 }

--- a/pkg/dochandler/docvalidator/validator.go
+++ b/pkg/dochandler/docvalidator/validator.go
@@ -88,17 +88,15 @@ func (v *Validator) TransformDocument(internal document.Document) (*document.Res
 		MethodMetadata: document.MethodMetadata{},
 	}
 
-	processKeys(internal, resolutionResult)
+	processKeys(internal)
 
 	return resolutionResult, nil
 }
 
-// generic documents will most likely only contain operation keys
-// operation keys are not part of external document but resolution result
-func processKeys(internal document.Document, resolutionResult *document.ResolutionResult) {
-	var operationPublicKeys []document.PublicKey
+// generic documents will most likely not contain keys
+func processKeys(internal document.Document) {
+	var pubKeysKeys []document.PublicKey
 
-	var nonOperationsKeys []document.PublicKey
 	for _, pk := range internal.PublicKeys() {
 		relativeID := "#" + pk.ID()
 
@@ -108,19 +106,12 @@ func processKeys(internal document.Document, resolutionResult *document.Resoluti
 		externalPK[document.ControllerProperty] = internal[document.IDProperty]
 		externalPK[document.PublicKeyJwkProperty] = pk.JWK()
 
-		usages := pk.Usage()
-		if document.IsOperationsKey(usages) {
-			operationPublicKeys = append(operationPublicKeys, externalPK)
-		} else {
-			nonOperationsKeys = append(nonOperationsKeys, externalPK)
-		}
+		pubKeysKeys = append(pubKeysKeys, externalPK)
 	}
 
-	if len(nonOperationsKeys) > 0 {
-		internal[document.PublicKeyProperty] = nonOperationsKeys
+	if len(pubKeysKeys) > 0 {
+		internal[document.PublicKeyProperty] = pubKeysKeys
 	} else {
 		delete(internal, document.PublicKeyProperty)
 	}
-
-	resolutionResult.MethodMetadata.OperationPublicKeys = operationPublicKeys
 }

--- a/pkg/dochandler/docvalidator/validator_test.go
+++ b/pkg/dochandler/docvalidator/validator_test.go
@@ -116,7 +116,6 @@ func TestTransformDocument(t *testing.T) {
 	require.NoError(t, err)
 	result, err = v.TransformDocument(doc)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(result.MethodMetadata.OperationPublicKeys))
 	require.Equal(t, 0, len(result.Document.PublicKeys()))
 }
 

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -126,7 +126,8 @@ func (r *DocumentHandler) getCreateResponse(operation *batch.Operation) (*docume
 	}
 
 	externalResult.MethodMetadata.Published = false
-	externalResult.MethodMetadata.RecoveryKey = operation.SuffixData.RecoveryKey
+	externalResult.MethodMetadata.RecoveryCommitment = operation.SuffixData.RecoveryCommitment
+	externalResult.MethodMetadata.UpdateCommitment = operation.Delta.UpdateCommitment
 
 	return externalResult, nil
 }
@@ -185,7 +186,8 @@ func (r *DocumentHandler) resolveRequestWithID(uniquePortion string) (*document.
 	}
 
 	externalResult.MethodMetadata.Published = true
-	externalResult.MethodMetadata.RecoveryKey = internalResult.MethodMetadata.RecoveryKey
+	externalResult.MethodMetadata.RecoveryCommitment = internalResult.MethodMetadata.RecoveryCommitment
+	externalResult.MethodMetadata.UpdateCommitment = internalResult.MethodMetadata.UpdateCommitment
 
 	return externalResult, nil
 }

--- a/pkg/document/resolution.go
+++ b/pkg/document/resolution.go
@@ -6,8 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package document
 
-import "github.com/trustbloc/sidetree-core-go/pkg/jws"
-
 // ResolutionResult describes resolution result
 type ResolutionResult struct {
 	Context        string         `json:"@context"`
@@ -17,7 +15,7 @@ type ResolutionResult struct {
 
 // MethodMetadata contains document metadata
 type MethodMetadata struct {
-	OperationPublicKeys []PublicKey `json:"operationPublicKeys,omitempty"`
-	RecoveryKey         *jws.JWK    `json:"recoveryKey,omitempty"`
-	Published           bool        `json:"published"`
+	UpdateCommitment   string `json:"updateCommitment"`
+	RecoveryCommitment string `json:"recoveryCommitment"`
+	Published          bool   `json:"published"`
 }

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -126,10 +125,6 @@ func validateDelta(delta *model.DeltaModel, code uint) error {
 }
 
 func validateSuffixData(suffixData *model.SuffixDataModel, code uint) error {
-	if err := validateRecoveryKey(suffixData.RecoveryKey); err != nil {
-		return err
-	}
-
 	if !docutil.IsComputedUsingHashAlgorithm(suffixData.RecoveryCommitment, uint64(code)) {
 		return errors.New("next recovery commitment hash is not computed with the latest supported hash algorithm")
 	}
@@ -139,14 +134,6 @@ func validateSuffixData(suffixData *model.SuffixDataModel, code uint) error {
 	}
 
 	return nil
-}
-
-func validateRecoveryKey(key *jws.JWK) error {
-	if key == nil {
-		return errors.New("missing recovery key")
-	}
-
-	return key.Validate()
 }
 
 func validateCreateRequest(create *model.CreateRequest) error {

--- a/pkg/operation/deactivate.go
+++ b/pkg/operation/deactivate.go
@@ -79,10 +79,6 @@ func parseSignedDataForDeactivate(req *model.DeactivateRequest) (*model.Deactiva
 		return nil, err
 	}
 
-	if signedData.RecoveryRevealValue != req.RecoveryRevealValue {
-		return nil, errors.New("signed recovery reveal mismatch for deactivate")
-	}
-
 	if signedData.DidSuffix != req.DidSuffix {
 		return nil, errors.New("signed did suffix mismatch for deactivate")
 	}

--- a/pkg/operation/deactivate_test.go
+++ b/pkg/operation/deactivate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -82,21 +83,6 @@ func TestParseDeactivateOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "signed did suffix mismatch for deactivate")
 		require.Nil(t, op)
 	})
-	t.Run("validate signed data error - reveal value mismatch", func(t *testing.T) {
-		signedData := getSignedDataForDeactivate()
-		signedData.RecoveryRevealValue = "different"
-
-		recoverRequest, err := getDeactivateRequest(signedData)
-		require.NoError(t, err)
-
-		request, err := json.Marshal(recoverRequest)
-		require.NoError(t, err)
-
-		op, err := ParseDeactivateOperation(request, p)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "signed recovery reveal mismatch for deactivate")
-		require.Nil(t, op)
-	})
 }
 
 func getDeactivateRequest(signedData *model.DeactivateSignedDataModel) (*model.DeactivateRequest, error) {
@@ -106,10 +92,9 @@ func getDeactivateRequest(signedData *model.DeactivateSignedDataModel) (*model.D
 	}
 
 	return &model.DeactivateRequest{
-		Operation:           model.OperationTypeDeactivate,
-		DidSuffix:           "did",
-		RecoveryRevealValue: "recoveryReveal",
-		SignedData:          compactJWS,
+		Operation:  model.OperationTypeDeactivate,
+		DidSuffix:  "did",
+		SignedData: compactJWS,
 	}, nil
 }
 
@@ -119,8 +104,12 @@ func getDefaultDeactivateRequest() (*model.DeactivateRequest, error) {
 
 func getSignedDataForDeactivate() *model.DeactivateSignedDataModel {
 	return &model.DeactivateSignedDataModel{
-		DidSuffix:           "did",
-		RecoveryRevealValue: "recoveryReveal",
+		DidSuffix: "did",
+		RecoveryKey: &jws.JWK{
+			Kty: "kty",
+			Crv: "crv",
+			X:   "x",
+		},
 	}
 }
 

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -8,6 +8,7 @@ package operation
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	internal "github.com/trustbloc/sidetree-core-go/pkg/internal/jws"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -86,8 +88,8 @@ func parseSignedDataForRecovery(compactJWS string, code uint) (*model.RecoverSig
 }
 
 func validateSignedDataForRecovery(signedData *model.RecoverSignedDataModel, code uint) error {
-	if err := validateRecoveryKey(signedData.RecoveryKey); err != nil {
-		return err
+	if err := validateKey(signedData.RecoveryKey); err != nil {
+		return fmt.Errorf("signed data for recovery: %s", err.Error())
 	}
 
 	if !docutil.IsComputedUsingHashAlgorithm(signedData.RecoveryCommitment, uint64(code)) {
@@ -119,4 +121,12 @@ func validateRecoverRequest(recover *model.RecoverRequest) error {
 	}
 
 	return nil
+}
+
+func validateKey(key *jws.JWK) error {
+	if key == nil {
+		return errors.New("missing key")
+	}
+
+	return key.Validate()
 }

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -112,7 +112,7 @@ func TestParseRecoverOperation(t *testing.T) {
 
 		op, err := ParseRecoverOperation(request, p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing recovery key")
+		require.Contains(t, err.Error(), "signed data for recovery: missing key")
 		require.Nil(t, op)
 	})
 }
@@ -124,7 +124,7 @@ func TestValidateSignedDataForRecovery(t *testing.T) {
 		err := validateSignedDataForRecovery(signed, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"missing recovery key")
+			"signed data for recovery: missing key")
 	})
 	t.Run("invalid patch data hash", func(t *testing.T) {
 		signed := getSignedDataForRecovery()

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -9,6 +9,7 @@ package operation
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
@@ -74,8 +75,8 @@ func parseSignedDataForUpdate(compactJWS string, code uint) (*model.UpdateSigned
 		return nil, err
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(schema.DeltaHash, uint64(code)) {
-		return nil, errors.New("delta hash is not computed with the latest supported hash algorithm")
+	if err := validateSignedDataForUpdate(schema, code); err != nil {
+		return nil, err
 	}
 
 	return schema, nil
@@ -92,6 +93,18 @@ func validateUpdateRequest(update *model.UpdateRequest) error {
 
 	if update.SignedData == "" {
 		return errors.New("missing signed data")
+	}
+
+	return nil
+}
+
+func validateSignedDataForUpdate(signedData *model.UpdateSignedDataModel, code uint) error {
+	if err := validateKey(signedData.UpdateKey); err != nil {
+		return fmt.Errorf("signed data for update: %s", err.Error())
+	}
+
+	if !docutil.IsComputedUsingHashAlgorithm(signedData.DeltaHash, uint64(code)) {
+		return errors.New("delta hash is not computed with the latest supported hash algorithm")
 	}
 
 	return nil

--- a/pkg/processor/operationfilter.go
+++ b/pkg/processor/operationfilter.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 )
 
 // OperationValidationFilter filters out invalid operations.
@@ -21,9 +22,9 @@ type OperationValidationFilter struct {
 }
 
 // NewOperationFilter returns new operation filter with the given name. (Note that name is only used for logging.)
-func NewOperationFilter(name string, store OperationStoreClient) *OperationValidationFilter {
+func NewOperationFilter(name string, store OperationStoreClient, pc protocol.Client) *OperationValidationFilter {
 	return &OperationValidationFilter{
-		OperationProcessor: New(name, store),
+		OperationProcessor: New(name, store, pc),
 	}
 }
 

--- a/pkg/processor/operationfilter_test.go
+++ b/pkg/processor/operationfilter_test.go
@@ -20,60 +20,59 @@ import (
 )
 
 func TestOperationFilter_Filter(t *testing.T) {
-	t.Run("Store error", func(t *testing.T) {
-		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
+	recoveryKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
 
+	updateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	pc := mocks.NewMockProtocolClient()
+
+	t.Run("Store error", func(t *testing.T) {
 		errExpected := errors.New("injected store error")
 		store := mocks.NewMockOperationStore(nil)
 		store.Validate = false
 		store.Err = errExpected
 
-		createOp, err := getCreateOperation(privateKey)
+		createOp, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
 
-		filter := NewOperationFilter("test", store)
+		filter := NewOperationFilter("test", store, pc)
 		validOps, err := filter.Filter(createOp.UniqueSuffix, []*batch.Operation{createOp})
 		require.EqualError(t, err, err.Error())
 		require.Empty(t, validOps)
 	})
 
 	t.Run("No create operation error", func(t *testing.T) {
-		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
-
 		store := mocks.NewMockOperationStore(nil)
 		store.Validate = false
 
-		createOp, err := getCreateOperation(privateKey)
+		createOp, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
 
-		updateOp1, err := getUpdateOperation(privateKey, createOp.UniqueSuffix, 1)
+		updateOp1, _, err := getUpdateOperation(updateKey, createOp.UniqueSuffix, 1)
 		require.NoError(t, err)
 
-		filter := NewOperationFilter("test", store)
+		filter := NewOperationFilter("test", store, pc)
 		validOps, err := filter.Filter(createOp.UniqueSuffix, []*batch.Operation{updateOp1})
 		require.EqualError(t, err, "missing create operation")
 		require.Empty(t, validOps)
 	})
 
 	t.Run("Unique suffix not found in store", func(t *testing.T) {
-		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
-
 		store := mocks.NewMockOperationStore(nil)
 		store.Validate = false
 
-		createOp, err := getCreateOperation(privateKey)
+		createOp, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
 
-		updateOp1, err := getUpdateOperation(privateKey, createOp.UniqueSuffix, 1)
+		updateOp1, _, err := getUpdateOperation(updateKey, createOp.UniqueSuffix, 1)
 		require.NoError(t, err)
-		updateOp2, err := getUpdateOperation(privateKey, createOp.UniqueSuffix, 3)
+		updateOp2, _, err := getUpdateOperation(updateKey, createOp.UniqueSuffix, 3)
 		require.NoError(t, err)
 
-		// The second update should be discarded
-		filter := NewOperationFilter("test", store)
+		// The second update should be discarded because same update key has been used
+		filter := NewOperationFilter("test", store, pc)
 		validOps, err := filter.Filter(createOp.UniqueSuffix, []*batch.Operation{createOp, updateOp1, updateOp2})
 		require.NoError(t, err)
 		require.Len(t, validOps, 2)
@@ -82,28 +81,25 @@ func TestOperationFilter_Filter(t *testing.T) {
 	})
 
 	t.Run("Unique suffix exists in store", func(t *testing.T) {
-		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
-
 		store := mocks.NewMockOperationStore(nil)
 		store.Validate = false
 
-		createOp1, err := getCreateOperation(privateKey)
+		createOp1, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
 		err = store.Put(createOp1)
 		require.Nil(t, err)
 
-		createOp2, err := getCreateOperation(privateKey)
+		createOp2, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
-		updateOp1, err := getUpdateOperation(privateKey, "123456", 1)
+		updateOp1, _, err := getUpdateOperation(updateKey, "123456", 1)
 		require.NoError(t, err)
-		updateOp2, err := getUpdateOperation(privateKey, createOp1.UniqueSuffix, 1)
+		updateOp2, _, err := getUpdateOperation(updateKey, createOp1.UniqueSuffix, 1)
 		require.NoError(t, err)
-		updateOp3, err := getUpdateOperation(privateKey, createOp1.UniqueSuffix, 3)
+		updateOp3, _, err := getUpdateOperation(updateKey, createOp1.UniqueSuffix, 3)
 		require.NoError(t, err)
 
 		// The create operation and first and third update should be discarded
-		filter := NewOperationFilter("test", store)
+		filter := NewOperationFilter("test", store, pc)
 		validOps, err := filter.Filter(createOp1.UniqueSuffix, []*batch.Operation{createOp2, updateOp1, updateOp2, updateOp3})
 		require.NoError(t, err)
 		require.Len(t, validOps, 1)
@@ -111,26 +107,24 @@ func TestOperationFilter_Filter(t *testing.T) {
 	})
 
 	t.Run("With deactivate operation", func(t *testing.T) {
-		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		require.NoError(t, err)
 		store := mocks.NewMockOperationStore(nil)
 		store.Validate = false
 
-		createOp1, err := getCreateOperation(privateKey)
+		createOp1, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
 
 		err = store.Put(createOp1)
 		require.Nil(t, err)
 
-		createOp2, err := getCreateOperation(privateKey)
+		createOp2, err := getCreateOperation(recoveryKey, updateKey)
 		require.NoError(t, err)
-		updateOp, err := getUpdateOperation(privateKey, createOp1.UniqueSuffix, 1)
+		updateOp, _, err := getUpdateOperation(updateKey, createOp1.UniqueSuffix, 1)
 		require.NoError(t, err)
-		deactivateOp, err := getDeactivateOperation(privateKey, createOp1.UniqueSuffix, 2)
+		deactivateOp, err := getDeactivateOperation(recoveryKey, createOp1.UniqueSuffix, 2)
 		require.NoError(t, err)
 
 		// The create should be discarded (since there's already a create) and update should be discarded since the document was deactivated
-		filter := NewOperationFilter("test", store)
+		filter := NewOperationFilter("test", store, pc)
 		validOps, err := filter.Filter(createOp1.UniqueSuffix, []*batch.Operation{createOp2, updateOp, deactivateOp})
 		require.NoError(t, err)
 		require.Len(t, validOps, 1)

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -7,9 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package dochandler
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,10 +19,10 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/request"
+	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
-	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
 )
 
 func TestResolveHandler_Resolve(t *testing.T) {
@@ -220,19 +217,14 @@ func getDelta() (*model.DeltaModel, error) {
 }
 
 func getSuffixData() *model.SuffixDataModel {
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		panic(err)
-	}
-
-	recoveryKey, err := pubkey.GetPublicKeyJWK(&privateKey.PublicKey)
-	if err != nil {
-		panic(err)
-	}
-
 	return &model.SuffixDataModel{
 		DeltaHash:          computeMultihash(validDoc),
-		RecoveryKey:        recoveryKey,
 		RecoveryCommitment: computeMultihash("recoveryReveal"),
 	}
+}
+
+var testJWK = &jws.JWK{
+	Kty: "kty",
+	Crv: "crv",
+	X:   "x",
 }

--- a/pkg/restapi/helper/deactivate.go
+++ b/pkg/restapi/helper/deactivate.go
@@ -9,7 +9,6 @@ package helper
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -31,8 +30,8 @@ type DeactivateRequestInfo struct {
 	// DID Suffix of the document to be deactivated
 	DidSuffix string
 
-	// reveal value for this deactivate operation
-	RecoveryRevealValue []byte
+	// Recovery key for current deactivate request
+	RecoveryKey *jws.JWK
 
 	// Signer that will be used for signing specific subset of request data
 	// Signer for recover operation must be recovery key
@@ -46,8 +45,8 @@ func NewDeactivateRequest(info *DeactivateRequestInfo) ([]byte, error) {
 	}
 
 	signedDataModel := model.DeactivateSignedDataModel{
-		DidSuffix:           info.DidSuffix,
-		RecoveryRevealValue: docutil.EncodeToString(info.RecoveryRevealValue),
+		DidSuffix:   info.DidSuffix,
+		RecoveryKey: info.RecoveryKey,
 	}
 
 	jws, err := signutil.SignModel(signedDataModel, info.Signer)
@@ -56,10 +55,9 @@ func NewDeactivateRequest(info *DeactivateRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.DeactivateRequest{
-		Operation:           model.OperationTypeDeactivate,
-		DidSuffix:           info.DidSuffix,
-		RecoveryRevealValue: docutil.EncodeToString(info.RecoveryRevealValue),
-		SignedData:          jws,
+		Operation:  model.OperationTypeDeactivate,
+		DidSuffix:  info.DidSuffix,
+		SignedData: jws,
 	}
 
 	return canonicalizer.MarshalCanonical(schema)

--- a/pkg/restapi/model/request.go
+++ b/pkg/restapi/model/request.go
@@ -32,10 +32,7 @@ type SuffixDataModel struct {
 	// Hash of the delta object
 	DeltaHash string `json:"delta_hash"`
 
-	// Initial recovery public key in JWK format
-	RecoveryKey *jws.JWK `json:"recovery_key"`
-
-	// Initial recovery commitment
+	// Commitment hash for the next recovery or deactivate operation
 	RecoveryCommitment string `json:"recovery_commitment"`
 }
 
@@ -56,9 +53,6 @@ type UpdateRequest struct {
 	//The suffix of the DID
 	DidSuffix string `json:"did_suffix"`
 
-	// Reveal value for this update operation
-	UpdateRevealValue string `json:"update_reveal_value"`
-
 	// Compact JWS - signature information
 	SignedData string `json:"signed_data"`
 
@@ -76,18 +70,14 @@ type DeactivateRequest struct {
 	// Required: true
 	DidSuffix string `json:"did_suffix"`
 
-	// the current reveal value to use for this request
-	// Required: true
-	RecoveryRevealValue string `json:"recovery_reveal_value"`
-
 	// Compact JWS - signature information
 	SignedData string `json:"signed_data"`
 }
 
 // UpdateSignedDataModel defines signed data model for update
 type UpdateSignedDataModel struct {
-	// Reveal value for this update operation
-	UpdateRevealValue string `json:"update_reveal_value"`
+	// The current update key
+	UpdateKey *jws.JWK `json:"update_key"`
 
 	// Hash of the unsigned delta object
 	DeltaHash string `json:"delta_hash"`
@@ -99,11 +89,8 @@ type RecoverSignedDataModel struct {
 	// Hash of the unsigned delta object
 	DeltaHash string `json:"delta_hash"`
 
-	// The new recovery key
+	// The current recovery key
 	RecoveryKey *jws.JWK `json:"recovery_key"`
-
-	// the current reveal value to use for this request
-	RecoveryRevealValue string `json:"recovery_reveal_value"`
 
 	// Recovery commitment be used for the next recovery/deactivate
 	RecoveryCommitment string `json:"recovery_commitment"`
@@ -116,9 +103,8 @@ type DeactivateSignedDataModel struct {
 	// Required: true
 	DidSuffix string `json:"did_suffix"`
 
-	// the current reveal value to use for this request
-	// Required: true
-	RecoveryRevealValue string `json:"recovery_reveal_value"`
+	// The current recovery key
+	RecoveryKey *jws.JWK `json:"recovery_key"`
 }
 
 // RecoverRequest is the struct for document recovery payload
@@ -130,10 +116,6 @@ type RecoverRequest struct {
 	//The suffix of the DID
 	// Required: true
 	DidSuffix string `json:"did_suffix"`
-
-	// The reveal value for this recovery
-	// Required: true
-	RecoveryRevealValue string `json:"recovery_reveal_value"`
 
 	// Compact JWS - signature information
 	SignedData string `json:"signed_data"`


### PR DESCRIPTION
- generate recovery and update commitments from corresponding public JWK during create
- add update key to update request
- add recovery key for deactivate and recover requests
- validate keys against previously provided commitments
- validate signature against passed in keys
- return update and recovery commitments in resolution result metadata (remove recovery key and operation keys)

Closes #303

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>