### PR TITLE
chore: Signature payload should not be encoded

### DIFF
--- a/pkg/commitment/hash.go
+++ b/pkg/commitment/hash.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package commitment
 
 import (
+	log "github.com/sirupsen/logrus"
+
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -18,6 +20,8 @@ func Calculate(jwk *jws.JWK, multihashCode uint) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	log.Debugf("calculating commitment from JWK: %s", string(data))
 
 	multiHashBytes, err := docutil.ComputeMultihash(multihashCode, data)
 	if err != nil {

--- a/pkg/commitment/hash_test.go
+++ b/pkg/commitment/hash_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 )
 
@@ -44,5 +45,20 @@ func TestCalculate(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, commitment)
 		require.Contains(t, err.Error(), "Expected '{' but got 'n'")
+	})
+
+	t.Run("interop test", func(t *testing.T) {
+		jwk := &jws.JWK{
+			Kty: "EC",
+			Crv: "secp256k1",
+			X:   "5s3-bKjD1Eu_3NJu8pk7qIdOPl1GBzU_V8aR3xiacoM",
+			Y:   "v0-Q5H3vcfAfQ4zsebJQvMrIg3pcsaJzRvuIYZ3_UOY",
+		}
+
+		canonicalized, err := canonicalizer.MarshalCanonical(jwk)
+		require.NoError(t, err)
+
+		expected := `{"crv":"secp256k1","kty":"EC","x":"5s3-bKjD1Eu_3NJu8pk7qIdOPl1GBzU_V8aR3xiacoM","y":"v0-Q5H3vcfAfQ4zsebJQvMrIg3pcsaJzRvuIYZ3_UOY"}`
+		require.Equal(t, string(canonicalized), expected)
 	})
 }

--- a/pkg/internal/signutil/signature.go
+++ b/pkg/internal/signutil/signature.go
@@ -9,7 +9,6 @@ package signutil
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/canonicalizer"
 	internaljws "github.com/trustbloc/sidetree-core-go/pkg/internal/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -32,19 +31,17 @@ func SignModel(model interface{}, signer Signer) (string, error) {
 		return "", err
 	}
 
-	payload := docutil.EncodeToString(signedDataBytes)
-
-	return SignPayload(payload, signer)
+	return SignPayload(signedDataBytes, signer)
 }
 
 // SignPayload allows for singing payload
-func SignPayload(payload string, signer Signer) (string, error) {
+func SignPayload(payload []byte, signer Signer) (string, error) {
 	alg, ok := signer.Headers().Algorithm()
 	if !ok || alg == "" {
 		return "", errors.New("signing algorithm is required")
 	}
 
-	jwsSignature, err := internaljws.NewJWS(signer.Headers(), nil, []byte(payload), signer)
+	jwsSignature, err := internaljws.NewJWS(signer.Headers(), nil, payload, signer)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/internal/signutil/signature_test.go
+++ b/pkg/internal/signutil/signature_test.go
@@ -51,7 +51,7 @@ func TestSignPayload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		signer := ecsigner.New(privateKey, "ES256", "key-1")
 
-		message := "test"
+		message := []byte("test")
 		jwsSignature, err := SignPayload(message, signer)
 		require.NoError(t, err)
 		require.NotEmpty(t, jwsSignature)
@@ -62,13 +62,13 @@ func TestSignPayload(t *testing.T) {
 	t.Run("signing algorithm required", func(t *testing.T) {
 		signer := ecsigner.New(privateKey, "", "kid")
 
-		jws, err := SignPayload("test", signer)
+		jws, err := SignPayload([]byte("test"), signer)
 		require.Error(t, err)
 		require.Empty(t, jws)
 		require.Contains(t, err.Error(), "signing algorithm is required")
 	})
 	t.Run("kid is required", func(t *testing.T) {
-		jws, err := SignPayload("", NewMockSigner(errors.New("test error"), true))
+		jws, err := SignPayload([]byte(""), NewMockSigner(errors.New("test error"), true))
 		require.Error(t, err)
 		require.Empty(t, jws)
 		require.Contains(t, err.Error(), "test error")

--- a/pkg/operation/deactivate.go
+++ b/pkg/operation/deactivate.go
@@ -9,10 +9,10 @@ package operation
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -40,7 +40,7 @@ func parseDeactivateRequest(payload []byte) (*model.DeactivateRequest, error) {
 	schema := &model.DeactivateRequest{}
 	err := json.Unmarshal(payload, schema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal deactivate request: %s", err.Error())
 	}
 
 	if err := validateDeactivateRequest(schema); err != nil {
@@ -65,18 +65,13 @@ func validateDeactivateRequest(req *model.DeactivateRequest) error {
 func parseSignedDataForDeactivate(req *model.DeactivateRequest) (*model.DeactivateSignedDataModel, error) {
 	jws, err := parseSignedData(req.SignedData)
 	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := docutil.DecodeString(string(jws.Payload))
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("deactivate: %s", err.Error())
 	}
 
 	signedData := &model.DeactivateSignedDataModel{}
-	err = json.Unmarshal(bytes, signedData)
+	err = json.Unmarshal(jws.Payload, signedData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal signed data model for deactivate: %s", err.Error())
 	}
 
 	if signedData.DidSuffix != req.DidSuffix {

--- a/pkg/operation/deactivate_test.go
+++ b/pkg/operation/deactivate_test.go
@@ -83,6 +83,22 @@ func TestParseDeactivateOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "signed did suffix mismatch for deactivate")
 		require.Nil(t, op)
 	})
+	t.Run("parse signed data error - unmarshal signed data failed", func(t *testing.T) {
+		deactivateRequest, err := getDefaultDeactivateRequest()
+		require.NoError(t, err)
+
+		compactJWS, err := signutil.SignPayload([]byte("payload"), NewMockSigner())
+		require.NoError(t, err)
+
+		deactivateRequest.SignedData = compactJWS
+		request, err := json.Marshal(deactivateRequest)
+		require.NoError(t, err)
+
+		op, err := ParseDeactivateOperation(request, p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to unmarshal signed data model for deactivate")
+		require.Nil(t, op)
+	})
 }
 
 func getDeactivateRequest(signedData *model.DeactivateSignedDataModel) (*model.DeactivateRequest, error) {

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -21,7 +21,7 @@ func ParseOperation(namespace string, operationBuffer []byte, protocol protocol.
 	schema := &operationSchema{}
 	err := json.Unmarshal(operationBuffer, schema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal operation buffer into operation schema: %s", err.Error())
 	}
 
 	var op *batch.Operation

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -75,6 +75,12 @@ func TestGetOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "not implemented")
 		require.Nil(t, op)
 	})
+	t.Run("unmarshal request error - not JSON", func(t *testing.T) {
+		op, err := ParseOperation(namespace, []byte("operation"), p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to unmarshal operation buffer into operation schema")
+		require.Nil(t, op)
+	})
 }
 
 func getUnsupportedRequest() []byte {

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -53,7 +53,7 @@ func parseRecoverRequest(payload []byte) (*model.RecoverRequest, error) {
 	schema := &model.RecoverRequest{}
 	err := json.Unmarshal(payload, schema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal recover request: %s", err.Error())
 	}
 
 	if err := validateRecoverRequest(schema); err != nil {
@@ -66,18 +66,13 @@ func parseRecoverRequest(payload []byte) (*model.RecoverRequest, error) {
 func parseSignedDataForRecovery(compactJWS string, code uint) (*model.RecoverSignedDataModel, error) {
 	jws, err := parseSignedData(compactJWS)
 	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := docutil.DecodeString(string(jws.Payload))
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("recover: %s", err.Error())
 	}
 
 	schema := &model.RecoverSignedDataModel{}
-	err = json.Unmarshal(bytes, schema)
+	err = json.Unmarshal(jws.Payload, schema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal signed data model for recover: %s", err.Error())
 	}
 
 	if err := validateSignedDataForRecovery(schema, code); err != nil {
@@ -104,7 +99,12 @@ func validateSignedDataForRecovery(signedData *model.RecoverSignedDataModel, cod
 }
 
 func parseSignedData(compactJWS string) (*internal.JSONWebSignature, error) {
-	return internal.ParseJWS(compactJWS)
+	jws, err := internal.ParseJWS(compactJWS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse signed data: %s", err.Error())
+	}
+
+	return jws, nil
 }
 
 func validateRecoverRequest(recover *model.RecoverRequest) error {

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -97,6 +97,22 @@ func TestParseRecoverOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid JWS compact format")
 		require.Nil(t, op)
 	})
+	t.Run("parse signed data error - unmarshal failed", func(t *testing.T) {
+		recoverRequest, err := getDefaultRecoverRequest()
+		require.NoError(t, err)
+
+		compactJWS, err := signutil.SignPayload([]byte("payload"), NewMockSigner())
+		require.NoError(t, err)
+
+		recoverRequest.SignedData = compactJWS
+		request, err := json.Marshal(recoverRequest)
+		require.NoError(t, err)
+
+		op, err := ParseRecoverOperation(request, p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to unmarshal signed data model for recover")
+		require.Nil(t, op)
+	})
 	t.Run("validate signed data error", func(t *testing.T) {
 		signedData := getSignedDataForRecovery()
 		signedData.RecoveryKey = nil

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -48,7 +48,7 @@ func parseUpdateRequest(payload []byte) (*model.UpdateRequest, error) {
 	schema := &model.UpdateRequest{}
 	err := json.Unmarshal(payload, schema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal update request: %s", err.Error())
 	}
 
 	if err := validateUpdateRequest(schema); err != nil {
@@ -61,18 +61,13 @@ func parseUpdateRequest(payload []byte) (*model.UpdateRequest, error) {
 func parseSignedDataForUpdate(compactJWS string, code uint) (*model.UpdateSignedDataModel, error) {
 	jws, err := parseSignedData(compactJWS)
 	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := docutil.DecodeString(string(jws.Payload))
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("update: %s", err.Error())
 	}
 
 	schema := &model.UpdateSignedDataModel{}
-	err = json.Unmarshal(bytes, schema)
+	err = json.Unmarshal(jws.Payload, schema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal signed data model for update: %s", err.Error())
 	}
 
 	if err := validateSignedDataForUpdate(schema, code); err != nil {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -190,15 +190,10 @@ func (s *OperationProcessor) applyUpdateOperation(operation *batch.Operation, rm
 		return nil, err
 	}
 
-	decoded, err := docutil.DecodeString(string(jwsParts.Payload))
-	if err != nil {
-		return nil, err
-	}
-
 	var signedDataModel model.UpdateSignedDataModel
-	err = json.Unmarshal(decoded, &signedDataModel)
+	err = json.Unmarshal(jwsParts.Payload, &signedDataModel)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal signed data model while applying update: %s", err.Error())
 	}
 
 	// TODO: protocol should be calculated based on transaction number
@@ -259,15 +254,10 @@ func (s *OperationProcessor) applyDeactivateOperation(operation *batch.Operation
 		return nil, err
 	}
 
-	decoded, err := docutil.DecodeString(string(jwsParts.Payload))
-	if err != nil {
-		return nil, err
-	}
-
 	var signedDataModel model.DeactivateSignedDataModel
-	err = json.Unmarshal(decoded, &signedDataModel)
+	err = json.Unmarshal(jwsParts.Payload, &signedDataModel)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal signed data model while applying deactivate: %s", err.Error())
 	}
 
 	// verify signed did suffix against actual did suffix
@@ -314,15 +304,10 @@ func (s *OperationProcessor) applyRecoverOperation(operation *batch.Operation, r
 		return nil, err
 	}
 
-	decoded, err := docutil.DecodeString(string(jwsParts.Payload))
-	if err != nil {
-		return nil, err
-	}
-
 	var signedDataModel model.RecoverSignedDataModel
-	err = json.Unmarshal(decoded, &signedDataModel)
+	err = json.Unmarshal(jwsParts.Payload, &signedDataModel)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal signed data model while applying recover: %s", err.Error())
 	}
 
 	// TODO: protocol should be calculated based on transaction number


### PR DESCRIPTION
In order to make update, recover, deactivate tests from reference implementation work, following fixes need to be applied:
- signature payload should not be encoded

Closes #331

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>