### PR TITLE
chore: verify suffix data delta hash against delta (create)

### DIFF
--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -430,9 +430,7 @@ func getCreateRequestWithDoc(doc string) (*model.CreateRequest, error) {
 		return nil, err
 	}
 
-	encodedDelta := docutil.EncodeToString(deltaBytes)
-
-	suffixData, err := getSuffixData(encodedDelta)
+	suffixData, err := getSuffixData(deltaBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +444,7 @@ func getCreateRequestWithDoc(doc string) (*model.CreateRequest, error) {
 
 	return &model.CreateRequest{
 		Operation:  model.OperationTypeCreate,
-		Delta:      encodedDelta,
+		Delta:      docutil.EncodeToString(deltaBytes),
 		SuffixData: encodedSuffixData,
 	}, nil
 }
@@ -459,7 +457,7 @@ func getDeltaWithDoc(doc string) (*model.DeltaModel, error) {
 
 	return &model.DeltaModel{
 		Patches:          []patch.Patch{patches},
-		UpdateCommitment: encodedMultihash("updateReveal"),
+		UpdateCommitment: encodedMultihash([]byte("updateReveal")),
 	}, nil
 }
 
@@ -477,7 +475,7 @@ func newAddPublicKeysPatch(doc string) (patch.Patch, error) {
 	return p, nil
 }
 
-func getSuffixData(encodedDelta string) (*model.SuffixDataModel, error) {
+func getSuffixData(delta []byte) (*model.SuffixDataModel, error) {
 	jwk := &jws.JWK{
 		Kty: "kty",
 		Crv: "crv",
@@ -490,13 +488,13 @@ func getSuffixData(encodedDelta string) (*model.SuffixDataModel, error) {
 	}
 
 	return &model.SuffixDataModel{
-		DeltaHash:          encodedMultihash(encodedDelta),
+		DeltaHash:          encodedMultihash(delta),
 		RecoveryCommitment: c,
 	}, nil
 }
 
-func encodedMultihash(data string) string {
-	mh, err := docutil.ComputeMultihash(sha2_256, []byte(data))
+func encodedMultihash(data []byte) string {
+	mh, err := docutil.ComputeMultihash(sha2_256, data)
 	if err != nil {
 		panic(err)
 	}
@@ -518,7 +516,7 @@ func getUpdateRequest() (*model.UpdateRequest, error) {
 
 func getUpdateDelta() *model.DeltaModel {
 	return &model.DeltaModel{
-		UpdateCommitment: encodedMultihash("updateReveal"),
+		UpdateCommitment: encodedMultihash([]byte("updateReveal")),
 	}
 }
 

--- a/pkg/docutil/hash.go
+++ b/pkg/docutil/hash.go
@@ -8,6 +8,7 @@ package docutil
 
 import (
 	"crypto"
+	"errors"
 	"fmt"
 	"hash"
 
@@ -76,4 +77,30 @@ func GetMultihashCode(encodedMultihash string) (uint64, error) {
 	}
 
 	return mh.Code, nil
+}
+
+// IsValidHash compares encoded content with encoded multihash
+func IsValidHash(encodedContent, encodedMultihash string) error {
+	content, err := DecodeString(encodedContent)
+	if err != nil {
+		return err
+	}
+
+	code, err := GetMultihashCode(encodedMultihash)
+	if err != nil {
+		return err
+	}
+
+	computedMultihash, err := ComputeMultihash(uint(code), content)
+	if err != nil {
+		return err
+	}
+
+	encodedComputedMultihash := EncodeToString(computedMultihash)
+
+	if encodedComputedMultihash != encodedMultihash {
+		return errors.New("supplied hash doesn't match original content")
+	}
+
+	return nil
 }

--- a/pkg/docutil/hash_test.go
+++ b/pkg/docutil/hash_test.go
@@ -71,3 +71,25 @@ func TestIsComputedUsingHashAlgorithm(t *testing.T) {
 	ok = IsComputedUsingHashAlgorithm("invalid", sha2_256)
 	require.False(t, ok)
 }
+
+func TestIsValidHash(t *testing.T) {
+	multihash, err := ComputeMultihash(sha2_256, []byte("test"))
+	require.NoError(t, err)
+
+	encodedMultihash := EncodeToString(multihash)
+
+	err = IsValidHash(EncodeToString([]byte("test")), encodedMultihash)
+	require.NoError(t, err)
+
+	err = IsValidHash("hello", encodedMultihash)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "illegal base64 data at input byte 4")
+
+	err = IsValidHash(EncodeToString([]byte("content")), string(multihash))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "illegal base64 data at input byte 0")
+
+	err = IsValidHash(EncodeToString([]byte("content")), encodedMultihash)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "supplied hash doesn't match original content")
+}

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -8,6 +8,7 @@ package operation
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -34,6 +35,12 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 	delta, err := ParseDelta(schema.Delta, code)
 	if err != nil {
 		return nil, err
+	}
+
+	// verify actual delta hash matches expected delta hash
+	err = docutil.IsValidHash(schema.Delta, suffixData.DeltaHash)
+	if err != nil {
+		return nil, fmt.Errorf("parse create operation: delta doesn't match suffix data delta hash: %s", err.Error())
 	}
 
 	uniqueSuffix, err := docutil.CalculateUniqueSuffix(schema.SuffixData, code)

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -275,8 +275,8 @@ func getSignedDataForRecovery() *model.RecoverSignedDataModel {
 			Crv: "crv",
 			X:   "x",
 		},
-		RecoveryCommitment: computeMultihash("recoveryReveal"),
-		DeltaHash:          computeMultihash("operation"),
+		RecoveryCommitment: computeMultihash([]byte("recoveryReveal")),
+		DeltaHash:          computeMultihash([]byte("operation")),
 	}
 }
 

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -208,7 +208,7 @@ func getUpdateRequest(delta *model.DeltaModel) (*model.UpdateRequest, error) {
 	}
 
 	signedModel := model.UpdateSignedDataModel{
-		DeltaHash: computeMultihash(string(deltaBytes)),
+		DeltaHash: computeMultihash(deltaBytes),
 		UpdateKey: updateKey}
 
 	compactJWS, err := signutil.SignModel(signedModel, NewMockSigner())
@@ -248,7 +248,7 @@ func getUpdateDelta() (*model.DeltaModel, error) {
 	}
 
 	return &model.DeltaModel{
-		UpdateCommitment: computeMultihash("updateReveal"),
+		UpdateCommitment: computeMultihash([]byte("updateReveal")),
 		Patches:          []patch.Patch{jsonPatch},
 	}, nil
 }

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -138,14 +138,24 @@ func getSuffixData() (*model.SuffixDataModel, error) {
 		return nil, err
 	}
 
+	delta, err := getDelta()
+	if err != nil {
+		return nil, err
+	}
+
+	deltaBytes, err := canonicalizer.MarshalCanonical(delta)
+	if err != nil {
+		return nil, err
+	}
+
 	return &model.SuffixDataModel{
-		DeltaHash:          computeMultihash(validDoc),
+		DeltaHash:          computeMultihash(deltaBytes),
 		RecoveryCommitment: recoveryCommitment,
 	}, nil
 }
 
-func computeMultihash(data string) string {
-	mh, err := docutil.ComputeMultihash(sha2_256, []byte(data))
+func computeMultihash(data []byte) string {
+	mh, err := docutil.ComputeMultihash(sha2_256, data)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/txnhandler/models/anchor.go
+++ b/pkg/txnhandler/models/anchor.go
@@ -18,7 +18,7 @@ type AnchorFile struct {
 	MapFileHash string `json:"mapFileHash,omitempty"`
 
 	// Operations contain proving data for create, recover and deactivate operations
-	Operations Operations `json:"Operations"`
+	Operations Operations `json:"operations"`
 }
 
 //CreateOperation contains create operation data

--- a/pkg/txnhandler/models/map.go
+++ b/pkg/txnhandler/models/map.go
@@ -15,7 +15,7 @@ import (
 // MapFile defines the schema for map file and its related operations
 type MapFile struct {
 	Chunks     []Chunk    `json:"chunks"`
-	Operations Operations `json:"Operations,omitempty"`
+	Operations Operations `json:"operations,omitempty"`
 }
 
 // Chunk holds chunk file URI


### PR DESCRIPTION
Add verification that suffix data delta hash matches provided delta:
- during operation validation for create
- when applying create operation during resolution

Closes #338

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>