### PR TITLE
feat: Get protocol parameters by transaction number

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -9,7 +9,7 @@ package protocol
 // Protocol defines protocol parameters
 type Protocol struct {
 	// StartingBlockChainTime is inclusive starting logical blockchain time that this protocol applies to.
-	StartingBlockChainTime uint
+	StartingBlockChainTime uint64
 	// HashAlgorithmInMultiHashCode is hash algorithm in multihash code
 	HashAlgorithmInMultiHashCode uint
 	// MaxOperationsPerBatch defines maximum operations per batch
@@ -31,6 +31,8 @@ type Client interface {
 
 	// Current returns latest version of protocol
 	Current() Protocol
+
+	Get(transactionTime uint64) (Protocol, error)
 }
 
 // ClientProvider returns a protocol client for the given namespace

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -125,7 +125,7 @@ func validateDelta(delta *model.DeltaModel, code uint) error {
 	}
 
 	if !docutil.IsComputedUsingHashAlgorithm(delta.UpdateCommitment, uint64(code)) {
-		return errors.New("next update commitment hash is not computed with the latest supported hash algorithm")
+		return fmt.Errorf("next update commitment hash is not computed with the required supported hash algorithm: %d", code)
 	}
 
 	return nil
@@ -133,11 +133,11 @@ func validateDelta(delta *model.DeltaModel, code uint) error {
 
 func validateSuffixData(suffixData *model.SuffixDataModel, code uint) error {
 	if !docutil.IsComputedUsingHashAlgorithm(suffixData.RecoveryCommitment, uint64(code)) {
-		return errors.New("next recovery commitment hash is not computed with the latest supported hash algorithm")
+		return fmt.Errorf("next recovery commitment hash is not computed with the required supported hash algorithm: %d", code)
 	}
 
 	if !docutil.IsComputedUsingHashAlgorithm(suffixData.DeltaHash, uint64(code)) {
-		return errors.New("patch data hash is not computed with the latest supported hash algorithm")
+		return fmt.Errorf("patch data hash is not computed with the required supported hash algorithm: %d", code)
 	}
 
 	return nil

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -123,7 +123,7 @@ func TestValidateSuffixData(t *testing.T) {
 		suffixData.DeltaHash = ""
 		err = validateSuffixData(suffixData, sha2_256)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "patch data hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "patch data hash is not computed with the required supported hash algorithm")
 	})
 	t.Run("invalid next recovery commitment hash", func(t *testing.T) {
 		suffixData, err := getSuffixData()
@@ -132,7 +132,7 @@ func TestValidateSuffixData(t *testing.T) {
 		suffixData.RecoveryCommitment = ""
 		err = validateSuffixData(suffixData, sha2_256)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "next recovery commitment hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "next recovery commitment hash is not computed with the required supported hash algorithm")
 	})
 }
 
@@ -151,7 +151,7 @@ func TestValidateDelta(t *testing.T) {
 		err = validateDelta(delta, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"next update commitment hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the required supported hash algorithm")
 	})
 	t.Run("missing patches", func(t *testing.T) {
 		delta, err := getDelta()

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -65,7 +65,7 @@ func TestGetOperation(t *testing.T) {
 
 		op, err := ParseOperation(namespace, operation, invalid)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "next update commitment hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "next update commitment hash is not computed with the required supported hash algorithm")
 		require.Nil(t, op)
 	})
 	t.Run("unsupported operation type error", func(t *testing.T) {

--- a/pkg/operation/recover_test.go
+++ b/pkg/operation/recover_test.go
@@ -147,14 +147,14 @@ func TestValidateSignedDataForRecovery(t *testing.T) {
 		signed.DeltaHash = ""
 		err := validateSignedDataForRecovery(signed, sha2_256)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "patch data hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "patch data hash is not computed with the required hash algorithm")
 	})
 	t.Run("invalid next recovery commitment hash", func(t *testing.T) {
 		signed := getSignedDataForRecovery()
 		signed.RecoveryCommitment = ""
 		err := validateSignedDataForRecovery(signed, sha2_256)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "next recovery commitment hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "next recovery commitment hash is not computed with the required hash algorithm")
 	})
 }
 
@@ -176,7 +176,7 @@ func TestParseSignedData(t *testing.T) {
 		jws, err := parseSignedData("")
 		require.Error(t, err)
 		require.Nil(t, jws)
-		require.Contains(t, err.Error(), "invalid JWS compact format")
+		require.Contains(t, err.Error(), "missing signed data")
 	})
 	t.Run("missing protected headers", func(t *testing.T) {
 		jws, err := parseSignedData(".cGF5bG9hZA.c2lnbmF0dXJl")

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -24,7 +24,7 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
-	_, err = parseSignedDataForUpdate(schema.SignedData, protocol.HashAlgorithmInMultiHashCode)
+	_, err = ParseSignedDataForUpdate(schema.SignedData, protocol.HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,8 @@ func parseUpdateRequest(payload []byte) (*model.UpdateRequest, error) {
 	return schema, nil
 }
 
-func parseSignedDataForUpdate(compactJWS string, code uint) (*model.UpdateSignedDataModel, error) {
+// ParseSignedDataForUpdate will parse and validate signed data for update
+func ParseSignedDataForUpdate(compactJWS string, code uint) (*model.UpdateSignedDataModel, error) {
 	jws, err := parseSignedData(compactJWS)
 	if err != nil {
 		return nil, fmt.Errorf("update: %s", err.Error())

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -67,7 +67,7 @@ func TestParseUpdateOperation(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(),
-			"next update commitment hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the required supported hash algorithm")
 	})
 	t.Run("invalid signed data", func(t *testing.T) {
 		delta, err := getUpdateDelta()
@@ -108,12 +108,12 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 		req, err := getDefaultUpdateRequest()
 		require.NoError(t, err)
 
-		schema, err := parseSignedDataForUpdate(req.SignedData, sha2_256)
+		schema, err := ParseSignedDataForUpdate(req.SignedData, sha2_256)
 		require.NoError(t, err)
 		require.NotNil(t, schema)
 	})
 	t.Run("invalid JWS compact format", func(t *testing.T) {
-		schema, err := parseSignedDataForUpdate("invalid", sha2_256)
+		schema, err := ParseSignedDataForUpdate("invalid", sha2_256)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "invalid JWS compact format")
@@ -129,7 +129,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 
 		compactJWS, err := signutil.SignPayload(payload, NewMockSigner())
 
-		schema, err := parseSignedDataForUpdate(compactJWS, sha2_256)
+		schema, err := ParseSignedDataForUpdate(compactJWS, sha2_256)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "delta hash is not computed with the latest supported hash algorithm")
@@ -138,7 +138,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 		compactJWS, err := signutil.SignPayload([]byte("test"), NewMockSigner())
 		require.NoError(t, err)
 
-		schema, err := parseSignedDataForUpdate(compactJWS, sha2_256)
+		schema, err := ParseSignedDataForUpdate(compactJWS, sha2_256)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "invalid character")
@@ -154,7 +154,7 @@ func TestValidateUpdateDelta(t *testing.T) {
 		err = validateDelta(delta, sha2_256)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"next update commitment hash is not computed with the latest supported hash algorithm")
+			"next update commitment hash is not computed with the required supported hash algorithm")
 	})
 }
 

--- a/pkg/txnhandler/provider_test.go
+++ b/pkg/txnhandler/provider_test.go
@@ -124,7 +124,7 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		require.NotEmpty(t, anchorString)
 
 		invalid := mocks.NewMockProtocolClient()
-		invalid.Protocol.HashAlgorithmInMultiHashCode = 55
+		invalid.Versions[0].HashAlgorithmInMultiHashCode = 55
 
 		pcp := mocks.NewMockProtocolClientProvider()
 		pcp.ProtocolClients[mocks.DefaultNS] = invalid


### PR DESCRIPTION
Add to protocol interface get function for retrieving protocol parameters by transaction number (block number). So far we were only retrieving latest protocol.

Also, re-used common code for parsing signed data.

Closes #348

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>