### PR TITLE
chore: protected header validation rules

### DIFF
--- a/pkg/restapi/helper/recover.go
+++ b/pkg/restapi/helper/recover.go
@@ -95,7 +95,7 @@ func validateRecoverRequest(info *RecoverRequestInfo) error {
 		return errors.New("missing opaque document")
 	}
 
-	if err := validateSigner(info.Signer, true); err != nil {
+	if err := validateSigner(info.Signer); err != nil {
 		return err
 	}
 

--- a/pkg/restapi/helper/recover_test.go
+++ b/pkg/restapi/helper/recover_test.go
@@ -68,7 +68,7 @@ func TestNewRecoverRequest(t *testing.T) {
 	})
 	t.Run("signing error", func(t *testing.T) {
 		info := getRecoverRequestInfo()
-		info.Signer = NewMockSigner(errors.New(signerErr), true)
+		info.Signer = NewMockSigner(errors.New(signerErr))
 
 		request, err := NewRecoverRequest(info)
 		require.Error(t, err)

--- a/pkg/restapi/helper/update.go
+++ b/pkg/restapi/helper/update.go
@@ -85,5 +85,5 @@ func validateUpdateRequest(info *UpdateRequestInfo) error {
 		return errors.New("missing update information")
 	}
 
-	return validateSigner(info.Signer, false)
+	return validateSigner(info.Signer)
 }

--- a/pkg/util/ecsigner/signer.go
+++ b/pkg/util/ecsigner/signer.go
@@ -34,10 +34,7 @@ func New(privKey *ecdsa.PrivateKey, alg, kid string) *Signer {
 func (signer *Signer) Headers() jws.Headers {
 	headers := make(jws.Headers)
 	headers[jws.HeaderAlgorithm] = signer.alg
-
-	if signer.kid != "" {
-		headers[jws.HeaderKeyID] = signer.kid
-	}
+	headers[jws.HeaderKeyID] = signer.kid
 
 	return headers
 }

--- a/pkg/util/edsigner/signer.go
+++ b/pkg/util/edsigner/signer.go
@@ -29,10 +29,7 @@ func New(privKey ed25519.PrivateKey, alg, kid string) *Signer {
 func (signer *Signer) Headers() jws.Headers {
 	headers := make(jws.Headers)
 	headers[jws.HeaderAlgorithm] = signer.alg
-
-	if signer.kid != "" {
-		headers[jws.HeaderKeyID] = signer.kid
-	}
+	headers[jws.HeaderKeyID] = signer.kid
 
 	return headers
 }


### PR DESCRIPTION
Implement latest protected header validation rules:
- kid MUST be present in the protected header
- alg MUST be present in the protected header, its value MUST NOT be none
- no additional members may be present in the protected header

Closes #325

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>