### PR TITLE
chore: use underscores for internal JSON model

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -10,70 +10,64 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
-// Operation defines an operation
+// Operation is used for parsing operation request
 type Operation struct {
 
-	//Operation type
-	Type OperationType `json:"type"`
+	//Type defines operation type
+	Type OperationType
 
-	Namespace string `json:"namespace"`
+	//Namespace defines document namespace
+	Namespace string
 
-	//ID is full ID for this document - includes namespace + unique suffix
-	ID string `json:"id"`
+	// ID is full ID for this document -  namespace + unique suffix
+	ID string
 
-	//The unique suffix - encoded hash of the original create document
-	UniqueSuffix string `json:"uniqueSuffix"`
+	//UniqueSuffix is unique suffix
+	UniqueSuffix string
 
 	// OperationBuffer is the original operation request
-	OperationBuffer []byte `json:"operationBuffer"`
+	OperationBuffer []byte
 
-	// Compact JWS - signed data for the operation
-	SignedData string `json:"signedData"`
+	//SignedData is signed data for the operation (compact JWS)
+	SignedData string
 
-	// operation delta
-	Delta *model.DeltaModel `json:"delta"`
+	// DeltaModel is operation delta model
+	DeltaModel *model.DeltaModel
 
-	// encoded delta
-	EncodedDelta string `json:"encodedDelta"`
+	// Delta is encoded delta
+	Delta string
 
-	// suffix data
-	SuffixData *model.SuffixDataModel `json:"suffixData"`
+	// SuffixDataModel is suffix data model
+	SuffixDataModel *model.SuffixDataModel
 
-	// encoded suffix data
-	EncodedSuffixData string `json:"encodedSuffixData"`
-
-	//The logical blockchain time that this operation was anchored on the blockchain
-	TransactionTime uint64 `json:"transactionTime"`
-	//The transaction number of the transaction this operation was batched within
-	TransactionNumber uint64 `json:"transactionNumber"`
-	//The index this operation was assigned to in the batch
-	OperationIndex uint `json:"operationIndex"`
+	// SuffixData is encoded suffix data
+	SuffixData string
 }
 
-// AnchoredOperation defines an anchored operation
+// AnchoredOperation defines an anchored operation (stored in document operation store)
 type AnchoredOperation struct {
 
-	//Operation type
+	//Type defines operation type
 	Type OperationType `json:"type"`
 
-	//The unique suffix - encoded hash of the original create document
-	UniqueSuffix string `json:"uniqueSuffix"`
+	//UniqueSuffix defines document unique suffix
+	UniqueSuffix string `json:"unique_suffix"`
 
-	// Compact JWS - signed data for the operation
-	SignedData string `json:"signedData,omitempty"`
+	//SignedData is signed data for the operation (compact JWS)
+	SignedData string `json:"signed_data,omitempty"`
 
-	// encoded delta
-	EncodedDelta string `json:"encodedDelta,omitempty"`
+	//Delta is encoded delta
+	Delta string `json:"delta,omitempty"`
 
-	// encoded suffix data
-	EncodedSuffixData string `json:"encodedSuffixData,omitempty"`
+	//SuffixData is encoded suffix data
+	SuffixData string `json:"suffix_data,omitempty"`
 
-	//The logical blockchain time that this operation was anchored on the blockchain
-	TransactionTime uint64 `json:"transactionTime"`
+	//The logical blockchain time (block number) that this operation was anchored on the blockchain
+	TransactionTime uint64 `json:"transaction_time"`
 	//The transaction number of the transaction this operation was batched within
-	TransactionNumber uint64 `json:"transactionNumber"`
+	TransactionNumber uint64 `json:"transaction_number"`
 	//The index this operation was assigned to in the batch
-	OperationIndex uint `json:"operationIndex"`
+	OperationIndex uint `json:"operation_index"`
 }
 
 // OperationType defines valid values for operation type

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -117,7 +117,7 @@ func (r *DocumentHandler) ProcessOperation(operation *batch.Operation) (*documen
 }
 
 func (r *DocumentHandler) getCreateResponse(operation *batch.Operation) (*document.ResolutionResult, error) {
-	doc, err := getInitialDocument(operation.Delta.Patches)
+	doc, err := getInitialDocument(operation.DeltaModel.Patches)
 	if err != nil {
 		return nil, err
 	}
@@ -128,8 +128,8 @@ func (r *DocumentHandler) getCreateResponse(operation *batch.Operation) (*docume
 	}
 
 	externalResult.MethodMetadata.Published = false
-	externalResult.MethodMetadata.RecoveryCommitment = operation.SuffixData.RecoveryCommitment
-	externalResult.MethodMetadata.UpdateCommitment = operation.Delta.UpdateCommitment
+	externalResult.MethodMetadata.RecoveryCommitment = operation.SuffixDataModel.RecoveryCommitment
+	externalResult.MethodMetadata.UpdateCommitment = operation.DeltaModel.UpdateCommitment
 
 	return externalResult, nil
 }
@@ -215,7 +215,7 @@ func (r *DocumentHandler) resolveRequestWithDocument(id string, initial *model.C
 		return nil, fmt.Errorf("%s: provided did doesn't match did created from initial state", badRequest)
 	}
 
-	if err := r.validateInitialDocument(op.Delta.Patches); err != nil {
+	if err := r.validateInitialDocument(op.DeltaModel.Patches); err != nil {
 		return nil, fmt.Errorf("%s: validate initial document: %s", badRequest, err.Error())
 	}
 
@@ -246,12 +246,12 @@ func (r *DocumentHandler) addToBatch(operation *batch.Operation) error {
 // validateOperation validates the operation
 func (r *DocumentHandler) validateOperation(operation *batch.Operation) error {
 	// check maximum operation size against protocol
-	if len(operation.EncodedDelta) > int(r.protocol.Current().MaxDeltaByteSize) {
+	if len(operation.Delta) > int(r.protocol.Current().MaxDeltaByteSize) {
 		return errors.New("delta byte size exceeds protocol max delta byte size")
 	}
 
 	if operation.Type == batch.OperationTypeCreate {
-		return r.validateInitialDocument(operation.Delta.Patches)
+		return r.validateInitialDocument(operation.DeltaModel.Patches)
 	}
 
 	return r.validator.IsValidPayload(operation.OperationBuffer)

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -70,7 +70,7 @@ func TestDocumentHandler_ProcessOperation_InitialDocumentError(t *testing.T) {
 
 	createOp := getCreateOperation()
 
-	createOp.Delta = &model.DeltaModel{
+	createOp.DeltaModel = &model.DeltaModel{
 		Patches: []patch.Patch{replacePatch},
 	}
 
@@ -377,14 +377,14 @@ func getCreateOperationWithInitialState(suffixData, delta string) (*batchapi.Ope
 	}
 
 	return &batchapi.Operation{
-		Type:              batchapi.OperationTypeCreate,
-		UniqueSuffix:      uniqueSuffix,
-		ID:                namespace + docutil.NamespaceDelimiter + uniqueSuffix,
-		OperationBuffer:   payload,
-		Delta:             deltaModel,
-		EncodedDelta:      delta,
-		EncodedSuffixData: suffixData,
-		SuffixData:        suffixDataModel,
+		Type:            batchapi.OperationTypeCreate,
+		UniqueSuffix:    uniqueSuffix,
+		ID:              namespace + docutil.NamespaceDelimiter + uniqueSuffix,
+		OperationBuffer: payload,
+		DeltaModel:      deltaModel,
+		Delta:           delta,
+		SuffixData:      suffixData,
+		SuffixDataModel: suffixDataModel,
 	}, nil
 }
 
@@ -392,10 +392,10 @@ func getAnchoredCreateOperation() *batchapi.AnchoredOperation {
 	op := getCreateOperation()
 
 	return &batchapi.AnchoredOperation{
-		Type:              op.Type,
-		UniqueSuffix:      op.UniqueSuffix,
-		EncodedDelta:      op.EncodedDelta,
-		EncodedSuffixData: op.EncodedSuffixData,
+		Type:         op.Type,
+		UniqueSuffix: op.UniqueSuffix,
+		Delta:        op.Delta,
+		SuffixData:   op.SuffixData,
 	}
 }
 

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -81,7 +81,7 @@ func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (*doc
 		doc = make(document.Document)
 	}
 
-	doc, err := composer.ApplyPatches(doc, operation.Delta.Patches)
+	doc, err := composer.ApplyPatches(doc, operation.DeltaModel.Patches)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/create.go
+++ b/pkg/operation/create.go
@@ -49,13 +49,13 @@ func ParseCreateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 	}
 
 	return &batch.Operation{
-		OperationBuffer:   request,
-		Type:              batch.OperationTypeCreate,
-		UniqueSuffix:      uniqueSuffix,
-		Delta:             delta,
-		EncodedDelta:      schema.Delta,
-		SuffixData:        suffixData,
-		EncodedSuffixData: schema.SuffixData,
+		OperationBuffer: request,
+		Type:            batch.OperationTypeCreate,
+		UniqueSuffix:    uniqueSuffix,
+		DeltaModel:      delta,
+		Delta:           schema.Delta,
+		SuffixDataModel: suffixData,
+		SuffixData:      schema.SuffixData,
 	}, nil
 }
 

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -43,8 +43,8 @@ func ParseRecoverOperation(request []byte, protocol protocol.Protocol) (*batch.O
 		OperationBuffer: request,
 		Type:            batch.OperationTypeRecover,
 		UniqueSuffix:    schema.DidSuffix,
-		Delta:           delta,
-		EncodedDelta:    schema.Delta,
+		DeltaModel:      delta,
+		Delta:           schema.Delta,
 		SignedData:      schema.SignedData,
 	}, nil
 }

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -38,8 +38,8 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		Type:            batch.OperationTypeUpdate,
 		OperationBuffer: request,
 		UniqueSuffix:    schema.DidSuffix,
-		Delta:           delta,
-		EncodedDelta:    schema.Delta,
+		DeltaModel:      delta,
+		Delta:           schema.Delta,
 		SignedData:      schema.SignedData,
 	}, nil
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -231,18 +231,18 @@ func (s *OperationProcessor) applyCreateOperation(op *batch.AnchoredOperation, p
 		return nil, errors.New("create has to be the first operation")
 	}
 
-	suffixData, err := operation.ParseSuffixData(op.EncodedSuffixData, p.HashAlgorithmInMultiHashCode)
+	suffixData, err := operation.ParseSuffixData(op.SuffixData, p.HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse suffix data: %s", err.Error())
 	}
 
 	// verify actual delta hash matches expected delta hash
-	err = docutil.IsValidHash(op.EncodedDelta, suffixData.DeltaHash)
+	err = docutil.IsValidHash(op.Delta, suffixData.DeltaHash)
 	if err != nil {
 		return nil, fmt.Errorf("create delta doesn't match suffix data delta hash: %s", err.Error())
 	}
 
-	delta, err := operation.ParseDelta(op.EncodedDelta, p.HashAlgorithmInMultiHashCode)
+	delta, err := operation.ParseDelta(op.Delta, p.HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
@@ -284,7 +284,7 @@ func (s *OperationProcessor) applyUpdateOperation(op *batch.AnchoredOperation, p
 	}
 
 	// verify the delta against the signed delta hash
-	err = docutil.IsValidHash(op.EncodedDelta, signedDataModel.DeltaHash)
+	err = docutil.IsValidHash(op.Delta, signedDataModel.DeltaHash)
 	if err != nil {
 		return nil, fmt.Errorf("update delta doesn't match delta hash: %s", err.Error())
 	}
@@ -295,7 +295,7 @@ func (s *OperationProcessor) applyUpdateOperation(op *batch.AnchoredOperation, p
 		return nil, fmt.Errorf("failed to check signature: %s", err.Error())
 	}
 
-	delta, err := operation.ParseDelta(op.EncodedDelta, p.HashAlgorithmInMultiHashCode)
+	delta, err := operation.ParseDelta(op.Delta, p.HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
@@ -377,7 +377,7 @@ func (s *OperationProcessor) applyRecoverOperation(op *batch.AnchoredOperation, 
 	}
 
 	// verify the delta against the signed delta hash
-	err = docutil.IsValidHash(op.EncodedDelta, signedDataModel.DeltaHash)
+	err = docutil.IsValidHash(op.Delta, signedDataModel.DeltaHash)
 	if err != nil {
 		return nil, fmt.Errorf("recover delta doesn't match delta hash: %s", err.Error())
 	}
@@ -388,7 +388,7 @@ func (s *OperationProcessor) applyRecoverOperation(op *batch.AnchoredOperation, 
 		return nil, fmt.Errorf("failed to check signature: %s", err.Error())
 	}
 
-	delta, err := operation.ParseDelta(op.EncodedDelta, p.HashAlgorithmInMultiHashCode)
+	delta, err := operation.ParseDelta(op.Delta, p.HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -40,10 +40,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.NoError(t, err)
 
 		result, err := docHandler.ProcessOperation(&batch.Operation{
-			Type:         batch.OperationTypeCreate,
-			ID:           id,
-			Delta:        delta,
-			EncodedDelta: create.Delta,
+			Type:       batch.OperationTypeCreate,
+			ID:         id,
+			DeltaModel: delta,
+			Delta:      create.Delta,
 		})
 		require.NoError(t, err)
 
@@ -148,10 +148,10 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.NoError(t, err)
 
 		result, err := docHandler.ProcessOperation(&batch.Operation{
-			Type:         batch.OperationTypeCreate,
-			ID:           id,
-			Delta:        delta,
-			EncodedDelta: create.Delta,
+			Type:       batch.OperationTypeCreate,
+			ID:         id,
+			DeltaModel: delta,
+			Delta:      create.Delta,
 		})
 		require.NoError(t, err)
 

--- a/pkg/txnhandler/models/anchor.go
+++ b/pkg/txnhandler/models/anchor.go
@@ -61,7 +61,7 @@ func getCreateOperations(ops []*batch.Operation) []CreateOperation {
 	var result []CreateOperation
 	for _, op := range ops {
 		if op.Type == batch.OperationTypeCreate {
-			create := CreateOperation{SuffixData: op.EncodedSuffixData}
+			create := CreateOperation{SuffixData: op.SuffixData}
 
 			result = append(result, create)
 		}

--- a/pkg/txnhandler/models/anchor_test.go
+++ b/pkg/txnhandler/models/anchor_test.go
@@ -73,11 +73,11 @@ func generateOperations(numOfOperations int, opType batch.OperationType) (ops []
 
 func generateOperation(num int, opType batch.OperationType) *batch.Operation {
 	return &batch.Operation{
-		Type:              opType,
-		UniqueSuffix:      fmt.Sprintf("%s-%d", opType, num),
-		Namespace:         "did:sidetree",
-		EncodedSuffixData: "suffix-data",
-		EncodedDelta:      "delta",
-		SignedData:        "signed-data",
+		Type:         opType,
+		UniqueSuffix: fmt.Sprintf("%s-%d", opType, num),
+		Namespace:    "did:sidetree",
+		SuffixData:   "suffix-data",
+		Delta:        "delta",
+		SignedData:   "signed-data",
 	}
 }

--- a/pkg/txnhandler/models/chunk.go
+++ b/pkg/txnhandler/models/chunk.go
@@ -44,7 +44,7 @@ func getDeltas(filter batch.OperationType, ops []*batch.Operation) []string {
 	var deltas []string
 	for _, op := range ops {
 		if op.Type == filter {
-			deltas = append(deltas, op.EncodedDelta)
+			deltas = append(deltas, op.Delta)
 		}
 	}
 

--- a/pkg/txnhandler/provider.go
+++ b/pkg/txnhandler/provider.go
@@ -131,7 +131,7 @@ func (h *OperationProvider) assembleBatchOperations(af *models.AnchorFile, mf *m
 			return nil, fmt.Errorf("parse delta: %s", err.Error())
 		}
 
-		operations[i].EncodedDelta = delta
+		operations[i].Delta = delta
 	}
 
 	return operations, nil
@@ -232,9 +232,9 @@ func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *tx
 
 		// TODO: they are assembling operation buffer in reference implementation (might be easier for version manager)
 		create := &batch.AnchoredOperation{
-			Type:              batch.OperationTypeCreate,
-			UniqueSuffix:      suffix,
-			EncodedSuffixData: op.SuffixData,
+			Type:         batch.OperationTypeCreate,
+			UniqueSuffix: suffix,
+			SuffixData:   op.SuffixData,
 		}
 
 		suffixes = append(suffixes, suffix)

--- a/pkg/txnhandler/provider_test.go
+++ b/pkg/txnhandler/provider_test.go
@@ -409,7 +409,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		af := &models.AnchorFile{
 			MapFileHash: "hash",
 			Operations: models.Operations{
-				Create:     []models.CreateOperation{{SuffixData: createOp.EncodedSuffixData}},
+				Create:     []models.CreateOperation{{SuffixData: createOp.SuffixData}},
 				Deactivate: []models.SignedOperation{{DidSuffix: deactivateOp.UniqueSuffix, SignedData: deactivateOp.SignedData}},
 			},
 		}
@@ -421,7 +421,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 			},
 		}
 
-		cf := &models.ChunkFile{Deltas: []string{createOp.EncodedDelta, updateOp.EncodedDelta}}
+		cf := &models.ChunkFile{Deltas: []string{createOp.Delta, updateOp.Delta}}
 
 		file, err := provider.assembleBatchOperations(af, mf, cf, &txn.SidetreeTxn{Namespace: defaultNS})
 		require.NoError(t, err)
@@ -443,7 +443,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		af := &models.AnchorFile{
 			MapFileHash: "hash",
 			Operations: models.Operations{
-				Create: []models.CreateOperation{{SuffixData: createOp.EncodedSuffixData}},
+				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
 				Deactivate: []models.SignedOperation{
 					{DidSuffix: deactivateOp.UniqueSuffix, SignedData: deactivateOp.SignedData}},
 			},
@@ -457,7 +457,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		}
 
 		// don't add update operation delta to chunk file in order to cause error
-		cf := &models.ChunkFile{Deltas: []string{createOp.EncodedDelta}}
+		cf := &models.ChunkFile{Deltas: []string{createOp.Delta}}
 
 		file, err := provider.assembleBatchOperations(af, mf, cf, &txn.SidetreeTxn{Namespace: defaultNS})
 		require.Error(t, err)
@@ -475,7 +475,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		af := &models.AnchorFile{
 			MapFileHash: "hash",
 			Operations: models.Operations{
-				Create: []models.CreateOperation{{SuffixData: createOp.EncodedSuffixData}},
+				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
 			},
 		}
 


### PR DESCRIPTION
Included:
- use underscores for internal JSON model
- rename anchored operation model fields to match batch files fields
- remove JSON tags from operation model (used for parsing and validating)
- rename operation model fields to match anchored operation model fields
- removed txn fields from operation model

Closes #221

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>