### PR TITLE
chore: add ability to enable 'replace' patch

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -24,6 +24,8 @@ type Protocol struct {
 	MaxMapFileSize uint
 	// MaxChunkFileSize is maximum allowed size (in bytes) of chunk file stored in CAS
 	MaxChunkFileSize uint
+	// EnableReplacePatch is used to enable replace patch (action)
+	EnableReplacePatch bool
 }
 
 // Client defines interface for accessing protocol version/information

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -177,6 +177,10 @@ func TestDocumentHandler_ResolveDocument_Interop(t *testing.T) {
 	dochandler := getDocumentHandler(mocks.NewMockOperationStore(nil))
 	require.NotNil(t, dochandler)
 
+	pc := mocks.NewMockProtocolClient()
+	pc.Protocol.EnableReplacePatch = true
+	dochandler.protocol = pc
+
 	result, err := dochandler.ResolveDocument(interopResolveDidWithInitialState)
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/pkg/operation/recover.go
+++ b/pkg/operation/recover.go
@@ -29,7 +29,7 @@ func ParseRecoverOperation(request []byte, protocol protocol.Protocol) (*batch.O
 
 	code := protocol.HashAlgorithmInMultiHashCode
 
-	delta, err := ParseDelta(schema.Delta, code)
+	delta, err := ParseDelta(schema.Delta, protocol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -29,7 +29,7 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
-	delta, err := ParseDelta(schema.Delta, protocol.HashAlgorithmInMultiHashCode)
+	delta, err := ParseDelta(schema.Delta, protocol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -147,11 +147,15 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 
 func TestValidateUpdateDelta(t *testing.T) {
 	t.Run("invalid next update commitment hash", func(t *testing.T) {
+		p := protocol.Protocol{
+			HashAlgorithmInMultiHashCode: sha2_256,
+		}
+
 		delta, err := getUpdateDelta()
 		require.NoError(t, err)
 
 		delta.UpdateCommitment = ""
-		err = validateDelta(delta, sha2_256)
+		err = validateDelta(delta, p)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
 			"next update commitment hash is not computed with the required supported hash algorithm")

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -231,7 +231,7 @@ func (s *OperationProcessor) applyCreateOperation(op *batch.AnchoredOperation, p
 		return nil, errors.New("create has to be the first operation")
 	}
 
-	suffixData, err := operation.ParseSuffixData(op.SuffixData, p.HashAlgorithmInMultiHashCode)
+	suffixData, err := operation.ParseSuffixData(op.SuffixData, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse suffix data: %s", err.Error())
 	}
@@ -242,7 +242,7 @@ func (s *OperationProcessor) applyCreateOperation(op *batch.AnchoredOperation, p
 		return nil, fmt.Errorf("create delta doesn't match suffix data delta hash: %s", err.Error())
 	}
 
-	delta, err := operation.ParseDelta(op.Delta, p.HashAlgorithmInMultiHashCode)
+	delta, err := operation.ParseDelta(op.Delta, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
@@ -295,7 +295,7 @@ func (s *OperationProcessor) applyUpdateOperation(op *batch.AnchoredOperation, p
 		return nil, fmt.Errorf("failed to check signature: %s", err.Error())
 	}
 
-	delta, err := operation.ParseDelta(op.Delta, p.HashAlgorithmInMultiHashCode)
+	delta, err := operation.ParseDelta(op.Delta, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
@@ -388,7 +388,7 @@ func (s *OperationProcessor) applyRecoverOperation(op *batch.AnchoredOperation, 
 		return nil, fmt.Errorf("failed to check signature: %s", err.Error())
 	}
 
-	delta, err := operation.ParseDelta(op.Delta, p.HashAlgorithmInMultiHashCode)
+	delta, err := operation.ParseDelta(op.Delta, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}

--- a/pkg/txnhandler/provider.go
+++ b/pkg/txnhandler/provider.go
@@ -126,7 +126,7 @@ func (h *OperationProvider) assembleBatchOperations(af *models.AnchorFile, mf *m
 			return nil, err
 		}
 
-		_, err = operation.ParseDelta(delta, p.HashAlgorithmInMultiHashCode)
+		_, err = operation.ParseDelta(delta, p)
 		if err != nil {
 			return nil, fmt.Errorf("parse delta: %s", err.Error())
 		}
@@ -225,7 +225,7 @@ func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *tx
 			return nil, err
 		}
 
-		_, err = operation.ParseSuffixData(op.SuffixData, p.HashAlgorithmInMultiHashCode)
+		_, err = operation.ParseSuffixData(op.SuffixData, p)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add ability to enable 'replace' patch (it will be used for interop tests)

Closes #339

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>