### PR TITLE
chore: add configuration and validation of supported algorithms for signing

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -26,6 +26,8 @@ type Protocol struct {
 	MaxChunkFileSize uint
 	// EnableReplacePatch is used to enable replace patch (action)
 	EnableReplacePatch bool
+	//SignatureAlgorithms is used to specify supported signature algorithms (e.g. EdDSA, ES256, ES384, ES512, ES256K)
+	SignatureAlgorithms []string
 }
 
 // Client defines interface for accessing protocol version/information

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -40,6 +40,7 @@ func NewMockProtocolClient() *MockProtocolClient {
 		MaxChunkFileSize:             maxBatchFileSize,
 		MaxMapFileSize:               maxBatchFileSize,
 		MaxAnchorFileSize:            maxBatchFileSize,
+		SignatureAlgorithms:          []string{"EdDSA", "ES256"},
 	}
 
 	// has to be sorted for mock client to work

--- a/pkg/operation/deactivate.go
+++ b/pkg/operation/deactivate.go
@@ -23,7 +23,7 @@ func ParseDeactivateOperation(request []byte, p protocol.Protocol) (*batch.Opera
 		return nil, err
 	}
 
-	signedData, err := ParseSignedDataForDeactivate(schema.SignedData)
+	signedData, err := ParseSignedDataForDeactivate(schema.SignedData, p)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +67,8 @@ func validateDeactivateRequest(req *model.DeactivateRequest) error {
 }
 
 // ParseSignedDataForDeactivate will parse and validate signed data for deactivate
-func ParseSignedDataForDeactivate(compactJWS string) (*model.DeactivateSignedDataModel, error) {
-	jws, err := parseSignedData(compactJWS)
+func ParseSignedDataForDeactivate(compactJWS string, p protocol.Protocol) (*model.DeactivateSignedDataModel, error) {
+	jws, err := parseSignedData(compactJWS, p)
 	if err != nil {
 		return nil, fmt.Errorf("deactivate: %s", err.Error())
 	}

--- a/pkg/operation/deactivate_test.go
+++ b/pkg/operation/deactivate_test.go
@@ -24,6 +24,7 @@ const sha2_256 = 18
 func TestParseDeactivateOperation(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
+		SignatureAlgorithms:          []string{"alg"},
 	}
 
 	t.Run("success", func(t *testing.T) {

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -20,6 +20,7 @@ const namespace = "did:sidetree"
 func TestGetOperation(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
+		SignatureAlgorithms:          []string{"alg"},
 	}
 
 	t.Run("create", func(t *testing.T) {

--- a/pkg/operation/update.go
+++ b/pkg/operation/update.go
@@ -24,7 +24,7 @@ func ParseUpdateOperation(request []byte, protocol protocol.Protocol) (*batch.Op
 		return nil, err
 	}
 
-	_, err = ParseSignedDataForUpdate(schema.SignedData, protocol.HashAlgorithmInMultiHashCode)
+	_, err = ParseSignedDataForUpdate(schema.SignedData, protocol)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +59,8 @@ func parseUpdateRequest(payload []byte) (*model.UpdateRequest, error) {
 }
 
 // ParseSignedDataForUpdate will parse and validate signed data for update
-func ParseSignedDataForUpdate(compactJWS string, code uint) (*model.UpdateSignedDataModel, error) {
-	jws, err := parseSignedData(compactJWS)
+func ParseSignedDataForUpdate(compactJWS string, p protocol.Protocol) (*model.UpdateSignedDataModel, error) {
+	jws, err := parseSignedData(compactJWS, p)
 	if err != nil {
 		return nil, fmt.Errorf("update: %s", err.Error())
 	}
@@ -71,7 +71,7 @@ func ParseSignedDataForUpdate(compactJWS string, code uint) (*model.UpdateSigned
 		return nil, fmt.Errorf("failed to unmarshal signed data model for update: %s", err.Error())
 	}
 
-	if err := validateSignedDataForUpdate(schema, code); err != nil {
+	if err := validateSignedDataForUpdate(schema, p.HashAlgorithmInMultiHashCode); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -25,6 +25,7 @@ import (
 func TestParseUpdateOperation(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
+		SignatureAlgorithms:          []string{"alg"},
 	}
 	t.Run("success", func(t *testing.T) {
 		payload, err := getUpdateRequestBytes()
@@ -104,16 +105,21 @@ func TestParseUpdateOperation(t *testing.T) {
 }
 
 func TestParseSignedDataForUpdate(t *testing.T) {
+	p := protocol.Protocol{
+		HashAlgorithmInMultiHashCode: sha2_256,
+		SignatureAlgorithms:          []string{"alg"},
+	}
+
 	t.Run("success", func(t *testing.T) {
 		req, err := getDefaultUpdateRequest()
 		require.NoError(t, err)
 
-		schema, err := ParseSignedDataForUpdate(req.SignedData, sha2_256)
+		schema, err := ParseSignedDataForUpdate(req.SignedData, p)
 		require.NoError(t, err)
 		require.NotNil(t, schema)
 	})
 	t.Run("invalid JWS compact format", func(t *testing.T) {
-		schema, err := ParseSignedDataForUpdate("invalid", sha2_256)
+		schema, err := ParseSignedDataForUpdate("invalid", p)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "invalid JWS compact format")
@@ -129,7 +135,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 
 		compactJWS, err := signutil.SignPayload(payload, NewMockSigner())
 
-		schema, err := ParseSignedDataForUpdate(compactJWS, sha2_256)
+		schema, err := ParseSignedDataForUpdate(compactJWS, p)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "delta hash is not computed with the latest supported hash algorithm")
@@ -138,7 +144,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 		compactJWS, err := signutil.SignPayload([]byte("test"), NewMockSigner())
 		require.NoError(t, err)
 
-		schema, err := ParseSignedDataForUpdate(compactJWS, sha2_256)
+		schema, err := ParseSignedDataForUpdate(compactJWS, p)
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(), "invalid character")

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -268,7 +268,7 @@ func (s *OperationProcessor) applyUpdateOperation(op *batch.AnchoredOperation, p
 		return nil, errors.New("update cannot be first operation")
 	}
 
-	signedDataModel, err := operation.ParseSignedDataForUpdate(op.SignedData, p.HashAlgorithmInMultiHashCode)
+	signedDataModel, err := operation.ParseSignedDataForUpdate(op.SignedData, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal signed data model while applying update: %s", err.Error())
 	}
@@ -320,7 +320,7 @@ func (s *OperationProcessor) applyDeactivateOperation(op *batch.AnchoredOperatio
 		return nil, errors.New("deactivate can only be applied to an existing document")
 	}
 
-	signedDataModel, err := operation.ParseSignedDataForDeactivate(op.SignedData)
+	signedDataModel, err := operation.ParseSignedDataForDeactivate(op.SignedData, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse signed data model while applying deactivate: %s", err.Error())
 	}
@@ -361,7 +361,7 @@ func (s *OperationProcessor) applyRecoverOperation(op *batch.AnchoredOperation, 
 		return nil, errors.New("recover can only be applied to an existing document")
 	}
 
-	signedDataModel, err := operation.ParseSignedDataForRecover(op.SignedData, p.HashAlgorithmInMultiHashCode)
+	signedDataModel, err := operation.ParseSignedDataForRecover(op.SignedData, p)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse signed data model while applying recover: %s", err.Error())
 	}
@@ -430,21 +430,21 @@ func (s *OperationProcessor) getOperationCommitment(op *batch.AnchoredOperation)
 
 	switch op.Type {
 	case batch.OperationTypeUpdate:
-		signedDataModel, innerErr := operation.ParseSignedDataForUpdate(op.SignedData, p.HashAlgorithmInMultiHashCode)
+		signedDataModel, innerErr := operation.ParseSignedDataForUpdate(op.SignedData, p)
 		if innerErr != nil {
 			return "", fmt.Errorf("failed to parse signed data model for update: %s", innerErr.Error())
 		}
 
 		commitmentKey = signedDataModel.UpdateKey
 	case batch.OperationTypeDeactivate:
-		signedDataModel, innerErr := operation.ParseSignedDataForDeactivate(op.SignedData)
+		signedDataModel, innerErr := operation.ParseSignedDataForDeactivate(op.SignedData, p)
 		if innerErr != nil {
 			return "", fmt.Errorf("failed to parse signed data model for deactivate: %s", innerErr.Error())
 		}
 
 		commitmentKey = signedDataModel.RecoveryKey
 	case batch.OperationTypeRecover:
-		signedDataModel, innerErr := operation.ParseSignedDataForRecover(op.SignedData, p.HashAlgorithmInMultiHashCode)
+		signedDataModel, innerErr := operation.ParseSignedDataForRecover(op.SignedData, p)
 		if innerErr != nil {
 			return "", fmt.Errorf("failed to parse signed data model for recover: %s", innerErr.Error())
 		}

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -750,7 +750,7 @@ func TestRecover(t *testing.T) {
 			RecoveryCommitment: getEncodedMultihash([]byte("different")),
 			DeltaHash:          getEncodedMultihash([]byte("{}")),
 		}
-		recoverOp.SignedData, err = signutil.SignModel(signedModel, ecsigner.New(privateKey, "P-256", ""))
+		recoverOp.SignedData, err = signutil.SignModel(signedModel, ecsigner.New(privateKey, "ES256", ""))
 
 		anchoredOp := getAnchoredOperation(recoverOp)
 


### PR DESCRIPTION
Add validation of supported algorithms for signed data for update, deactivate and recover operations at request time. Supported algorithms are: EdDSA, ES256, ES384, ES512, ES256K.

Add new parameter to protocol parameters called signature algorithms that will allow configuring supported algorithms.

Closes #198

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>