### PR TITLE
chore: Add validation of supported key algorithms for signed operations

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -26,8 +26,10 @@ type Protocol struct {
 	MaxChunkFileSize uint
 	// EnableReplacePatch is used to enable replace patch (action)
 	EnableReplacePatch bool
-	//SignatureAlgorithms is used to specify supported signature algorithms (e.g. EdDSA, ES256, ES384, ES512, ES256K)
+	//SignatureAlgorithms contain supported signature algorithms for signed operations (e.g. EdDSA, ES256, ES384, ES512, ES256K)
 	SignatureAlgorithms []string
+	//KeyAlgorithms contain supported key algorithms for signed operations (e.g. secp256k1, P-256, P-384, P-512, Ed25519)
+	KeyAlgorithms []string
 }
 
 // Client defines interface for accessing protocol version/information

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -41,6 +41,7 @@ func NewMockProtocolClient() *MockProtocolClient {
 		MaxMapFileSize:               maxBatchFileSize,
 		MaxAnchorFileSize:            maxBatchFileSize,
 		SignatureAlgorithms:          []string{"EdDSA", "ES256"},
+		KeyAlgorithms:                []string{"Ed25519", "P-256"},
 	}
 
 	// has to be sorted for mock client to work

--- a/pkg/operation/deactivate.go
+++ b/pkg/operation/deactivate.go
@@ -79,5 +79,9 @@ func ParseSignedDataForDeactivate(compactJWS string, p protocol.Protocol) (*mode
 		return nil, fmt.Errorf("failed to unmarshal signed data model for deactivate: %s", err.Error())
 	}
 
+	if err := validateSigningKey(signedData.RecoveryKey, p.KeyAlgorithms); err != nil {
+		return nil, fmt.Errorf("signed data for deactivate: %s", err.Error())
+	}
+
 	return signedData, nil
 }

--- a/pkg/operation/deactivate_test.go
+++ b/pkg/operation/deactivate_test.go
@@ -25,6 +25,7 @@ func TestParseDeactivateOperation(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
 		SignatureAlgorithms:          []string{"alg"},
+		KeyAlgorithms:                []string{"crv"},
 	}
 
 	t.Run("success", func(t *testing.T) {
@@ -98,6 +99,21 @@ func TestParseDeactivateOperation(t *testing.T) {
 		op, err := ParseDeactivateOperation(request, p)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to unmarshal signed data model for deactivate")
+		require.Nil(t, op)
+	})
+	t.Run("error - key algorithm not supported", func(t *testing.T) {
+		p := protocol.Protocol{
+			HashAlgorithmInMultiHashCode: sha2_256,
+			SignatureAlgorithms:          []string{"alg"},
+			KeyAlgorithms:                []string{"other"},
+		}
+
+		request, err := getDeactivateRequestBytes()
+		require.NoError(t, err)
+
+		op, err := ParseDeactivateOperation(request, p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signed data for deactivate: key algorithm 'crv' is not in the allowed list [other]")
 		require.Nil(t, op)
 	})
 }

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -21,6 +21,7 @@ func TestGetOperation(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
 		SignatureAlgorithms:          []string{"alg"},
+		KeyAlgorithms:                []string{"crv"},
 	}
 
 	t.Run("create", func(t *testing.T) {

--- a/pkg/operation/update_test.go
+++ b/pkg/operation/update_test.go
@@ -26,6 +26,7 @@ func TestParseUpdateOperation(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
 		SignatureAlgorithms:          []string{"alg"},
+		KeyAlgorithms:                []string{"crv"},
 	}
 	t.Run("success", func(t *testing.T) {
 		payload, err := getUpdateRequestBytes()
@@ -108,6 +109,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 	p := protocol.Protocol{
 		HashAlgorithmInMultiHashCode: sha2_256,
 		SignatureAlgorithms:          []string{"alg"},
+		KeyAlgorithms:                []string{"crv"},
 	}
 
 	t.Run("success", func(t *testing.T) {
@@ -138,7 +140,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 		schema, err := ParseSignedDataForUpdate(compactJWS, p)
 		require.Error(t, err)
 		require.Nil(t, schema)
-		require.Contains(t, err.Error(), "delta hash is not computed with the latest supported hash algorithm")
+		require.Contains(t, err.Error(), "delta hash is not computed with the required hash algorithm: 18")
 	})
 	t.Run("payload not JSON object", func(t *testing.T) {
 		compactJWS, err := signutil.SignPayload([]byte("test"), NewMockSigner())

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -225,6 +225,6 @@ func getSuffixData() *model.SuffixDataModel {
 
 var testJWK = &jws.JWK{
 	Kty: "kty",
-	Crv: "crv",
+	Crv: "P-256",
 	X:   "x",
 }

--- a/pkg/txnhandler/handler_test.go
+++ b/pkg/txnhandler/handler_test.go
@@ -289,8 +289,9 @@ func generateDeactivateOperation(num int) (*batch.Operation, error) {
 	}
 
 	info := &helper.DeactivateRequestInfo{
-		DidSuffix: fmt.Sprintf("did:sidetree:deactivate-%d", num),
-		Signer:    ecsigner.New(privateKey, "ES256", "")}
+		DidSuffix:   fmt.Sprintf("did:sidetree:deactivate-%d", num),
+		Signer:      ecsigner.New(privateKey, "ES256", ""),
+		RecoveryKey: testJWK}
 
 	request, err := helper.NewDeactivateRequest(info)
 	if err != nil {
@@ -339,6 +340,6 @@ func getTestPatch() (patch.Patch, error) {
 
 var testJWK = &jws.JWK{
 	Kty: "kty",
-	Crv: "crv",
+	Crv: "P-256",
 	X:   "x",
 }


### PR DESCRIPTION
Add validation of supported key algorithms for signed operations at request time. Supported key algorithms for 'crv' are: Ed25519, secp256k1, P-256, P-384, P-512.

Add new parameter to protocol parameters called key algorithms that will allow configuring supported key algorithms.

Closes #364

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>