### PR TITLE
chore: Rename protocol parameters as per spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/gorilla/mux v1.7.3
 	github.com/minio/sha256-simd v0.1.1 // indirect
-	github.com/multiformats/go-multihash v0.0.13
+	github.com/multiformats/go-multihash v0.0.14
 	github.com/pkg/errors v0.9.1
 	github.com/square/go-jose/v3 v3.0.0-20191119004800-96c717272387
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mr-tron/base58 v1.1.3 h1:v+sk57XuaCKGXpWtVBX8YJzO7hMGx4Aajh4TQbdEFdc=
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
-github.com/multiformats/go-multihash v0.0.13 h1:06x+mk/zj1FoMsgNejLpy6QTvJqlSt/BhLEy87zidlc=
-github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
+github.com/multiformats/go-multihash v0.0.14 h1:QoBceQYQQtNUuf6s7wHxnE2c8bhbMqhfGzNI032se/I=
+github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-varint v0.0.5 h1:XVZwSo04Cs3j/jS0uAEPpT3JY6DzMcVLLoWOSnCxOjg=
 github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -8,14 +8,15 @@ package protocol
 
 // Protocol defines protocol parameters
 type Protocol struct {
-	// StartingBlockChainTime is inclusive starting logical blockchain time that this protocol applies to.
-	StartingBlockChainTime uint64
+	// GenesisTime is inclusive starting logical blockchain time that this protocol applies to
+	// (e.g. block number in a blockchain)
+	GenesisTime uint64
 	// HashAlgorithmInMultiHashCode is hash algorithm in multihash code
 	HashAlgorithmInMultiHashCode uint
-	// MaxOperationsPerBatch defines maximum operations per batch
-	MaxOperationsPerBatch uint
-	// MaxDeltaByteSize is maximum size of the `delta` property in bytes
-	MaxDeltaByteSize uint
+	// MaxOperationCount defines maximum number of operations per batch
+	MaxOperationCount uint
+	// MaxOperationSize is maximum uncompressed operation size
+	MaxOperationSize uint
 	// CompressionAlgorithm is file compression algorithm
 	CompressionAlgorithm string
 	// MaxAnchorFileSize is maximum allowed size (in bytes) of anchor file stored in CAS

--- a/pkg/batch/cutter/cutter.go
+++ b/pkg/batch/cutter/cutter.go
@@ -60,7 +60,7 @@ func (r *BatchCutter) Add(operation *batch.OperationInfo) (uint, error) {
 func (r *BatchCutter) Cut(force bool) ([]*batch.OperationInfo, uint, Committer, error) {
 	pending := r.pendingBatch.Len()
 
-	maxOperationsPerBatch := r.client.Current().MaxOperationsPerBatch
+	maxOperationsPerBatch := r.client.Current().MaxOperationCount
 	if !force && pending < maxOperationsPerBatch {
 		return nil, pending, nil, nil
 	}

--- a/pkg/batch/cutter/cutter_test.go
+++ b/pkg/batch/cutter/cutter_test.go
@@ -25,7 +25,7 @@ var (
 
 func TestBatchCutter(t *testing.T) {
 	c := mocks.NewMockProtocolClient()
-	c.Protocol.MaxOperationsPerBatch = 3
+	c.Protocol.MaxOperationCount = 3
 	r := New(c, &opqueue.MemQueue{})
 
 	ops, pending, commit, err := r.Cut(false)

--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -285,7 +285,7 @@ func TestAddAfterStop(t *testing.T) {
 
 func TestProcessBatchErrorRecovery(t *testing.T) {
 	ctx := newMockContext()
-	ctx.ProtocolClient.Protocol.MaxOperationsPerBatch = 2
+	ctx.ProtocolClient.Protocol.MaxOperationCount = 2
 	ctx.CasClient = mocks.NewMockCasClient(fmt.Errorf("CAS Error"))
 
 	writer, err := New(namespace, ctx, WithBatchTimeout(500*time.Millisecond))
@@ -335,7 +335,7 @@ func TestStartWithExistingItems(t *testing.T) {
 	opQueue := &opqueue.MemQueue{}
 
 	ctx := newMockContext()
-	ctx.ProtocolClient.Protocol.MaxOperationsPerBatch = maxOperationsPerBatch
+	ctx.ProtocolClient.Protocol.MaxOperationCount = maxOperationsPerBatch
 	ctx.OpQueue = opQueue
 
 	writer, err := New(namespace, ctx)
@@ -364,7 +364,7 @@ func TestProcessError(t *testing.T) {
 		q.PeekReturns(invalidQueue, nil)
 
 		ctx := newMockContext()
-		ctx.ProtocolClient.Protocol.MaxOperationsPerBatch = 1
+		ctx.ProtocolClient.Protocol.MaxOperationCount = 1
 		ctx.OpQueue = q
 
 		writer, err := New("test1", ctx, WithBatchTimeout(10*time.Millisecond))
@@ -387,7 +387,7 @@ func TestProcessError(t *testing.T) {
 		q.PeekReturns(nil, errExpected)
 
 		ctx := newMockContext()
-		ctx.ProtocolClient.Protocol.MaxOperationsPerBatch = 2
+		ctx.ProtocolClient.Protocol.MaxOperationCount = 2
 		ctx.OpQueue = q
 
 		writer, err := New("test1", ctx, WithBatchTimeout(10*time.Millisecond))
@@ -411,7 +411,7 @@ func TestProcessError(t *testing.T) {
 		q.RemoveReturns(0, 1, errExpected)
 
 		ctx := newMockContext()
-		ctx.ProtocolClient.Protocol.MaxOperationsPerBatch = 2
+		ctx.ProtocolClient.Protocol.MaxOperationCount = 2
 		ctx.OpQueue = q
 
 		writer, err := New("test2", ctx, WithBatchTimeout(10*time.Millisecond))

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -81,13 +81,13 @@ func TestDocumentHandler_ProcessOperation_InitialDocumentError(t *testing.T) {
 	require.Contains(t, err.Error(), "expected array of interfaces")
 }
 
-func TestDocumentHandler_ProcessOperation_MaxDeltaSizeError(t *testing.T) {
+func TestDocumentHandler_ProcessOperation_MaxOperationSizeError(t *testing.T) {
 	dochandler := getDocumentHandler(mocks.NewMockOperationStore(nil))
 	require.NotNil(t, dochandler)
 
 	// modify handler protocol client to decrease max operation size
 	protocol := mocks.NewMockProtocolClient()
-	protocol.Protocol.MaxDeltaByteSize = 2
+	protocol.Protocol.MaxOperationSize = 2
 	dochandler.protocol = protocol
 
 	createOp := getCreateOperation()
@@ -95,7 +95,7 @@ func TestDocumentHandler_ProcessOperation_MaxDeltaSizeError(t *testing.T) {
 	doc, err := dochandler.ProcessOperation(createOp)
 	require.NotNil(t, err)
 	require.Nil(t, doc)
-	require.Contains(t, err.Error(), "delta byte size exceeds protocol max delta byte size")
+	require.Contains(t, err.Error(), "operation byte size exceeds protocol max operation byte size")
 }
 
 func TestDocumentHandler_ResolveDocument_DID(t *testing.T) {
@@ -220,13 +220,13 @@ func TestDocumentHandler_ResolveDocument_Interop(t *testing.T) {
 	require.NotNil(t, result)
 }
 
-func TestDocumentHandler_ResolveDocument_InitialValue_MaxDeltaSizeError(t *testing.T) {
+func TestDocumentHandler_ResolveDocument_InitialValue_MaxOperationSizeError(t *testing.T) {
 	dochandler := getDocumentHandler(mocks.NewMockOperationStore(nil))
 	require.NotNil(t, dochandler)
 
 	// modify handler protocol client to decrease max operation size
 	protocol := mocks.NewMockProtocolClient()
-	protocol.Protocol.MaxDeltaByteSize = 2
+	protocol.Protocol.MaxOperationSize = 2
 	dochandler.protocol = protocol
 
 	docID := getCreateOperation().ID
@@ -234,7 +234,7 @@ func TestDocumentHandler_ResolveDocument_InitialValue_MaxDeltaSizeError(t *testi
 	result, err := dochandler.ResolveDocument(docID + initialStateParam + "abc.123")
 	require.NotNil(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "delta byte size exceeds protocol max delta byte size")
+	require.Contains(t, err.Error(), "bad request: operation byte size exceeds protocol max operation byte size")
 }
 
 func TestDocumentHandler_ResolveDocument_InitialDocumentNotValid(t *testing.T) {

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -20,7 +20,7 @@ const DefaultNS = "did:sidetree"
 // maximum batch files size in bytes
 const maxBatchFileSize = 20000
 
-const maxDeltaByteSize = 2000
+const maxOperationByteSize = 2000
 
 // MockProtocolClient mocks protocol for testing purposes.
 type MockProtocolClient struct {
@@ -32,10 +32,10 @@ type MockProtocolClient struct {
 func NewMockProtocolClient() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		StartingBlockChainTime:       0,
+		GenesisTime:                  0,
 		HashAlgorithmInMultiHashCode: sha2_256,
-		MaxOperationsPerBatch:        2,
-		MaxDeltaByteSize:             maxDeltaByteSize,
+		MaxOperationCount:            2,
+		MaxOperationSize:             maxOperationByteSize,
 		CompressionAlgorithm:         "GZIP",
 		MaxChunkFileSize:             maxBatchFileSize,
 		MaxMapFileSize:               maxBatchFileSize,
@@ -61,7 +61,7 @@ func (m *MockProtocolClient) Current() protocol.Protocol {
 // Get mocks getting protocol version based on blockchain(transaction) time
 func (m *MockProtocolClient) Get(transactionTime uint64) (protocol.Protocol, error) {
 	for i := len(m.Versions) - 1; i >= 0; i-- {
-		if transactionTime >= m.Versions[i].StartingBlockChainTime {
+		if transactionTime >= m.Versions[i].GenesisTime {
 			return m.Versions[i], nil
 		}
 	}


### PR DESCRIPTION
Change MaxDeltaSizeInBytes to MaxOperationSize and adjust validations for operations and resolution with initial value.

Rename:
MaxOperationsPerBatch to MaxOperationCount
StartingBlockChainTime to GenesisTime

Closes #368

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>