### PR TITLE
chore: remove references to 'ops' purpose

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -26,4 +26,4 @@ Document resolution is based on ID or encoded original document.
 
 -- ID : The latest document will be returned if found.
 
--- ID with initial-values parameter: The ID is passed in along with the initial-values parameter as follows: <ID>;initial-values=<encoded-DID-document>. Standard resolution is performed if the DID is found in the document store. If the document cannot be found then the encoded DID Document is used to generate and return as the resolved DID Document, in which case the supplied encoded DID Document is subject to the same validation as an original DID Document in a create operation.
+-- ID with initial-state parameter: The ID is passed in along with the initial-values parameter as follows: <ID>;initial-values=<encoded-DID-document>. Standard resolution is performed if the DID is found in the document store. If the document cannot be found then the encoded DID Document is used to generate and return as the resolved DID Document, in which case the supplied encoded DID Document is subject to the same validation as an original DID Document in a create operation.

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -417,7 +417,7 @@ const testDoc = `{
 		{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -428,7 +428,7 @@ const testDoc = `{
 		{
 		  "id": "key2",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -454,7 +454,7 @@ const testDoc = `{
 const addKeys = `[{
 		  "id": "key3",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -466,7 +466,7 @@ const addKeys = `[{
 const updateExistingKey = `[{
 	"id": "key2",
 	"type": "JsonWebKey2020",
-	"purpose": ["ops"],
+	"purpose": ["general"],
 	"jwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/dochandler/didvalidator/testdata/doc.json
+++ b/pkg/dochandler/didvalidator/testdata/doc.json
@@ -3,18 +3,7 @@
     {
       "id": "master",
       "type": "EcdsaSecp256k1VerificationKey2019",
-      "purpose": ["ops", "general", "auth", "assertion", "agreement", "delegation", "invocation"],
-      "jwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "ops-only",
-      "type": "JsonWebKey2020",
-      "purpose": ["ops"],
+      "purpose": ["general", "auth", "assertion", "agreement", "delegation", "invocation"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/dochandler/didvalidator/validator_test.go
+++ b/pkg/dochandler/didvalidator/validator_test.go
@@ -279,7 +279,7 @@ var docWithContext = []byte(`{
 	"publicKey": [{
       	"id": "key-1",
       	"type": "JsonWebKey2020",
-      	"purpose": ["ops", "general"],
+      	"purpose": ["general"],
 		"jwk": {
 			"kty": "EC",
         	"crv": "P-256K",
@@ -301,7 +301,7 @@ var pubKeyWithController = []byte(`{
       "id": "key-1",
       "type": "JsonWebKey2020",
       "controller": "did:example:123456789abcdefghi",
-      "purpose": ["ops", "general"],
+      "purpose": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/dochandler/docvalidator/validator_test.go
+++ b/pkg/dochandler/docvalidator/validator_test.go
@@ -136,7 +136,7 @@ const validDocWithOpsKeys = `
     {
       "id": "update-key",
       "type": "JsonWebKey2020",
-      "purpose": ["ops"],
+      "purpose": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -136,15 +136,15 @@ func (r *DocumentHandler) getCreateResponse(operation *batch.Operation) (*docume
 
 // ResolveDocument fetches the latest DID Document of a DID. Two forms of string can be passed in the URI:
 //
-// 1. Standard DID format: did:sidetree:<unique-portion>
+// 1. Standard DID format: did:METHOD:<did-suffix>
 //
-// 2. DID with initial-values DID parameter:
-// did:sidetree:<unique-portion>;initial-values=<encoded-original-did-document>
+// 2. DID with initial-state DID parameter (Long-Form DID URIs)
+// did:METHOD:<did-suffix>?initial-state=<create-suffix-data-object>.<create-delta-object>
 //
 // Standard resolution is performed if the DID is found to be registered on the blockchain.
-// If the DID Document cannot be found, the encoded DID Document given in the initial-values DID parameter is used
-// to generate and return as the resolved DID Document, in which case the supplied encoded DID Document is subject to
-// the same validation as an original DID Document in a create operation
+// If the DID Document cannot be found, the <create-suffix-data-object> and <create-delta-object> given
+// in the initial-state DID parameter are used to generate and return resolved DID Document. In this case the supplied
+// encoded delta and suffix objects are subject to the same validation as during processing create operation.
 func (r *DocumentHandler) ResolveDocument(idOrInitialDoc string) (*document.ResolutionResult, error) {
 	if !strings.HasPrefix(idOrInitialDoc, r.namespace+docutil.NamespaceDelimiter) {
 		return nil, errors.New("must start with configured namespace")

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -441,7 +441,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/document/diddocument_test.go
+++ b/pkg/document/diddocument_test.go
@@ -25,7 +25,7 @@ func TestValid(t *testing.T) {
 		{
 			"id":      "key1",
 			"type":    "JsonWebKey2020",
-			"purpose": []interface{}{"ops", "general"},
+			"purpose": []interface{}{"auth", "general"},
 			"jwk": map[string]interface{}{
 				"kty": "EC",
 				"crv": "P-256K",

--- a/pkg/document/testdata/doc.json
+++ b/pkg/document/testdata/doc.json
@@ -3,7 +3,7 @@
     {
       "id": "key1",
       "type": "JsonWebKey2020",
-      "purpose": ["ops", "general"],
+      "purpose": ["auth", "general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -19,8 +19,6 @@ var (
 )
 
 const (
-	// ops defines key purpose as operations key
-	ops = "ops"
 	// auth defines key purpose as authentication key
 	auth = "auth"
 	// assertion defines key purpose as assertion key
@@ -53,7 +51,6 @@ const (
 )
 
 var allowedOps = map[string]string{
-	ops:        ops,
 	auth:       auth,
 	general:    general,
 	assertion:  assertion,
@@ -63,12 +60,6 @@ var allowedOps = map[string]string{
 }
 
 type existenceMap map[string]string
-
-var allowedKeyTypesOps = existenceMap{
-	jwsVerificationKey2020:            jwsVerificationKey2020,
-	jsonWebKey2020:                    jsonWebKey2020,
-	ecdsaSecp256k1VerificationKey2019: ecdsaSecp256k1VerificationKey2019,
-}
 
 var allowedKeyTypesGeneral = existenceMap{
 	jwsVerificationKey2020:            jwsVerificationKey2020,
@@ -94,7 +85,6 @@ var allowedKeyTypesAgreement = existenceMap{
 }
 
 var allowedKeyTypes = map[string]existenceMap{
-	ops:        allowedKeyTypesOps,
 	general:    allowedKeyTypesGeneral,
 	auth:       allowedKeyTypesVerification,
 	assertion:  allowedKeyTypesVerification,
@@ -125,12 +115,6 @@ func ValidatePublicKeys(pubKeys []PublicKey) error {
 
 		if err := validateKeyPurpose(pubKey); err != nil {
 			return err
-		}
-
-		if IsOperationsKey(pubKey.Purpose()) {
-			if err := ValidateOperationsKey(pubKey); err != nil {
-				return err
-			}
 		}
 
 		if !validateKeyTypePurpose(pubKey) {
@@ -258,15 +242,6 @@ func validateKeyTypePurpose(pubKey PublicKey) bool {
 	return true
 }
 
-// ValidateOperationsKey validates operation key
-func ValidateOperationsKey(pubKey PublicKey) error {
-	if !IsOperationsKey(pubKey.Purpose()) {
-		return fmt.Errorf("key '%s' is not an operations key", pubKey.ID())
-	}
-
-	return ValidateJWK(pubKey.JWK())
-}
-
 // ValidateJWK validates JWK
 func ValidateJWK(jwk JWK) error {
 	if jwk == nil {
@@ -290,11 +265,6 @@ func ValidateJWK(jwk JWK) error {
 	}
 
 	return nil
-}
-
-// IsOperationsKey returns true if key is an operations key
-func IsOperationsKey(purposes []string) bool {
-	return isPurposeKey(purposes, ops)
 }
 
 // IsGeneralKey returns true if key is a general key

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -200,31 +200,6 @@ func TestValidateID(t *testing.T) {
 	})
 }
 
-func TestValidateOperationsKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	pk["id"] = "kid"
-
-	err := ValidateOperationsKey(pk)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "is not an operations key")
-
-	pk[purposeKey] = []interface{}{ops}
-	err = ValidateOperationsKey(pk)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "key has to be in JWK format")
-
-	jwk := map[string]interface{}{
-		"kty": "kty",
-		"crv": "crv",
-		"x":   "x",
-		"y":   "y",
-	}
-
-	pk["jwk"] = jwk
-	err = ValidateOperationsKey(pk)
-	require.NoError(t, err)
-}
-
 func TestValidateJWK(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		jwk := JWK{
@@ -369,10 +344,6 @@ func TestInvalidKeyPurpose(t *testing.T) {
 	require.Error(t, err, "invalid purpose")
 }
 
-func TestOpsKeyPurpose(t *testing.T) {
-	testKeyPurpose(t, allowedKeyTypesOps, ops)
-}
-
 func TestVerificationKeyPurpose(t *testing.T) {
 	testKeyPurpose(t, allowedKeyTypesVerification, assertion)
 	testKeyPurpose(t, allowedKeyTypesVerification, auth)
@@ -440,8 +411,8 @@ const moreProperties = `{
     {
       "id": "key1",
       "other": "unknown",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops"], 
+      "type": "JsonWebKey2020",
+      "purpose": ["general"], 
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -456,7 +427,7 @@ const noPurpose = `{
   "publicKey": [
     {
       "id": "key1",
-      "type": "JwsVerificationKey2020",
+      "type": "JsonWebKey2020",
       "purpose": [], 
       "jwk": {
         "kty": "EC",
@@ -472,7 +443,7 @@ const wrongPurpose = `{
   "publicKey": [
     {
       "id": "key1",
-      "type": "JwsVerificationKey2020",
+      "type": "JsonWebKey2020",
       "purpose": ["invalid"],
       "jwk": {
         "kty": "EC",
@@ -488,8 +459,8 @@ const tooMuchPurpose = `{
   "publicKey": [
     {
       "id": "key1",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops", "general", "auth", "assertion", "agreement", "delegation", "invocation", "other"],
+      "type": "JsonWebKey2020",
+      "purpose": ["general", "auth", "assertion", "agreement", "delegation", "invocation", "other"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -504,8 +475,8 @@ const noJWK = `{
   "publicKey": [
     {
       "id": "key1",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops"],
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
       "jwk": {}
     }
   ]
@@ -515,8 +486,8 @@ const idLong = `{
   "publicKey": [
     {
       "id": "idwihmorethan50characters123456789012345678901234567890",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops"],
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -529,8 +500,8 @@ const idLong = `{
 const noID = `{
   "publicKey": [
     {
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops"],
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -561,8 +532,8 @@ const duplicateID = `{
   "publicKey": [
     {
       "id": "key1",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops"],
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -572,8 +543,8 @@ const duplicateID = `{
     },
     {
       "id": "key1",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["ops"],
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/internal/request/method.go
+++ b/pkg/internal/request/method.go
@@ -43,7 +43,7 @@ func GetParts(namespace, params string) (string, *model.CreateRequest, error) {
 
 	pos := strings.Index(params, initialMatch)
 	if pos == -1 {
-		// there is no initial-values so params contains only did
+		// there is no initial-state so params contains only did
 		return params, nil, nil
 	}
 

--- a/pkg/operation/create_test.go
+++ b/pkg/operation/create_test.go
@@ -312,7 +312,7 @@ const validDoc = `{
 		{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -405,7 +405,7 @@ const addPublicKeysPatch = `{
 	"public_keys": [{
 		"id": "key1",
 		"type": "JsonWebKey2020",
-		"purpose": ["ops", "general"],
+		"purpose": ["general"],
 		"jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -418,7 +418,7 @@ const addPublicKeysPatch = `{
 const testAddPublicKeys = `[{
 	"id": "key1",
 	"type": "JsonWebKey2020",
-	"purpose": ["ops", "general"],
+	"purpose": ["general"],
 	"jwk": {
 		"kty": "EC",
 		"crv": "P-256K",
@@ -478,7 +478,7 @@ const testDoc = `{
 	"publicKey": [{
 		"id": "key1",
 		"type": "JsonWebKey2020",
-		"purpose": ["ops", "general"],
+		"purpose": ["general"],
 		"jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -499,7 +499,7 @@ const invalidKeysDoc = `{
 	"publicKey": [{
 		"id": "key1",	
 		"type": "JsonWebKey2020",
-		"purpose": ["ops"],
+		"purpose": ["general"],
 		"jwk": {
 			"kty": "EC",
 			"crv": "P-256K"

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1613,7 +1613,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -1627,7 +1627,7 @@ const recoveredDoc = `{
 	"publicKey": [{
 		  "id": "recovered",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/restapi/diddochandler/doc.go
+++ b/pkg/restapi/diddochandler/doc.go
@@ -74,7 +74,7 @@ type errorWrapper struct {
 //swagger:parameters resolveDocParams
 //nolint:deadcode,unused
 type resolveDocumentParams struct {
-	// The DID or the DID with initial-values parameter that contains encoded original did document.
+	// The DID or the DID with initial-state parameter that contains create operation delta and suffix objects.
 	//
 	// in: path
 	// required: true

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -170,7 +170,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purpose": ["ops", "general"],
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -259,8 +259,8 @@ type operationSchema struct {
 const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
-		  "type": "JwsVerificationKey2020",
-		  "purpose": ["ops", "general"],
+		  "type": "JsonWebKey2020",
+		  "purpose": ["general"],
 		  "jwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -273,8 +273,8 @@ const validDoc = `{
 const recoverDoc = `{
 	"publicKey": [{
 		"id": "recoverKey",
-		"type": "JwsVerificationKey2020",
-		"purpose": ["ops"],
+		"type": "JsonWebKey2020",
+		"purpose": ["general"],
 		"jwk": {
 			"kty": "EC",
 			"crv": "P-256K",


### PR DESCRIPTION
Ops purpose is no longer valid; remove all references to "ops" purpose

Also, minor changes to comments that got out of sync with spec.

Closes #375

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>