### PR TITLE
chore: If applying patch fails we should continue to the next patch

### DIFF
--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -65,20 +65,19 @@ func TestDocumentHandler_ProcessOperation_InitialDocumentError(t *testing.T) {
 	dochandler := getDocumentHandler(mocks.NewMockOperationStore(nil))
 	require.NotNil(t, dochandler)
 
-	replacePatch, err := patch.NewAddPublicKeysPatch("{}")
+	publicKeysPatch, err := patch.NewAddPublicKeysPatch("{}")
 	require.NoError(t, err)
-	replacePatch["publicKeys"] = "invalid"
+	publicKeysPatch["publicKeys"] = "invalid"
 
 	createOp := getCreateOperation()
 
 	createOp.DeltaModel = &model.DeltaModel{
-		Patches: []patch.Patch{replacePatch},
+		Patches: []patch.Patch{publicKeysPatch},
 	}
 
 	doc, err := dochandler.ProcessOperation(createOp)
-	require.NotNil(t, err)
-	require.Nil(t, doc)
-	require.Contains(t, err.Error(), "expected array of interfaces")
+	require.Nil(t, err)
+	require.Equal(t, 0, len(doc.Document.PublicKeys()))
 }
 
 func TestDocumentHandler_ProcessOperation_MaxOperationSizeError(t *testing.T) {
@@ -269,7 +268,7 @@ func TestTransformToExternalDocument(t *testing.T) {
 	result, err = dochandler.transformToExternalDoc(doc, "abc")
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, "abc", result.Document[keyID])
+	require.Equal(t, "abc", result.Document[document.IDProperty])
 }
 
 func TestGetUniquePortion(t *testing.T) {

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -81,12 +81,9 @@ func (m *MockDocumentHandler) ProcessOperation(operation *batch.Operation) (*doc
 		doc = make(document.Document)
 	}
 
-	doc, err := composer.ApplyPatches(doc, operation.DeltaModel.Patches)
-	if err != nil {
-		return nil, err
-	}
-
 	doc = applyID(doc, operation.ID)
+
+	doc = composer.ApplyPatches(doc, operation.DeltaModel.Patches)
 
 	m.store[operation.ID] = doc
 
@@ -143,12 +140,9 @@ func (m *MockDocumentHandler) resolveWithInitialState(idOrDocument string) (*doc
 		return nil, err
 	}
 
-	doc, err := composer.ApplyPatches(make(document.Document), delta.Patches)
-	if err != nil {
-		return nil, err
-	}
+	doc := applyID(make(document.Document), id)
+	doc = composer.ApplyPatches(doc, delta.Patches)
 
-	doc = applyID(doc, id)
 	return &document.ResolutionResult{
 		Document: doc,
 	}, nil

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -294,10 +294,7 @@ func (s *OperationProcessor) applyCreateOperation(op *batch.AnchoredOperation, p
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
 
-	doc, err := composer.ApplyPatches(make(document.Document), delta.Patches)
-	if err != nil {
-		return nil, err
-	}
+	doc := composer.ApplyPatches(newDocWithID(op.UniqueSuffix), delta.Patches)
 
 	return &resolutionModel{
 		Doc:                            doc,
@@ -347,10 +344,7 @@ func (s *OperationProcessor) applyUpdateOperation(op *batch.AnchoredOperation, p
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
 
-	doc, err := composer.ApplyPatches(rm.Doc, delta.Patches)
-	if err != nil {
-		return nil, err
-	}
+	doc := composer.ApplyPatches(rm.Doc, delta.Patches)
 
 	return &resolutionModel{
 		Doc:                            doc,
@@ -440,10 +434,7 @@ func (s *OperationProcessor) applyRecoverOperation(op *batch.AnchoredOperation, 
 		return nil, fmt.Errorf("failed to parse delta: %s", err.Error())
 	}
 
-	doc, err := composer.ApplyPatches(make(document.Document), delta.Patches)
-	if err != nil {
-		return nil, err
-	}
+	doc := composer.ApplyPatches(newDocWithID(op.UniqueSuffix), delta.Patches)
 
 	return &resolutionModel{
 		Doc:                            doc,
@@ -545,4 +536,11 @@ func (s *OperationProcessor) getNextOperationCommitment(op *batch.AnchoredOperat
 	}
 
 	return nextCommitment, nil
+}
+
+func newDocWithID(id string) document.Document {
+	doc := make(document.Document)
+	doc[document.IDProperty] = id
+
+	return doc
 }


### PR DESCRIPTION
Sidetree-core logic:  if applying patch fails the whole operation fails

Spec and reference implementation: If applying patch fails we should continue to the next patch in patches array.

Closes #377

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>