### PR TITLE
chore: add registry for hashing algorithms

### DIFF
--- a/pkg/hashing/registry.go
+++ b/pkg/hashing/registry.go
@@ -1,0 +1,86 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package hashing
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/hashing/sha256"
+)
+
+// Option is a registry instance option
+type Option func(opts *Registry)
+
+// Registry contains hashing algorithms
+type Registry struct {
+	algorithms []Algorithm
+}
+
+// Algorithm defines hashing algorithm functionality
+type Algorithm interface {
+	Hash(value []byte) []byte
+	Accept(alg string) bool
+	Close() error
+}
+
+// New return new instance of hashing algorithms registry
+func New(opts ...Option) *Registry {
+	registry := &Registry{}
+
+	// apply options
+	for _, opt := range opts {
+		opt(registry)
+	}
+
+	return registry
+}
+
+// Hash data using specified algorithm
+func (r *Registry) Hash(alg string, data []byte) ([]byte, error) {
+	// resolve hashing algorithm
+	algorithm, err := r.resolveAlgorithm(alg)
+	if err != nil {
+		return nil, err
+	}
+
+	return algorithm.Hash(data), nil
+}
+
+// Close frees resources being maintained by hashing algorithm.
+func (r *Registry) Close() error {
+	for _, v := range r.algorithms {
+		if err := v.Close(); err != nil {
+			return fmt.Errorf("close algorithm: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Registry) resolveAlgorithm(alg string) (Algorithm, error) {
+	for _, v := range r.algorithms {
+		if v.Accept(alg) {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("hashing algorithm '%s' not supported", alg)
+}
+
+// WithAlgorithm adds hashing algorithm to the list of available algorithms
+func WithAlgorithm(alg Algorithm) Option {
+	return func(opts *Registry) {
+		opts.algorithms = append(opts.algorithms, alg)
+	}
+}
+
+// WithDefaultAlgorithms adds default hashing algorithms to the list of available algorithms
+func WithDefaultAlgorithms() Option {
+	return func(opts *Registry) {
+		opts.algorithms = append(opts.algorithms, sha256.New())
+	}
+}

--- a/pkg/hashing/registry_test.go
+++ b/pkg/hashing/registry_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package hashing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/hashing/sha256"
+)
+
+const algSHA256 = "SHA256"
+
+func TestNew(t *testing.T) {
+	t.Run("test new success", func(t *testing.T) {
+		registry := New()
+		require.NotNil(t, registry)
+	})
+	t.Run("test new with SHA256 algorithm option", func(t *testing.T) {
+		registry := New(WithAlgorithm(sha256.New()))
+		require.NotNil(t, registry)
+	})
+	t.Run("test new with default algorithms", func(t *testing.T) {
+		registry := New(WithDefaultAlgorithms())
+		require.NotNil(t, registry)
+	})
+}
+func TestRegistry_Hash(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		registry := New(WithAlgorithm(sha256.New()))
+
+		test := []byte("hello world")
+		h, err := registry.Hash(algSHA256, test)
+		require.NoError(t, err)
+		require.NotEmpty(t, h)
+	})
+
+	t.Run("error - algorithm not supported", func(t *testing.T) {
+		registry := New()
+
+		test := []byte("test data")
+		h, err := registry.Hash("other", test)
+		require.Error(t, err)
+		require.Empty(t, h)
+		require.Contains(t, err.Error(), "hashing algorithm 'other' not supported")
+	})
+}
+
+func TestRegistry_Close(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		registry := New(WithAlgorithm(sha256.New()), WithAlgorithm(&mockAlgorithm{}))
+
+		require.NoError(t, registry.Close())
+	})
+	t.Run("success", func(t *testing.T) {
+		registry := New(WithAlgorithm(&mockAlgorithm{CloseErr: errors.New("close error")}))
+		require.Error(t, registry.Close())
+	})
+}
+
+type mockAlgorithm struct {
+	CloseErr error
+}
+
+// Hash will mock hashing data
+func (m *mockAlgorithm) Hash(data []byte) []byte {
+	return data
+}
+
+// Accept algorithm
+func (m *mockAlgorithm) Accept(alg string) bool {
+	return true
+}
+
+// Close will close resources
+func (m *mockAlgorithm) Close() error {
+	return m.CloseErr
+}

--- a/pkg/hashing/sha256/algorithm.go
+++ b/pkg/hashing/sha256/algorithm.go
@@ -1,0 +1,39 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sha256
+
+import (
+	"crypto/sha256"
+)
+
+const algName = "SHA256"
+
+// Algorithm implements SHA256 hashing
+type Algorithm struct {
+}
+
+// New creates new gzip algorithm instance
+func New() *Algorithm {
+	return &Algorithm{}
+}
+
+// Hash will hash data using SHA256
+func (a *Algorithm) Hash(data []byte) []byte {
+	digest := sha256.Sum256(data)
+	return digest[:]
+}
+
+// Accept algorithm
+func (a *Algorithm) Accept(alg string) bool {
+	return alg == algName
+}
+
+// Close closes open resources
+func (a *Algorithm) Close() error {
+	// nothing to do
+	return nil
+}

--- a/pkg/hashing/sha256/algorithm_test.go
+++ b/pkg/hashing/sha256/algorithm_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sha256
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlgorithm_Accept(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		alg := New()
+		require.True(t, alg.Accept("SHA256"))
+		require.False(t, alg.Accept("other"))
+	})
+}
+
+func TestAlgorithm_Hash(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		alg := New()
+
+		test := []byte("test data")
+		h := alg.Hash(test)
+
+		expected := sha256.Sum256(test)
+		require.Equal(t, expected[:], h)
+	})
+}
+
+func TestAlgorithm_Close(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		alg := New()
+		require.NoError(t, alg.Close())
+	})
+}


### PR DESCRIPTION
Add registry for hashing algorithms; include SHA256 implementation.

Closes #395

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>