### PR TITLE
feat: Additional long form DID format

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -22,8 +22,12 @@ Upon successful validation against configured validator an operation will be add
 
 **Resolution**
 
-Document resolution is based on ID or encoded original document.
+Document resolution is based on ID or initial state values.
 
--- ID : The latest document will be returned if found.
+-- DID : The latest document will be returned if found.
 
--- ID with initial-state parameter: The ID is passed in along with the initial-values parameter as follows: <ID>;initial-values=<encoded-DID-document>. Standard resolution is performed if the DID is found in the document store. If the document cannot be found then the encoded DID Document is used to generate and return as the resolved DID Document, in which case the supplied encoded DID Document is subject to the same validation as an original DID Document in a create operation.
+-- Long Form DID can be requested in the following two formats:
+    a) DID with initial-state parameter
+    did:METHOD:<did-suffix>?initial-state=<create-suffix-data-object>.<create-delta-object>
+    b) DID followed by initial state
+    did:METHOD:<did-suffix>:<create-suffix-data-object>.<create-delta-object>

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -144,8 +144,11 @@ func (r *DocumentHandler) getCreateResponse(operation *batch.Operation) (*docume
 //
 // 1. Standard DID format: did:METHOD:<did-suffix>
 //
-// 2. DID with initial-state DID parameter (Long-Form DID URIs)
+// 2. Long Form DID format that can be in the following formats:
+// a) DID with initial-state parameter
 // did:METHOD:<did-suffix>?initial-state=<create-suffix-data-object>.<create-delta-object>
+// b) DID followed by initial state
+// did:METHOD:<did-suffix>:<create-suffix-data-object>.<create-delta-object>
 //
 // Standard resolution is performed if the DID is found to be registered on the blockchain.
 // If the DID Document cannot be found, the <create-suffix-data-object> and <create-delta-object> given

--- a/pkg/internal/request/method_test.go
+++ b/pkg/internal/request/method_test.go
@@ -61,6 +61,13 @@ func TestGetParts(t *testing.T) {
 	require.Equal(t, initial.Delta, "123")
 	require.Equal(t, initial.SuffixData, "xyz")
 	require.Equal(t, initial.Operation, model.OperationTypeCreate)
+
+	did, initial, err = GetParts(namespace, testDID+":xyz.123")
+	require.NoError(t, err)
+	require.Equal(t, testDID, did)
+	require.Equal(t, initial.Delta, "123")
+	require.Equal(t, initial.SuffixData, "xyz")
+	require.Equal(t, initial.Operation, model.OperationTypeCreate)
 }
 
 func TestGetInitialState(t *testing.T) {

--- a/pkg/restapi/diddochandler/doc.go
+++ b/pkg/restapi/diddochandler/doc.go
@@ -74,7 +74,7 @@ type errorWrapper struct {
 //swagger:parameters resolveDocParams
 //nolint:deadcode,unused
 type resolveDocumentParams struct {
-	// The DID or the DID with initial-state parameter that contains create operation delta and suffix objects.
+	// The DID or the DID with initial state value that contains create operation delta and suffix objects.
 	//
 	// in: path
 	// required: true


### PR DESCRIPTION
Currently we are supporting the following long form DID format:
did:METHOD:did-suffix?initial-state=create-suffix-data-object.create-delta-object

This PR implements second long form DID format:
did:METHOD:did-suffix:create-suffix-data-object.create-delta-object

Closes #398

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>