### PR TITLE
fix: resolution fails if namespace has . in it

### DIFF
--- a/pkg/internal/request/method.go
+++ b/pkg/internal/request/method.go
@@ -42,7 +42,9 @@ func GetParts(namespace, params string) (string, *model.CreateRequest, error) {
 	initialMatch := "?" + initialStateParam + "="
 
 	posInitialStateParam := strings.Index(params, initialMatch)
-	posDot := strings.Index(params, initialStateSeparator)
+	// namespace can have a . so strip namespace from params
+	paramsWithoutNamespace := strings.ReplaceAll(params, namespace, "")
+	posDot := strings.Index(paramsWithoutNamespace, initialStateSeparator)
 
 	if posInitialStateParam == -1 && posDot == -1 {
 		// there is short form did

--- a/pkg/internal/request/method_test.go
+++ b/pkg/internal/request/method_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
 )
 
@@ -67,6 +68,21 @@ func TestGetParts(t *testing.T) {
 	require.Equal(t, testDID, did)
 	require.Equal(t, initial.Delta, "123")
 	require.Equal(t, initial.SuffixData, "xyz")
+	require.Equal(t, initial.Operation, model.OperationTypeCreate)
+
+	namespaceWithDot := "did:bloc:trustbloc.dev"
+	didWithDot := namespaceWithDot + docutil.NamespaceDelimiter + "EiB2gB7F-aDjg8qPsTuZfVqWkJtIWXn4nObHSgtZ1IzMaQ"
+	did, initial, err = GetParts(namespaceWithDot, didWithDot)
+	require.NoError(t, err)
+	require.Equal(t, didWithDot, did)
+	require.Nil(t, initial)
+
+	didWithDotWithInitialState := didWithDot + ":abc.123"
+	did, initial, err = GetParts(namespaceWithDot, didWithDotWithInitialState)
+	require.NoError(t, err)
+	require.Equal(t, didWithDot, did)
+	require.Equal(t, initial.Delta, "123")
+	require.Equal(t, initial.SuffixData, "abc")
 	require.Equal(t, initial.Operation, model.OperationTypeCreate)
 }
 


### PR DESCRIPTION
This was introduced with additional long form DID format because it treats is as long form resolution. Do not check for . in namespace.

Closes #402

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>