### PR TITLE
chore: Add multiple patches for create/recover/update in helper

### DIFF
--- a/pkg/document/jwk.go
+++ b/pkg/document/jwk.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package document
 
+import "errors"
+
 // JWK represents public key in JWK format
 type JWK map[string]interface{}
 
@@ -32,4 +34,24 @@ func (jwk JWK) X() string {
 // Y is y
 func (jwk JWK) Y() string {
 	return stringEntry(jwk["y"])
+}
+
+// Validate will validate JWK properties
+func (jwk JWK) Validate() error {
+	// TODO: validation of the JWK fields depends on the algorithm (issue-409)
+	// For now check required fields for currently supported algorithms secp256k1, P-256, P-384, P-512 and Ed25519
+
+	if jwk.Crv() == "" {
+		return errors.New("JWK crv is missing")
+	}
+
+	if jwk.Kty() == "" {
+		return errors.New("JWK kty is missing")
+	}
+
+	if jwk.X() == "" {
+		return errors.New("JWK x is missing")
+	}
+
+	return nil
 }

--- a/pkg/document/jwk_test.go
+++ b/pkg/document/jwk_test.go
@@ -31,3 +31,44 @@ func TestJWK(t *testing.T) {
 	require.Equal(t, "x", jwk.X())
 	require.Equal(t, "y", jwk.Y())
 }
+
+func TestValidate(t *testing.T) {
+	t.Run("missing kty", func(t *testing.T) {
+		jwk := JWK{
+			"kty": "",
+			"crv": "crv",
+			"x":   "x",
+			"y":   "y",
+		}
+
+		err := ValidateJWK(jwk)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWK kty is missing")
+	})
+
+	t.Run("missing crv", func(t *testing.T) {
+		jwk := JWK{
+			"kty": "kty",
+			"crv": "",
+			"x":   "x",
+			"y":   "y",
+		}
+
+		err := ValidateJWK(jwk)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWK crv is missing")
+	})
+
+	t.Run("missing x", func(t *testing.T) {
+		jwk := JWK{
+			"kty": "kty",
+			"crv": "crv",
+			"x":   "",
+			"y":   "y",
+		}
+
+		err := ValidateJWK(jwk)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "JWK x is missing")
+	})
+}

--- a/pkg/document/validator.go
+++ b/pkg/document/validator.go
@@ -40,7 +40,6 @@ const (
 	// Ed25519VerificationKey2018 requires special handling (convert to base58)
 	Ed25519VerificationKey2018 = "Ed25519VerificationKey2018"
 
-	maxJwkProperties       = 4
 	maxPublicKeyProperties = 4
 
 	// public keys, services id length
@@ -248,23 +247,7 @@ func ValidateJWK(jwk JWK) error {
 		return errors.New("key has to be in JWK format")
 	}
 
-	if len(jwk) != maxJwkProperties {
-		return errors.New("invalid number of JWK properties")
-	}
-
-	if jwk.Crv() == "" {
-		return errors.New("JWK crv is missing")
-	}
-
-	if jwk.Kty() == "" {
-		return errors.New("JWK kty is missing")
-	}
-
-	if jwk.X() == "" {
-		return errors.New("JWK x is missing")
-	}
-
-	return nil
+	return jwk.Validate()
 }
 
 // IsGeneralKey returns true if key is a general key

--- a/pkg/document/validator_test.go
+++ b/pkg/document/validator_test.go
@@ -77,14 +77,6 @@ func TestValidatePublicKeysErrors(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "public key: id exceeds maximum length")
 	})
-	t.Run("invalid number of JWK properties", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(noJWK))
-		require.Nil(t, err)
-
-		err = ValidatePublicKeys(doc.PublicKeys())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid number of JWK properties")
-	})
 	t.Run("duplicate id", func(t *testing.T) {
 		doc, err := DidDocumentFromBytes([]byte(duplicateID))
 		require.Nil(t, err)
@@ -212,19 +204,6 @@ func TestValidateJWK(t *testing.T) {
 		err := ValidateJWK(jwk)
 		require.NoError(t, err)
 	})
-	t.Run("invalid property", func(t *testing.T) {
-		jwk := JWK{
-			"kty":   "kty",
-			"crv":   "crv",
-			"x":     "x",
-			"y":     "y",
-			"other": "value",
-		}
-
-		err := ValidateJWK(jwk)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid number of JWK properties")
-	})
 
 	t.Run("missing kty", func(t *testing.T) {
 		jwk := JWK{
@@ -237,32 +216,6 @@ func TestValidateJWK(t *testing.T) {
 		err := ValidateJWK(jwk)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "JWK kty is missing")
-	})
-
-	t.Run("missing crv", func(t *testing.T) {
-		jwk := JWK{
-			"kty": "kty",
-			"crv": "",
-			"x":   "x",
-			"y":   "y",
-		}
-
-		err := ValidateJWK(jwk)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "JWK crv is missing")
-	})
-
-	t.Run("missing x", func(t *testing.T) {
-		jwk := JWK{
-			"kty": "kty",
-			"crv": "crv",
-			"x":   "",
-			"y":   "y",
-		}
-
-		err := ValidateJWK(jwk)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "JWK x is missing")
 	})
 }
 
@@ -467,17 +420,6 @@ const tooMuchPurpose = `{
         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
       }
-    }
-  ]
-}`
-
-const noJWK = `{
-  "publicKey": [
-    {
-      "id": "key1",
-      "type": "JsonWebKey2020",
-      "purpose": ["general"],
-      "jwk": {}
     }
   ]
 }`

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -85,7 +85,7 @@ func TestPatchesFromDocument(t *testing.T) {
 		p, err := PatchesFromDocument(invalidKeysDoc)
 		require.Error(t, err)
 		require.Nil(t, p)
-		require.Contains(t, err.Error(), "invalid number of JWK properties")
+		require.Contains(t, err.Error(), "JWK x is missing")
 	})
 }
 

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -179,7 +179,7 @@ func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
 
 	return &helper.UpdateRequestInfo{
 		DidSuffix:        uniqueSuffix,
-		Patch:            patchJSON,
+		Patches:          []patch.Patch{patchJSON},
 		UpdateKey:        pubKey,
 		UpdateCommitment: updateCommitment,
 		MultihashCode:    sha2_256,

--- a/pkg/restapi/helper/create_test.go
+++ b/pkg/restapi/helper/create_test.go
@@ -11,12 +11,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
 )
 
@@ -38,11 +38,17 @@ func TestNewCreateRequest(t *testing.T) {
 	recoveryCommitment, err := commitment.Calculate(jwk, sha2_256, crypto.SHA256)
 	require.NoError(t, err)
 
-	t.Run("missing opaque document", func(t *testing.T) {
+	t.Run("missing opaque document or patches", func(t *testing.T) {
 		request, err := NewCreateRequest(&CreateRequestInfo{})
 		require.Error(t, err)
 		require.Empty(t, request)
-		require.Contains(t, err.Error(), "missing opaque document")
+		require.Contains(t, err.Error(), "either opaque document or patches have to be supplied")
+	})
+	t.Run("cannot provide both opaque document and patches", func(t *testing.T) {
+		request, err := NewCreateRequest(&CreateRequestInfo{OpaqueDocument: "{}", Patches: []patch.Patch{{}}})
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "cannot provide both opaque document and patches")
 	})
 	t.Run("recovery commitment error", func(t *testing.T) {
 		request, err := NewCreateRequest(&CreateRequestInfo{OpaqueDocument: "{}", RecoveryCommitment: recoveryCommitment})
@@ -71,7 +77,18 @@ func TestNewCreateRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "multihash[55] not supported")
 	})
-	t.Run("success", func(t *testing.T) {
+	t.Run("error - malformed opaque doc", func(t *testing.T) {
+		info := &CreateRequestInfo{OpaqueDocument: `{,}`,
+			RecoveryCommitment: recoveryCommitment,
+			UpdateCommitment:   recoveryCommitment,
+			MultihashCode:      sha2_256}
+
+		request, err := NewCreateRequest(info)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "invalid character ','")
+	})
+	t.Run("success - opaque document", func(t *testing.T) {
 		info := &CreateRequestInfo{OpaqueDocument: "{}",
 			RecoveryCommitment: recoveryCommitment,
 			UpdateCommitment:   recoveryCommitment,
@@ -81,4 +98,29 @@ func TestNewCreateRequest(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, request)
 	})
+
+	t.Run("success - patches", func(t *testing.T) {
+		p, err := patch.NewAddPublicKeysPatch(addKeys)
+		require.NoError(t, err)
+
+		info := &CreateRequestInfo{Patches: []patch.Patch{p},
+			RecoveryCommitment: recoveryCommitment,
+			UpdateCommitment:   recoveryCommitment,
+			MultihashCode:      sha2_256}
+
+		request, err := NewCreateRequest(info)
+		require.NoError(t, err)
+		require.NotEmpty(t, request)
+	})
 }
+
+const addKeys = `[{
+	"id": "test",
+	"type": "JsonWebKey2020",
+	"purpose": ["general"],
+	"jwk": {
+		"kty": "EC",
+		"crv": "P-256K",
+		"x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA"
+	}
+}]`

--- a/pkg/versions/0_1/txnprovider/handler_test.go
+++ b/pkg/versions/0_1/txnprovider/handler_test.go
@@ -342,7 +342,7 @@ func generateUpdateOperation(num int) (*batch.Operation, error) {
 		Signer:           ecsigner.New(privateKey, "ES256", "key-1"),
 		UpdateCommitment: c,
 		UpdateKey:        testJWK,
-		Patch:            testPatch,
+		Patches:          []patch.Patch{testPatch},
 		MultihashCode:    sha2_256,
 	}
 


### PR DESCRIPTION
Add ability to specify multiple patches for create, recover, update in restapi helper.

Closes #406

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>