### PR TITLE
fix: Apply patches should not modify original document in case of error

### DIFF
--- a/pkg/versions/0_1/doccomposer/composer.go
+++ b/pkg/versions/0_1/doccomposer/composer.go
@@ -30,16 +30,19 @@ func New() *DocumentComposer {
 
 // ApplyPatches applies patches to the document
 func (c *DocumentComposer) ApplyPatches(doc document.Document, patches []patch.Patch) (document.Document, error) {
-	var err error
+	result, err := deepCopy(doc)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, p := range patches {
-		doc, err = applyPatch(doc, p)
+		result, err = applyPatch(result, p)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return doc, nil
+	return result, nil
 }
 
 // applyPatch applies a patch to the document
@@ -270,4 +273,20 @@ func sliceToMapServices(services []document.Service) map[string]document.Service
 	}
 
 	return values
+}
+
+// deepCopy returns deep copy of JSON object
+func deepCopy(doc document.Document) (document.Document, error) {
+	bytes, err := json.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	var result document.Document
+	err = json.Unmarshal(bytes, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/pkg/versions/0_1/doccomposer/composer_test.go
+++ b/pkg/versions/0_1/doccomposer/composer_test.go
@@ -20,7 +20,7 @@ const invalid = "invalid"
 func TestApplyPatches(t *testing.T) {
 	documentComposer := New()
 
-	t.Run("succes - add one key to existing doc with two keys", func(t *testing.T) {
+	t.Run("success - add one key to existing doc with two keys", func(t *testing.T) {
 		original, err := setupDefaultDoc()
 		require.NoError(t, err)
 		require.Equal(t, 2, len(original.PublicKeys()))
@@ -37,6 +37,9 @@ func TestApplyPatches(t *testing.T) {
 		require.Equal(t, "key1", didDoc.PublicKeys()[0].ID())
 		require.Equal(t, "key2", didDoc.PublicKeys()[1].ID())
 		require.Equal(t, "key3", didDoc.PublicKeys()[2].ID())
+
+		// make sure that original document is not modified
+		require.Equal(t, 2, len(original.PublicKeys()))
 	})
 
 	t.Run("action not supported", func(t *testing.T) {
@@ -49,6 +52,15 @@ func TestApplyPatches(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, doc)
 		require.Contains(t, err.Error(), "not supported")
+	})
+	t.Run("error - original document deep copy fails (not json)", func(t *testing.T) {
+		doc := make(document.Document)
+		doc["key"] = make(chan int)
+
+		doc, err := documentComposer.ApplyPatches(doc, nil)
+		require.Error(t, err)
+		require.Nil(t, doc)
+		require.Contains(t, err.Error(), "json: unsupported type: chan int")
 	})
 }
 


### PR DESCRIPTION
Apply patches should not modify original document. Instead, make a copy of the original document and apply patches on that copy.

Closes #410

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>