### PR TITLE
chore: remove unused operation index from anchor model

### DIFF
--- a/pkg/api/batch/operation.go
+++ b/pkg/api/batch/operation.go
@@ -68,9 +68,6 @@ type AnchoredOperation struct {
 	//The transaction number of the transaction this operation was batched within
 	TransactionNumber uint64 `json:"transaction_number"`
 
-	//The index this operation was assigned to in the batch
-	OperationIndex uint `json:"operation_index"`
-
 	//The genesis time of the protocol that was used for this operation
 	ProtocolGenesisTime uint64 `json:"protocol_genesis_time"`
 }

--- a/pkg/versions/0_1/txnprocessor/txnprocessor.go
+++ b/pkg/versions/0_1/txnprocessor/txnprocessor.go
@@ -60,14 +60,14 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*batch.AnchoredOperation, s
 	batchSuffixes := make(map[string]bool)
 
 	var ops []*batch.AnchoredOperation
-	for index, op := range txnOps {
+	for _, op := range txnOps {
 		_, ok := batchSuffixes[op.UniqueSuffix]
 		if ok {
 			logger.Warnf("[%s] duplicate suffix[%s] found in transaction operations: discarding operation %v", sidetreeTxn.Namespace, op.UniqueSuffix, op)
 			continue
 		}
 
-		updatedOp := updateAnchoredOperation(op, uint(index), sidetreeTxn)
+		updatedOp := updateAnchoredOperation(op, sidetreeTxn)
 
 		logger.Debugf("updated operation with blockchain time: %s", updatedOp.UniqueSuffix)
 		ops = append(ops, updatedOp)
@@ -83,15 +83,13 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*batch.AnchoredOperation, s
 	return nil
 }
 
-func updateAnchoredOperation(op *batch.AnchoredOperation, index uint, sidetreeTxn txn.SidetreeTxn) *batch.AnchoredOperation {
+func updateAnchoredOperation(op *batch.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) *batch.AnchoredOperation {
 	//  The logical blockchain time that this operation was anchored on the blockchain
 	op.TransactionTime = sidetreeTxn.TransactionTime
 	// The transaction number of the transaction this operation was batched within
 	op.TransactionNumber = sidetreeTxn.TransactionNumber
 	// The genesis time of the protocol that was used for this operation
 	op.ProtocolGenesisTime = sidetreeTxn.ProtocolGenesisTime
-	// The index this operation was assigned to in the batch
-	op.OperationIndex = index
 
 	return op
 }

--- a/pkg/versions/0_1/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/0_1/txnprocessor/txnprocessor_test.go
@@ -88,10 +88,9 @@ func TestProcessTxnOperations(t *testing.T) {
 func TestUpdateOperation(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
 		updatedOps := updateAnchoredOperation(&batch.AnchoredOperation{UniqueSuffix: "abc"},
-			1, txn.SidetreeTxn{TransactionTime: 20, TransactionNumber: 2})
+			txn.SidetreeTxn{TransactionTime: 20, TransactionNumber: 2})
 		require.Equal(t, uint64(20), updatedOps.TransactionTime)
 		require.Equal(t, uint64(2), updatedOps.TransactionNumber)
-		require.Equal(t, uint(1), updatedOps.OperationIndex)
 	})
 }
 


### PR DESCRIPTION
Leftover from previous versions, not used any more.

Closes #419

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>