### PR TITLE
feat: Add canonical id to document

### DIFF
--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
@@ -98,7 +99,12 @@ func (m *MockDocumentHandler) ResolveDocument(didOrDocument string) (*document.R
 	if m.err != nil {
 		return nil, m.err
 	}
+
 	const badRequest = "bad request"
+	if !strings.HasPrefix(didOrDocument, m.namespace) {
+		return nil, fmt.Errorf("%s: must start with supported namespace", badRequest)
+	}
+
 	did, initial, err := request.GetParts(m.namespace, didOrDocument)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", badRequest, err.Error())

--- a/pkg/restapi/dochandler/resolvehandler.go
+++ b/pkg/restapi/dochandler/resolvehandler.go
@@ -22,7 +22,6 @@ var logger = log.New("sidetree-core-restapi-dochandler")
 
 // Resolver resolves documents
 type Resolver interface {
-	Namespace() string
 	ResolveDocument(idOrDocument string) (*document.ResolutionResult, error)
 }
 
@@ -40,7 +39,7 @@ func NewResolveHandler(resolver Resolver) *ResolveHandler {
 
 // Resolve resolves a document
 func (o *ResolveHandler) Resolve(rw http.ResponseWriter, req *http.Request) {
-	id := getID(o.resolver.Namespace(), req)
+	id := getID(req)
 	logger.Debugf("Resolving DID document for ID [%s]", id)
 	response, err := o.doResolve(id)
 	if err != nil {
@@ -52,11 +51,6 @@ func (o *ResolveHandler) Resolve(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (o *ResolveHandler) doResolve(id string) (*document.ResolutionResult, error) {
-	if !strings.HasPrefix(id, o.resolver.Namespace()) {
-		logger.Errorf("DID ID [%s] does not start with supported namespace [%s]", id, o.resolver.Namespace())
-		return nil, common.NewHTTPError(http.StatusBadRequest, errors.New("must start with supported namespace"))
-	}
-
 	doc, err := o.resolver.ResolveDocument(id)
 	if err != nil {
 		if strings.Contains(err.Error(), "bad request") {
@@ -76,6 +70,6 @@ func (o *ResolveHandler) doResolve(id string) (*document.ResolutionResult, error
 	return doc, nil
 }
 
-var getID = func(namespace string, req *http.Request) string {
+var getID = func(req *http.Request) string {
 	return mux.Vars(req)["id"]
 }

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -46,7 +46,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		}, 0)
 		require.NoError(t, err)
 
-		getID = func(namespace string, req *http.Request) string { return result.Document.ID() }
+		getID = func(req *http.Request) string { return result.Document.ID() }
 		handler := NewResolveHandler(docHandler)
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/document", nil)
@@ -70,7 +70,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 
 		initialState := ":" + initialStateJCS
 
-		getID = func(namespace string, req *http.Request) string { return id + initialState }
+		getID = func(req *http.Request) string { return id + initialState }
 		handler := NewResolveHandler(docHandler)
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/document", nil)
@@ -81,7 +81,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 	})
 
 	t.Run("Invalid ID", func(t *testing.T) {
-		getID = func(namespace string, req *http.Request) string { return "someid" }
+		getID = func(req *http.Request) string { return "someid" }
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
 		handler := NewResolveHandler(docHandler)
 
@@ -91,7 +91,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, rw.Code)
 	})
 	t.Run("Not found", func(t *testing.T) {
-		getID = func(namespace string, req *http.Request) string {
+		getID = func(req *http.Request) string {
 			return namespace + docutil.NamespaceDelimiter + "someid"
 		}
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)
@@ -103,7 +103,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, rw.Code)
 	})
 	t.Run("Error", func(t *testing.T) {
-		getID = func(namespace string, req *http.Request) string {
+		getID = func(req *http.Request) string {
 			return namespace + docutil.NamespaceDelimiter + "someid"
 		}
 		errExpected := errors.New("get doc error")
@@ -142,7 +142,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		}, 0)
 		require.NoError(t, err)
 
-		getID = func(namespace string, req *http.Request) string { return result.Document.ID() }
+		getID = func(req *http.Request) string { return result.Document.ID() }
 		handler := NewResolveHandler(docHandler)
 
 		rw := httptest.NewRecorder()


### PR DESCRIPTION
If alias namespace was used to resolve did, add canonical ID if document has been published.

Closes #427

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>