### PR TITLE
chore: Move patch validation to operation parser

### DIFF
--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -68,27 +68,6 @@ func TestDocumentHandler_ProcessOperation_Create(t *testing.T) {
 	require.NotNil(t, doc)
 }
 
-func TestDocumentHandler_ProcessOperation_InitialDocumentError(t *testing.T) {
-	dochandler, cleanup := getDocumentHandler(mocks.NewMockOperationStore(nil))
-	require.NotNil(t, dochandler)
-	defer cleanup()
-
-	replacePatch, err := patch.NewAddPublicKeysPatch("{}")
-	require.NoError(t, err)
-	replacePatch["publicKeys"] = "invalid"
-
-	createOp := getCreateOperation()
-
-	createOp.DeltaModel = &model.DeltaModel{
-		Patches: []patch.Patch{replacePatch},
-	}
-
-	doc, err := dochandler.ProcessOperation(createOp, 0)
-	require.NotNil(t, err)
-	require.Nil(t, doc)
-	require.Contains(t, err.Error(), "expected array of interfaces")
-}
-
 func TestDocumentHandler_ProcessOperation_MaxOperationSizeError(t *testing.T) {
 	dochandler, cleanup := getDocumentHandler(mocks.NewMockOperationStore(nil))
 	require.NotNil(t, dochandler)

--- a/pkg/dochandler/transformer/didtransformer/transformer_test.go
+++ b/pkg/dochandler/transformer/didtransformer/transformer_test.go
@@ -240,3 +240,63 @@ const ed25519Invalid = `{
 	}
   ]
 }`
+
+func TestIsAuthenticationKey(t *testing.T) {
+	pk := document.NewPublicKey(map[string]interface{}{})
+	ok := isAuthenticationKey(pk.Purpose())
+	require.False(t, ok)
+
+	pk[document.PurposeProperty] = []interface{}{document.KeyPurposeAuth}
+	ok = isAuthenticationKey(pk.Purpose())
+	require.True(t, ok)
+}
+
+func TestIsAssertionKey(t *testing.T) {
+	pk := document.NewPublicKey(map[string]interface{}{})
+	ok := isAssertionKey(pk.Purpose())
+	require.False(t, ok)
+
+	pk[document.PurposeProperty] = []interface{}{document.KeyPurposeAssertion}
+	ok = isAssertionKey(pk.Purpose())
+	require.True(t, ok)
+}
+
+func TestIsAgreementKey(t *testing.T) {
+	pk := document.NewPublicKey(map[string]interface{}{})
+	ok := isAgreementKey(pk.Purpose())
+	require.False(t, ok)
+
+	pk[document.PurposeProperty] = []interface{}{document.KeyPurposeAgreement}
+	ok = isAgreementKey(pk.Purpose())
+	require.True(t, ok)
+}
+
+func TestIsDelegationKey(t *testing.T) {
+	pk := document.NewPublicKey(map[string]interface{}{})
+	ok := isDelegationKey(pk.Purpose())
+	require.False(t, ok)
+
+	pk[document.PurposeProperty] = []interface{}{document.KeyPurposeDelegation}
+	ok = isDelegationKey(pk.Purpose())
+	require.True(t, ok)
+}
+
+func TestIsInvocationKey(t *testing.T) {
+	pk := document.NewPublicKey(map[string]interface{}{})
+	ok := isInvocationKey(pk.Purpose())
+	require.False(t, ok)
+
+	pk[document.PurposeProperty] = []interface{}{document.KeyPurposeInvocation}
+	ok = isInvocationKey(pk.Purpose())
+	require.True(t, ok)
+}
+
+func TestIsGeneralKey(t *testing.T) {
+	pk := document.NewPublicKey(map[string]interface{}{})
+	ok := isGeneralKey(pk.Purpose())
+	require.False(t, ok)
+
+	pk[document.PurposeProperty] = []interface{}{document.KeyPurposeGeneral}
+	ok = isGeneralKey(pk.Purpose())
+	require.True(t, ok)
+}

--- a/pkg/document/jwk_test.go
+++ b/pkg/document/jwk_test.go
@@ -41,7 +41,7 @@ func TestValidate(t *testing.T) {
 			"y":   "y",
 		}
 
-		err := ValidateJWK(jwk)
+		err := jwk.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "JWK kty is missing")
 	})
@@ -54,7 +54,7 @@ func TestValidate(t *testing.T) {
 			"y":   "y",
 		}
 
-		err := ValidateJWK(jwk)
+		err := jwk.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "JWK crv is missing")
 	})
@@ -67,7 +67,7 @@ func TestValidate(t *testing.T) {
 			"y":   "y",
 		}
 
-		err := ValidateJWK(jwk)
+		err := jwk.Validate()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "JWK x is missing")
 	})

--- a/pkg/document/publickey.go
+++ b/pkg/document/publickey.go
@@ -27,6 +27,24 @@ const (
 	PublicKeyBase58Property = "publicKeyBase58"
 )
 
+// KeyPurpose defines key purpose.
+type KeyPurpose string
+
+const (
+	// KeyPurposeAuth defines key purpose as authentication key.
+	KeyPurposeAuth = "auth"
+	// KeyPurposeAssertion defines key purpose as assertion key.
+	KeyPurposeAssertion = "assertion"
+	// KeyPurposeAgreement defines key purpose as agreement key.
+	KeyPurposeAgreement = "agreement"
+	// KeyPurposeDelegation defines key purpose as delegation key.
+	KeyPurposeDelegation = "delegation"
+	// KeyPurposeInvocation defines key purpose as invocation key.
+	KeyPurposeInvocation = "invocation"
+	// KeyPurposeGeneral defines key purpose as general key.
+	KeyPurposeGeneral = "general"
+)
+
 // PublicKey must include id and type properties, and exactly one value property.
 type PublicKey map[string]interface{}
 

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
-
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 )
@@ -67,6 +65,15 @@ const (
 	// ActionKey captures "action" key.
 	ActionKey Key = "action"
 )
+
+var actionConfig = map[Action]Key{
+	AddPublicKeys:          PublicKeys,
+	RemovePublicKeys:       PublicKeys,
+	AddServiceEndpoints:    ServiceEndpointsKey,
+	RemoveServiceEndpoints: ServiceEndpointIdsKey,
+	JSONPatch:              PatchesKey,
+	Replace:                DocumentKey,
+}
 
 // Patch defines generic patch structure.
 type Patch map[Key]interface{}
@@ -128,6 +135,7 @@ func NewReplacePatch(doc string) (Patch, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if err := validateReplaceDocument(parsed); err != nil {
 		return nil, err
 	}
@@ -141,10 +149,6 @@ func NewReplacePatch(doc string) (Patch, error) {
 
 // NewJSONPatch creates new generic update patch (will be used for generic updates).
 func NewJSONPatch(patches string) (Patch, error) {
-	if err := validateJSONPatches([]byte(patches)); err != nil {
-		return nil, err
-	}
-
 	var generic []interface{}
 	err := json.Unmarshal([]byte(patches), &generic)
 	if err != nil {
@@ -183,10 +187,6 @@ func NewRemovePublicKeysPatch(publicKeyIds string) (Patch, error) {
 		return nil, errors.New("missing public key ids")
 	}
 
-	if err := validateIds(ids); err != nil {
-		return nil, err
-	}
-
 	patch := make(Patch)
 	patch[ActionKey] = RemovePublicKeys
 	patch[PublicKeys] = getGenericArray(ids)
@@ -219,10 +219,6 @@ func NewRemoveServiceEndpointsPatch(serviceEndpointIds string) (Patch, error) {
 		return nil, errors.New("missing service ids")
 	}
 
-	if err := validateIds(ids); err != nil {
-		return nil, err
-	}
-
 	patch := make(Patch)
 	patch[ActionKey] = RemoveServiceEndpoints
 	patch[ServiceEndpointIdsKey] = getGenericArray(ids)
@@ -230,50 +226,54 @@ func NewRemoveServiceEndpointsPatch(serviceEndpointIds string) (Patch, error) {
 	return patch, nil
 }
 
-// GetValue returns value for specified key or nil if not found.
-func (p Patch) GetValue(key Key) interface{} {
-	return p[key]
+// GetValue returns patch value.
+func (p Patch) GetValue() (interface{}, error) {
+	action, err := p.GetAction()
+	if err != nil {
+		return nil, err
+	}
+
+	valueKey, ok := actionConfig[action]
+	if !ok {
+		return nil, fmt.Errorf("action '%s' is not supported", action)
+	}
+
+	entry, ok := p[valueKey]
+	if !ok {
+		return nil, fmt.Errorf("%s patch is missing key: %s", action, valueKey)
+	}
+
+	return entry, nil
 }
 
 // GetAction returns string value for specified key or "" if not found or wrong type.
-func (p Patch) GetAction() Action {
-	entry := p[ActionKey]
-	actionStr, ok := entry.(string)
-	if ok {
-		return Action(actionStr)
+func (p Patch) GetAction() (Action, error) {
+	entry, ok := p[ActionKey]
+	if !ok {
+		return "", fmt.Errorf("patch is missing %s key", ActionKey)
 	}
 
-	return p[ActionKey].(Action)
+	var action Action
+	switch v := entry.(type) {
+	case Action:
+		action = v
+	case string:
+		action = Action(v)
+	default:
+		return "", fmt.Errorf("action type not supported: %s", v)
+	}
+
+	_, ok = actionConfig[action]
+	if !ok {
+		return "", fmt.Errorf("action '%s' is not supported", action)
+	}
+
+	return action, nil
 }
 
 // Bytes returns byte representation of patch.
 func (p Patch) Bytes() ([]byte, error) {
 	return docutil.MarshalCanonical(p)
-}
-
-// Validate validates patch.
-func (p Patch) Validate() error {
-	action, err := p.parseAction()
-	if err != nil {
-		return err
-	}
-
-	switch action {
-	case Replace:
-		return p.validateReplace()
-	case JSONPatch:
-		return p.validateJSON()
-	case AddPublicKeys:
-		return p.validateAddPublicKeys()
-	case RemovePublicKeys:
-		return p.validateRemovePublicKeys()
-	case AddServiceEndpoints:
-		return p.validateAddServiceEndpoints()
-	case RemoveServiceEndpoints:
-		return p.validateRemoveServiceEndpoints()
-	}
-
-	return fmt.Errorf("action '%s' is not supported", action)
 }
 
 // JSONLdObject returns map that represents JSON LD Object.
@@ -289,7 +289,13 @@ func FromBytes(data []byte) (Patch, error) {
 		return nil, err
 	}
 
-	if err := patch.Validate(); err != nil {
+	_, err = patch.GetAction()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = patch.GetValue()
+	if err != nil {
 		return nil, err
 	}
 
@@ -317,14 +323,6 @@ func validateReplaceDocument(doc document.ReplaceDocument) error {
 		}
 	}
 
-	if err := document.ValidatePublicKeys(doc.PublicKeys()); err != nil {
-		return fmt.Errorf("failed to validate public keys for replace document: %s", err.Error())
-	}
-
-	if err := document.ValidateServices(doc.Services()); err != nil {
-		return fmt.Errorf("failed to validate services for replace document: %s", err.Error())
-	}
-
 	return nil
 }
 
@@ -346,46 +344,11 @@ func validateDocument(doc document.Document) error {
 	return nil
 }
 
-func validateJSONPatches(patches []byte) error {
-	jsonPatches, err := jsonpatch.DecodePatch(patches)
-	if err != nil {
-		return fmt.Errorf("%s: %s", JSONPatch, err.Error())
-	}
-
-	for _, p := range jsonPatches {
-		pathMsg, ok := p["path"]
-		if !ok {
-			return fmt.Errorf("%s: path not found", JSONPatch)
-		}
-
-		var path string
-		if err := json.Unmarshal(*pathMsg, &path); err != nil {
-			return fmt.Errorf("%s: invalid path", JSONPatch)
-		}
-
-		if strings.HasPrefix(path, "/"+document.ServiceProperty) {
-			return fmt.Errorf("%s: cannot modify services", JSONPatch)
-		}
-
-		if strings.HasPrefix(path, "/"+document.PublicKeyProperty) {
-			return fmt.Errorf("%s: cannot modify public keys", JSONPatch)
-		}
-	}
-
-	return nil
-}
-
 func getPublicKeys(publicKeys string) (interface{}, error) {
 	// create an empty did document with public keys
 	pkDoc, err := document.DidDocumentFromBytes([]byte(fmt.Sprintf(`{"%s":%s}`, document.PublicKeyProperty, publicKeys)))
 	if err != nil {
 		return nil, fmt.Errorf("public keys invalid: %s", err.Error())
-	}
-
-	pubKeys := pkDoc.PublicKeys()
-	err = document.ValidatePublicKeys(pubKeys)
-	if err != nil {
-		return nil, err
 	}
 
 	return pkDoc[document.PublicKeyProperty], nil
@@ -399,120 +362,7 @@ func getServices(serviceEndpoints string) (interface{}, error) {
 		return nil, fmt.Errorf("services invalid: %s", err.Error())
 	}
 
-	services := svcDoc.Services()
-	err = document.ValidateServices(services)
-	if err != nil {
-		return nil, err
-	}
-
 	return svcDoc[document.ServiceProperty], nil
-}
-
-func (p *Patch) parseAction() (Action, error) {
-	entry := p.GetValue(ActionKey)
-	if entry == nil {
-		return "", errors.New("patch is missing action property")
-	}
-
-	switch v := entry.(type) {
-	case Action:
-		return v, nil
-	case string:
-		return Action(v), nil
-	default:
-		return "", fmt.Errorf("action type not supported: %s", v)
-	}
-}
-
-func (p Patch) getRequiredArray(key Key) ([]interface{}, error) {
-	entry := p.GetValue(key)
-	if entry == nil {
-		return nil, fmt.Errorf("%s patch is missing %s", p.GetAction(), key)
-	}
-
-	arr, ok := entry.([]interface{})
-	if !ok {
-		return nil, errors.New("expected array of interfaces")
-	}
-
-	if len(arr) == 0 {
-		return nil, errors.New("required array is empty")
-	}
-
-	return arr, nil
-}
-
-func (p Patch) validateReplace() error {
-	doc, err := p.getRequiredMap(DocumentKey)
-	if err != nil {
-		return err
-	}
-
-	return validateReplaceDocument(document.ReplaceDocumentFromJSONLDObject(doc))
-}
-
-func (p Patch) validateJSON() error {
-	patches, err := p.getRequiredArray(PatchesKey)
-	if err != nil {
-		return err
-	}
-
-	patchesBytes, err := json.Marshal(patches)
-	if err != nil {
-		return err
-	}
-
-	return validateJSONPatches(patchesBytes)
-}
-
-func (p Patch) validateAddPublicKeys() error {
-	_, err := p.getRequiredArray(PublicKeys)
-	if err != nil {
-		return err
-	}
-
-	publicKeys := document.ParsePublicKeys(p.GetValue(PublicKeys))
-
-	return document.ValidatePublicKeys(publicKeys)
-}
-
-func (p Patch) validateRemovePublicKeys() error {
-	genericArr, err := p.getRequiredArray(PublicKeys)
-	if err != nil {
-		return err
-	}
-
-	return validateIds(document.StringArray(genericArr))
-}
-
-func (p Patch) validateAddServiceEndpoints() error {
-	_, err := p.getRequiredArray(ServiceEndpointsKey)
-	if err != nil {
-		return err
-	}
-
-	services := document.ParseServices(p.GetValue(ServiceEndpointsKey))
-
-	return document.ValidateServices(services)
-}
-
-func (p Patch) validateRemoveServiceEndpoints() error {
-	genericArr, err := p.getRequiredArray(ServiceEndpointIdsKey)
-	if err != nil {
-		return err
-	}
-
-	return validateIds(document.StringArray(genericArr))
-}
-
-func validateIds(ids []string) error {
-	for _, id := range ids {
-		if err := document.ValidateID(id); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func getStringArray(arr string) ([]string, error) {
@@ -532,18 +382,4 @@ func getGenericArray(arr []string) []interface{} {
 	}
 
 	return values
-}
-
-func (p Patch) getRequiredMap(key Key) (map[string]interface{}, error) {
-	entry := p.GetValue(key)
-	if entry == nil {
-		return nil, fmt.Errorf("%s patch is missing %s", p.GetAction(), key)
-	}
-
-	required, ok := entry.(map[string]interface{})
-	if !ok {
-		return nil, errors.New("unexpected interface for document")
-	}
-
-	return required, nil
 }

--- a/pkg/restapi/helper/create.go
+++ b/pkg/restapi/helper/create.go
@@ -86,12 +86,6 @@ func getPatches(opaque string, patches []patch.Patch) ([]patch.Patch, error) {
 		return patch.PatchesFromDocument(opaque)
 	}
 
-	for _, p := range patches {
-		if err := p.Validate(); err != nil {
-			return nil, err
-		}
-	}
-
 	return patches, nil
 }
 

--- a/pkg/versions/0_1/doccomposer/composer.go
+++ b/pkg/versions/0_1/doccomposer/composer.go
@@ -47,24 +47,29 @@ func (c *DocumentComposer) ApplyPatches(doc document.Document, patches []patch.P
 
 // applyPatch applies a patch to the document.
 func applyPatch(doc document.Document, p patch.Patch) (document.Document, error) {
-	if err := p.Validate(); err != nil {
+	action, err := p.GetAction()
+	if err != nil {
 		return nil, err
 	}
 
-	action := p.GetAction()
+	value, err := p.GetValue()
+	if err != nil {
+		return nil, err
+	}
+
 	switch action {
 	case patch.Replace:
-		return applyRecover(p.GetValue(patch.DocumentKey))
+		return applyRecover(value)
 	case patch.JSONPatch:
-		return applyJSON(doc, p.GetValue(patch.PatchesKey))
+		return applyJSON(doc, value)
 	case patch.AddPublicKeys:
-		return applyAddPublicKeys(doc, p.GetValue(patch.PublicKeys))
+		return applyAddPublicKeys(doc, value)
 	case patch.RemovePublicKeys:
-		return applyRemovePublicKeys(doc, p.GetValue(patch.PublicKeys))
+		return applyRemovePublicKeys(doc, value)
 	case patch.AddServiceEndpoints:
-		return applyAddServiceEndpoints(doc, p.GetValue(patch.ServiceEndpointsKey))
+		return applyAddServiceEndpoints(doc, value)
 	case patch.RemoveServiceEndpoints:
-		return applyRemoveServiceEndpoints(doc, p.GetValue(patch.ServiceEndpointIdsKey))
+		return applyRemoveServiceEndpoints(doc, value)
 	}
 
 	return nil, fmt.Errorf("action '%s' is not supported", action)

--- a/pkg/versions/0_1/doccomposer/composer_test.go
+++ b/pkg/versions/0_1/doccomposer/composer_test.go
@@ -112,20 +112,6 @@ func TestApplyPatches_JSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, doc)
 	})
-	t.Run("invalid json", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		ietf, err := patch.NewJSONPatch(patches)
-		require.NoError(t, err)
-
-		ietf["patches"] = invalid
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{ietf})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "expected array")
-	})
 	t.Run("invalid operation", func(t *testing.T) {
 		doc, err := setupDefaultDoc()
 		require.NoError(t, err)
@@ -191,19 +177,6 @@ func TestApplyPatches_AddPublicKeys(t *testing.T) {
 		diddoc := document.DidDocumentFromJSONLDObject(doc)
 		require.Equal(t, 3, len(diddoc.PublicKeys()))
 	})
-	t.Run("invalid json", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		addPublicKeys, err := patch.NewAddPublicKeysPatch(addKeys)
-		require.NoError(t, err)
-		addPublicKeys["public_keys"] = invalid
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{addPublicKeys})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "expected array of interfaces")
-	})
 }
 
 func TestApplyPatches_RemovePublicKeys(t *testing.T) {
@@ -237,32 +210,6 @@ func TestApplyPatches_RemovePublicKeys(t *testing.T) {
 
 		diddoc := document.DidDocumentFromJSONLDObject(doc)
 		require.Equal(t, 1, len(diddoc.PublicKeys()))
-	})
-	t.Run("invalid json", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		removePublicKeys, err := patch.NewRemovePublicKeysPatch(removeKeys)
-		require.NoError(t, err)
-		removePublicKeys["public_keys"] = invalid
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{removePublicKeys})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "expected array")
-	})
-	t.Run("invalid public key ids", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		removePublicKeys, err := patch.NewRemovePublicKeysPatch(removeKeys)
-		require.NoError(t, err)
-		removePublicKeys["public_keys"] = []interface{}{"a&b"}
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{removePublicKeys})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "id contains invalid characters")
 	})
 	t.Run("success - add and remove same key; doc stays at two keys", func(t *testing.T) {
 		doc, err := setupDefaultDoc()
@@ -338,19 +285,6 @@ func TestApplyPatches_AddServiceEndpoints(t *testing.T) {
 		diddoc := document.DidDocumentFromJSONLDObject(doc)
 		require.Equal(t, 3, len(diddoc.Services()))
 	})
-	t.Run("invalid json", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		addServices, err := patch.NewAddServiceEndpointsPatch(addServices)
-		require.NoError(t, err)
-		addServices["service_endpoints"] = invalid
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{addServices})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "expected array")
-	})
 }
 
 func TestApplyPatches_RemoveServiceEndpoints(t *testing.T) {
@@ -384,32 +318,6 @@ func TestApplyPatches_RemoveServiceEndpoints(t *testing.T) {
 
 		diddoc := document.DidDocumentFromJSONLDObject(doc)
 		require.Equal(t, 1, len(diddoc.Services()))
-	})
-	t.Run("invalid json", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		removeServices, err := patch.NewRemoveServiceEndpointsPatch(removeServices)
-		require.NoError(t, err)
-		removeServices["ids"] = invalid
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{removeServices})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "expected array")
-	})
-	t.Run("invalid service ids", func(t *testing.T) {
-		doc, err := setupDefaultDoc()
-		require.NoError(t, err)
-
-		removeServices, err := patch.NewRemoveServiceEndpointsPatch(removeServices)
-		require.NoError(t, err)
-		removeServices["ids"] = []interface{}{"svc", "a&b"}
-
-		doc, err = documentComposer.ApplyPatches(doc, []patch.Patch{removeServices})
-		require.Error(t, err)
-		require.Nil(t, doc)
-		require.Contains(t, err.Error(), "id contains invalid characters")
 	})
 	t.Run("success - add and remove same service; doc stays at two services", func(t *testing.T) {
 		doc, err := setupDefaultDoc()
@@ -524,8 +432,6 @@ const updateExistingKey = `[{
 		}
 	}]`
 
-const removeKeys = `["key1", "key2"]`
-
 const addServices = `[
     {
       "id": "svc3",
@@ -541,8 +447,6 @@ const updateExistingService = `[
       "endpoint": "http://hub.my-personal-server.com"
     }
   ]`
-
-const removeServices = `["svc1", "svc2"]`
 
 const replaceDoc = `{
 	"public_keys": [

--- a/pkg/versions/0_1/docvalidator/didvalidator/validator.go
+++ b/pkg/versions/0_1/docvalidator/didvalidator/validator.go
@@ -73,16 +73,6 @@ func (v *Validator) IsValidOriginalDocument(payload []byte) error {
 		return errors.New("document must NOT have the id property")
 	}
 
-	// Sidetree rule: validate public keys
-	if err := document.ValidatePublicKeys(didDoc.PublicKeys()); err != nil {
-		return err
-	}
-
-	// Sidetree rule: validate services
-	if err := document.ValidateServices(didDoc.Services()); err != nil {
-		return err
-	}
-
 	// Sidetree rule: must not have context
 	ctx := didDoc.Context()
 	if len(ctx) != 0 {

--- a/pkg/versions/0_1/docvalidator/didvalidator/validator_test.go
+++ b/pkg/versions/0_1/docvalidator/didvalidator/validator_test.go
@@ -37,26 +37,6 @@ func TestIsValidOriginalDocument(t *testing.T) {
 	require.Nil(t, err)
 }
 
-func TestIsValidOriginalDocument_ServiceErrors(t *testing.T) {
-	v := getDefaultValidator()
-
-	err := v.IsValidOriginalDocument(serviceNoID)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "service id is missing")
-}
-
-func TestIsValidOriginalDocument_PublicKeyErrors(t *testing.T) {
-	v := getDefaultValidator()
-
-	err := v.IsValidOriginalDocument(pubKeyNoID)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "public key id is missing")
-
-	err = v.IsValidOriginalDocument(pubKeyWithController)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "invalid number of public key properties")
-}
-
 func TestIsValidOriginalDocument_ContextProvidedError(t *testing.T) {
 	v := getDefaultValidator()
 
@@ -155,25 +135,8 @@ var (
     }] 
 }`)
 
-	pubKeyNoID  = []byte(`{ "publicKey": [{"id": "", "type": "JsonWebKey2020"}]}`)
-	serviceNoID = []byte(`{ "service": [{"id": "", "type": "IdentityHub", "endpoint": "https://example.com/hub"}]}`)
-	docWithID   = []byte(`{ "id" : "001", "name": "John Smith" }`)
+	docWithID = []byte(`{ "id" : "001", "name": "John Smith" }`)
 
 	validUpdate   = []byte(`{ "did_suffix": "abc" }`)
 	invalidUpdate = []byte(`{ "patch": "" }`)
-
-	pubKeyWithController = []byte(`{
-  "publicKey": [{
-      "id": "key-1",
-      "type": "JsonWebKey2020",
-      "controller": "did:example:123456789abcdefghi",
-      "purpose": ["general"],
-      "jwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-	}]
-}`)
 )

--- a/pkg/versions/0_1/docvalidator/docvalidator/validator.go
+++ b/pkg/versions/0_1/docvalidator/docvalidator/validator.go
@@ -71,10 +71,5 @@ func (v *Validator) IsValidOriginalDocument(payload []byte) error {
 		return errors.New("document must NOT have the id property")
 	}
 
-	// Sidetree rule: validate public keys
-	if err := document.ValidatePublicKeys(doc.PublicKeys()); err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/pkg/versions/0_1/docvalidator/docvalidator/validator_test.go
+++ b/pkg/versions/0_1/docvalidator/docvalidator/validator_test.go
@@ -36,14 +36,6 @@ func TestValidatoIsValidOriginalDocumentError(t *testing.T) {
 	require.Contains(t, err.Error(), "document must NOT have the id property")
 }
 
-func TestIsValidOriginalDocument_PublicKeyErrors(t *testing.T) {
-	v := getDefaultValidator()
-
-	err := v.IsValidOriginalDocument(pubKeyNoID)
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "public key id is missing")
-}
-
 func TestValidatorIsValidPayload(t *testing.T) {
 	store := mocks.NewMockOperationStore(nil)
 	v := New(store)
@@ -109,6 +101,4 @@ var (
 
 	validUpdate   = []byte(`{ "did_suffix": "abc" }`)
 	invalidUpdate = []byte(`{ "patch": "" }`)
-
-	pubKeyNoID = []byte(`{ "publicKey": [{"id": "", "type": "JsonWebKey2020"}]}`)
 )

--- a/pkg/versions/0_1/operationparser/create.go
+++ b/pkg/versions/0_1/operationparser/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationparser/patchvalidator"
 )
 
 // ParseCreateOperation will parse create operation.
@@ -169,11 +170,16 @@ func (p *Parser) validateDelta(delta *model.DeltaModel) error {
 	}
 
 	for _, ptch := range delta.Patches {
-		if !p.isPatchEnabled(ptch.GetAction()) {
-			return fmt.Errorf("%s patch action is not enabled", ptch.GetAction())
+		action, err := ptch.GetAction()
+		if err != nil {
+			return err
 		}
 
-		if err := ptch.Validate(); err != nil {
+		if !p.isPatchEnabled(action) {
+			return fmt.Errorf("%s patch action is not enabled", action)
+		}
+
+		if err := patchvalidator.Validate(ptch); err != nil {
 			return err
 		}
 	}

--- a/pkg/versions/0_1/operationparser/patchvalidator/addkeys.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/addkeys.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewAddPublicKeysValidator creates new validator.
+func NewAddPublicKeysValidator() *AddPublicKeysValidator {
+	return &AddPublicKeysValidator{}
+}
+
+// AddPublicKeysValidator implements validator for "add-public-keys" patch.
+type AddPublicKeysValidator struct {
+}
+
+// Validate validates patch.
+func (v *AddPublicKeysValidator) Validate(p patch.Patch) error {
+	value, err := p.GetValue()
+	if err != nil {
+		return err
+	}
+
+	_, err = getRequiredArray(value)
+	if err != nil {
+		return fmt.Errorf("invalid add public keys value: %s", err.Error())
+	}
+
+	publicKeys := document.ParsePublicKeys(value)
+
+	return validatePublicKeys(publicKeys)
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/addkeys_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/addkeys_test.go
@@ -1,0 +1,52 @@
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestAddPublicKeysPatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addPublicKeysPatch))
+		require.NoError(t, err)
+
+		err = NewAddPublicKeysValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("error - missing value", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addPublicKeysPatch))
+		require.NoError(t, err)
+
+		delete(p, patch.PublicKeys)
+		err = NewAddPublicKeysValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "add-public-keys patch is missing key: public_keys")
+	})
+	t.Run("error - invalid value for public keys", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addPublicKeysPatch))
+		require.NoError(t, err)
+
+		p[patch.PublicKeys] = ""
+		err = NewAddPublicKeysValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid add public keys value: expected array of interfaces")
+	})
+}
+
+const addPublicKeysPatch = `{
+   "action": "add-public-keys",
+   "public_keys": [{
+      "id": "key1",
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
+      "jwk": {
+         "kty": "EC",
+         "crv": "P-256K",
+         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+   }]
+}`

--- a/pkg/versions/0_1/operationparser/patchvalidator/addservices.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/addservices.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewAddServicesValidator creates new validator.
+func NewAddServicesValidator() *AddServicesValidator {
+	return &AddServicesValidator{}
+}
+
+// AddServicesValidator implements validator for "add-public-keys" patch.
+type AddServicesValidator struct {
+}
+
+// Validate validates patch.
+func (v *AddServicesValidator) Validate(p patch.Patch) error {
+	value, err := p.GetValue()
+	if err != nil {
+		return err
+	}
+
+	_, err = getRequiredArray(value)
+	if err != nil {
+		return fmt.Errorf("invalid add services value: %s", err.Error())
+	}
+
+	services := document.ParseServices(value)
+
+	return validateServices(services)
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/addservices_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/addservices_test.go
@@ -1,0 +1,60 @@
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestAddServiceEndpointsPatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addServiceEndpoints))
+		require.NoError(t, err)
+
+		err = NewAddServicesValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("missing service endpoints", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addServiceEndpoints))
+		require.NoError(t, err)
+
+		delete(p, patch.ServiceEndpointsKey)
+		err = NewAddServicesValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "add-service-endpoints patch is missing key: service_endpoints")
+	})
+	t.Run("error - service is missing id", func(t *testing.T) {
+		p, err := patch.NewAddServiceEndpointsPatch(testAddServiceEndpointsMissingID)
+		require.NoError(t, err)
+
+		err = NewAddServicesValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "service id is missing")
+	})
+}
+
+const addServiceEndpoints = `{
+  "action": "add-service-endpoints",
+  "service_endpoints": [
+    {
+      "id": "sds1",
+      "type": "SecureDataStore",
+      "endpoint": "http://hub.my-personal-server.com"
+    },
+    {
+      "id": "sds2",
+      "type": "SecureDataStore",
+      "endpoint": "http://some-cloud.com/hub"
+    }
+  ]
+}`
+
+const testAddServiceEndpointsMissingID = `[
+    {
+      "id": "",
+      "type": "SecureDataStore",
+      "endpoint": "http://some-cloud.com/hub"
+    }
+  ]`

--- a/pkg/versions/0_1/operationparser/patchvalidator/document_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/document_test.go
@@ -4,16 +4,18 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package document
+package patchvalidator
 
 import (
+	"io"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-)
 
-const purposeKey = "purpose"
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+)
 
 func TestValidatePublicKeys(t *testing.T) {
 	r := reader(t, "testdata/doc.json")
@@ -21,76 +23,76 @@ func TestValidatePublicKeys(t *testing.T) {
 	data, err := ioutil.ReadAll(r)
 	require.Nil(t, err)
 
-	doc, err := DidDocumentFromBytes(data)
+	doc, err := document.DidDocumentFromBytes(data)
 	require.Nil(t, err)
 
-	err = ValidatePublicKeys(doc.PublicKeys())
+	err = validatePublicKeys(doc.PublicKeys())
 	require.Nil(t, err)
 }
 
 func TestValidatePublicKeysErrors(t *testing.T) {
 	t.Run("missing purpose", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(noPurpose))
+		doc, err := document.DidDocumentFromBytes([]byte(noPurpose))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing purpose")
 	})
 	t.Run("invalid purpose", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(wrongPurpose))
+		doc, err := document.DidDocumentFromBytes([]byte(wrongPurpose))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid purpose")
 	})
 	t.Run("purpose exceeds maximum", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(tooMuchPurpose))
+		doc, err := document.DidDocumentFromBytes([]byte(tooMuchPurpose))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "public key purpose exceeds maximum length")
 	})
 	t.Run("invalid key type", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(invalidKeyType))
+		doc, err := document.DidDocumentFromBytes([]byte(invalidKeyType))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid key type")
 	})
 	t.Run("missing id", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(noID))
+		doc, err := document.DidDocumentFromBytes([]byte(noID))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "public key id is missing")
 	})
 	t.Run("invalid id - too long", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(idLong))
+		doc, err := document.DidDocumentFromBytes([]byte(idLong))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "public key: id exceeds maximum length")
 	})
 	t.Run("duplicate id", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(duplicateID))
+		doc, err := document.DidDocumentFromBytes([]byte(duplicateID))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "duplicate public key id")
 	})
 
 	t.Run("unknown property", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(moreProperties))
+		doc, err := document.DidDocumentFromBytes([]byte(moreProperties))
 		require.Nil(t, err)
 
-		err = ValidatePublicKeys(doc.PublicKeys())
+		err = validatePublicKeys(doc.PublicKeys())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid number of public key properties")
 	})
@@ -98,95 +100,95 @@ func TestValidatePublicKeysErrors(t *testing.T) {
 
 func TestValidateServices(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDoc))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDoc))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Nil(t, err)
 	})
 	t.Run("success - service can have allowed optional property", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocOptionalProperty))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocOptionalProperty))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.NoError(t, err)
 	})
 	t.Run("error - missing service id", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocNoID))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocNoID))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service id is missing")
 	})
 	t.Run("error - missing service type", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocNoType))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocNoType))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service type is missing")
 	})
 	t.Run("error - missing service endpoint", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocNoServiceEndpoint))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocNoServiceEndpoint))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service endpoint is missing")
 	})
 	t.Run("error - service id too long", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocLongID))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocLongID))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service: id exceeds maximum length")
 	})
 	t.Run("error - service type too long", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocLongType))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocLongType))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service type exceeds maximum length")
 	})
 	t.Run("error - service endpoint too long", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocLongServiceEndpoint))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocLongServiceEndpoint))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service endpoint exceeds maximum length")
 	})
 	t.Run("error - service endpoint not URI", func(t *testing.T) {
-		doc, err := DidDocumentFromBytes([]byte(serviceDocEndpointNotURI))
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocEndpointNotURI))
 		require.NoError(t, err)
 
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "service endpoint is not valid URI")
 	})
 	t.Run("success - didcomm service", func(t *testing.T) {
-		doc, err := DIDDocumentFromReader(reader(t, "testdata/doc.json"))
+		doc, err := document.DIDDocumentFromReader(reader(t, "testdata/doc.json"))
 		require.NoError(t, err)
-		err = ValidateServices(doc.Services())
+		err = validateServices(doc.Services())
 		require.NoError(t, err)
 	})
 }
 
 func TestValidateID(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		err := ValidateID("recovered")
+		err := validateID("recovered")
 		require.NoError(t, err)
 	})
 	t.Run("error - id not ASCII encoded character", func(t *testing.T) {
-		err := ValidateID("a****")
+		err := validateID("a****")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "id contains invalid characters")
 	})
 	t.Run("error - exceeded maximum length", func(t *testing.T) {
-		err := ValidateID("1234567890abcdefghijk123456789012345678901234567890")
+		err := validateID("1234567890abcdefghijk123456789012345678901234567890")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "id exceeds maximum length: 50")
 	})
@@ -194,128 +196,75 @@ func TestValidateID(t *testing.T) {
 
 func TestValidateJWK(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		jwk := JWK{
+		jwk := document.JWK{
 			"kty": "kty",
 			"crv": "crv",
 			"x":   "x",
 			"y":   "y",
 		}
 
-		err := ValidateJWK(jwk)
+		err := validateJWK(jwk)
 		require.NoError(t, err)
 	})
 
 	t.Run("missing kty", func(t *testing.T) {
-		jwk := JWK{
+		jwk := document.JWK{
 			"kty": "",
 			"crv": "crv",
 			"x":   "x",
 			"y":   "y",
 		}
 
-		err := ValidateJWK(jwk)
+		err := validateJWK(jwk)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "JWK kty is missing")
 	})
 }
 
-func TestIsAuthenticationKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	ok := IsAuthenticationKey(pk.Purpose())
-	require.False(t, ok)
-
-	pk[purposeKey] = []interface{}{auth}
-	ok = IsAuthenticationKey(pk.Purpose())
-	require.True(t, ok)
-}
-
-func TestIsAssertionKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	ok := IsAssertionKey(pk.Purpose())
-	require.False(t, ok)
-
-	pk[purposeKey] = []interface{}{assertion}
-	ok = IsAssertionKey(pk.Purpose())
-	require.True(t, ok)
-}
-
-func TestIsAgreementKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	ok := IsAgreementKey(pk.Purpose())
-	require.False(t, ok)
-
-	pk[purposeKey] = []interface{}{agreement}
-	ok = IsAgreementKey(pk.Purpose())
-	require.True(t, ok)
-}
-
-func TestIsDelegationKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	ok := IsDelegationKey(pk.Purpose())
-	require.False(t, ok)
-
-	pk[purposeKey] = []interface{}{delegation}
-	ok = IsDelegationKey(pk.Purpose())
-	require.True(t, ok)
-}
-
-func TestIsInvocationKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	ok := IsInvocationKey(pk.Purpose())
-	require.False(t, ok)
-
-	pk[purposeKey] = []interface{}{invocation}
-	ok = IsInvocationKey(pk.Purpose())
-	require.True(t, ok)
-}
-
-func TestIsGeneralKey(t *testing.T) {
-	pk := NewPublicKey(map[string]interface{}{})
-	ok := IsGeneralKey(pk.Purpose())
-	require.False(t, ok)
-
-	pk[purposeKey] = []interface{}{general}
-	ok = IsGeneralKey(pk.Purpose())
-	require.True(t, ok)
-}
-
 func TestGeneralKeyPurpose(t *testing.T) {
 	for _, pubKeyType := range allowedKeyTypesGeneral {
-		pk := createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{general})
-		err := ValidatePublicKeys([]PublicKey{pk})
+		pk := createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{document.KeyPurposeGeneral})
+		err := validatePublicKeys([]document.PublicKey{pk})
 		require.NoError(t, err, "valid purpose for type")
 	}
 
-	pk := createMockPublicKeyWithTypeAndPurpose("invalid", []interface{}{general})
-	err := ValidatePublicKeys([]PublicKey{pk})
+	pk := createMockPublicKeyWithTypeAndPurpose("invalid", []interface{}{document.KeyPurposeGeneral})
+	err := validatePublicKeys([]document.PublicKey{pk})
 	require.Error(t, err, "invalid purpose for type")
 }
 
 func TestInvalidKeyPurpose(t *testing.T) {
 	pk := createMockPublicKeyWithTypeAndPurpose(jsonWebKey2020, []interface{}{"invalidpurpose"})
-	err := ValidatePublicKeys([]PublicKey{pk})
+	err := validatePublicKeys([]document.PublicKey{pk})
 	require.Error(t, err, "invalid purpose")
 }
 
 func TestVerificationKeyPurpose(t *testing.T) {
-	testKeyPurpose(t, allowedKeyTypesVerification, assertion)
-	testKeyPurpose(t, allowedKeyTypesVerification, auth)
-	testKeyPurpose(t, allowedKeyTypesVerification, delegation)
-	testKeyPurpose(t, allowedKeyTypesVerification, invocation)
+	testKeyPurpose(t, allowedKeyTypesVerification, document.KeyPurposeAssertion)
+	testKeyPurpose(t, allowedKeyTypesVerification, document.KeyPurposeAuth)
+	testKeyPurpose(t, allowedKeyTypesVerification, document.KeyPurposeDelegation)
+	testKeyPurpose(t, allowedKeyTypesVerification, document.KeyPurposeInvocation)
 }
 
 func TestAgreementKeyPurpose(t *testing.T) {
-	testKeyPurpose(t, allowedKeyTypesAgreement, agreement)
+	testKeyPurpose(t, allowedKeyTypesAgreement, document.KeyPurposeAgreement)
+}
+
+func reader(t *testing.T, filename string) io.Reader {
+	f, err := os.Open(filename)
+	require.Nil(t, err)
+
+	return f
 }
 
 func testKeyPurpose(t *testing.T, allowedKeys existenceMap, pubKeyPurpose string) {
 	for _, pubKeyType := range allowedKeys {
-		pk := createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{general, pubKeyPurpose})
-		err := ValidatePublicKeys([]PublicKey{pk})
+		pk := createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{document.KeyPurposeGeneral, pubKeyPurpose})
+		err := validatePublicKeys([]document.PublicKey{pk})
 		require.NoError(t, err, "valid purpose for type")
 
 		pk = createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{pubKeyPurpose})
-		err = ValidatePublicKeys([]PublicKey{pk})
+		err = validatePublicKeys([]document.PublicKey{pk})
 		require.NoError(t, err, "valid purpose for type")
 	}
 
@@ -325,25 +274,25 @@ func testKeyPurpose(t *testing.T, allowedKeys existenceMap, pubKeyPurpose string
 			continue
 		}
 
-		pk := createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{general, pubKeyPurpose, agreement})
-		err := ValidatePublicKeys([]PublicKey{pk})
+		pk := createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{document.KeyPurposeGeneral, pubKeyPurpose, document.KeyPurposeAgreement})
+		err := validatePublicKeys([]document.PublicKey{pk})
 		require.Error(t, err, "invalid purpose for type")
 
-		pk = createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{general, pubKeyPurpose, assertion})
-		err = ValidatePublicKeys([]PublicKey{pk})
+		pk = createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{document.KeyPurposeGeneral, pubKeyPurpose, document.KeyPurposeAssertion})
+		err = validatePublicKeys([]document.PublicKey{pk})
 		require.Error(t, err, "invalid purpose for type")
 
-		pk = createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{general, pubKeyPurpose})
-		err = ValidatePublicKeys([]PublicKey{pk})
+		pk = createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{document.KeyPurposeGeneral, pubKeyPurpose})
+		err = validatePublicKeys([]document.PublicKey{pk})
 		require.Error(t, err, "invalid purpose for type")
 
 		pk = createMockPublicKeyWithTypeAndPurpose(pubKeyType, []interface{}{pubKeyPurpose})
-		err = ValidatePublicKeys([]PublicKey{pk})
+		err = validatePublicKeys([]document.PublicKey{pk})
 		require.Error(t, err, "invalid purpose for type")
 	}
 }
 
-func createMockPublicKeyWithTypeAndPurpose(pubKeyType string, purpose []interface{}) PublicKey {
+func createMockPublicKeyWithTypeAndPurpose(pubKeyType string, purpose []interface{}) document.PublicKey {
 	pk := map[string]interface{}{
 		"id":      "key1",
 		"type":    pubKeyType,

--- a/pkg/versions/0_1/operationparser/patchvalidator/ietf.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/ietf.go
@@ -1,0 +1,76 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewJSONValidator creates new validator.
+func NewJSONValidator() *JSONValidator {
+	return &JSONValidator{}
+}
+
+// JSONValidator implements validator for "ietf-json-patch" patch.
+type JSONValidator struct {
+}
+
+// Validate validates patch.
+func (v *JSONValidator) Validate(p patch.Patch) error {
+	value, err := p.GetValue()
+	if err != nil {
+		return err
+	}
+
+	patches, err := getRequiredArray(value)
+	if err != nil {
+		return fmt.Errorf("invalid json patch value: %s", err.Error())
+	}
+
+	patchesBytes, err := json.Marshal(patches)
+	if err != nil {
+		return err
+	}
+
+	return validateJSONPatches(patchesBytes)
+}
+
+func validateJSONPatches(patches []byte) error {
+	jsonPatches, err := jsonpatch.DecodePatch(patches)
+	if err != nil {
+		return fmt.Errorf("%s: %s", patch.JSONPatch, err.Error())
+	}
+
+	for _, p := range jsonPatches {
+		pathMsg, ok := p["path"]
+		if !ok {
+			return fmt.Errorf("%s: path not found", patch.JSONPatch)
+		}
+
+		var path string
+		if err := json.Unmarshal(*pathMsg, &path); err != nil {
+			return fmt.Errorf("%s: invalid path", patch.JSONPatch)
+		}
+
+		if strings.HasPrefix(path, "/"+document.ServiceProperty) {
+			return fmt.Errorf("%s: cannot modify services", patch.JSONPatch)
+		}
+
+		if strings.HasPrefix(path, "/"+document.PublicKeyProperty) {
+			return fmt.Errorf("%s: cannot modify public keys", patch.JSONPatch)
+		}
+	}
+
+	return nil
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/ietf_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/ietf_test.go
@@ -1,0 +1,86 @@
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestIETFPatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(ietfPatch))
+		require.NoError(t, err)
+
+		err = NewJSONValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("error - path not found", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(ietfPatchNoPath))
+		require.NoError(t, err)
+
+		err = NewJSONValidator().Validate(p)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "ietf-json-patch: path not found")
+	})
+	t.Run("error - cannot update services", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(ietfServicesPatch))
+		require.NoError(t, err)
+
+		err = NewJSONValidator().Validate(p)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "ietf-json-patch: cannot modify services")
+	})
+	t.Run("error - cannot update public keys", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(ietfPublicKeysPatch))
+		require.NoError(t, err)
+
+		err = NewJSONValidator().Validate(p)
+		require.Error(t, err)
+		require.Equal(t, err.Error(), "ietf-json-patch: cannot modify public keys")
+	})
+	t.Run("error missing patches", func(t *testing.T) {
+		p := make(patch.Patch)
+		p[patch.ActionKey] = patch.JSONPatch
+
+		err := NewJSONValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "ietf-json-patch patch is missing key: patches")
+	})
+}
+
+const ietfPatch = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
+      "path": "/name",
+      "value": "value"
+   }]
+}`
+
+const ietfPatchNoPath = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
+      "value": "value"
+   }]
+}`
+
+const ietfServicesPatch = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
+      "path": "/service",
+      "value": "new value"
+   }]
+}`
+
+const ietfPublicKeysPatch = `{
+  "action": "ietf-json-patch",
+  "patches": [{
+      "op": "replace",
+      "path": "/publicKey/0/type",
+      "value": "new type"
+   }]
+}`

--- a/pkg/versions/0_1/operationparser/patchvalidator/removekeys.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/removekeys.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewRemovePublicKeysValidator creates validator for "remove-public-keys" patch.
+func NewRemovePublicKeysValidator() *RemovePublicKeysValidator {
+	return &RemovePublicKeysValidator{}
+}
+
+// RemovePublicKeysValidator implements validator for "remove-public-keys" patch.
+type RemovePublicKeysValidator struct {
+}
+
+// Validate validates patch.
+func (v *RemovePublicKeysValidator) Validate(p patch.Patch) error {
+	value, err := p.GetValue()
+	if err != nil {
+		return err
+	}
+
+	genericArr, err := getRequiredArray(value)
+	if err != nil {
+		return fmt.Errorf("invalid remove public keys value: %s", err.Error())
+	}
+
+	return validateIds(document.StringArray(genericArr))
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/removekeys_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/removekeys_test.go
@@ -1,0 +1,50 @@
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestRemovePublicKeysPatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(removePublicKeysPatch))
+		require.NoError(t, err)
+
+		err = NewRemovePublicKeysValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("error - missing public key ids", func(t *testing.T) {
+		p := make(patch.Patch)
+		p[patch.ActionKey] = patch.RemovePublicKeys
+
+		err := NewRemovePublicKeysValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "remove-public-keys patch is missing key: public_keys")
+	})
+	t.Run("error - invalid add public keys value", func(t *testing.T) {
+		p := make(patch.Patch)
+		p[patch.ActionKey] = patch.RemovePublicKeys
+		p[patch.PublicKeys] = "whatever"
+
+		err := NewRemovePublicKeysValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected array of interfaces")
+	})
+	t.Run("invalid public key ids", func(t *testing.T) {
+		const ids = `["a123*b456"]`
+		p, err := patch.NewRemovePublicKeysPatch(ids)
+		require.NoError(t, err)
+
+		err = NewRemovePublicKeysValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "id contains invalid characters")
+	})
+}
+
+const removePublicKeysPatch = `{
+  "action": "remove-public-keys",
+  "public_keys": ["key1", "key2"]
+}`

--- a/pkg/versions/0_1/operationparser/patchvalidator/removeservices.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/removeservices.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewRemoveServicesValidator creates new validator.
+func NewRemoveServicesValidator() *RemoveServicesValidator {
+	return &RemoveServicesValidator{}
+}
+
+// RemoveServicesValidator implements validator for "remove-service-endpoints" patch.
+type RemoveServicesValidator struct {
+}
+
+// Validate validates patch.
+func (v *RemoveServicesValidator) Validate(p patch.Patch) error {
+	value, err := p.GetValue()
+	if err != nil {
+		return err
+	}
+
+	genericArr, err := getRequiredArray(value)
+	if err != nil {
+		return fmt.Errorf("invalid remove services value: %s", err.Error())
+	}
+
+	return validateIds(document.StringArray(genericArr))
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/removeservices_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/removeservices_test.go
@@ -1,0 +1,50 @@
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestRemoveServiceEndpointsPatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(removeServiceEndpoints))
+		require.NoError(t, err)
+
+		err = NewRemoveServicesValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("error - missing public key ids", func(t *testing.T) {
+		p := make(patch.Patch)
+		p[patch.ActionKey] = patch.RemoveServiceEndpoints
+
+		err := NewRemoveServicesValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "remove-service-endpoints patch is missing key: ids")
+	})
+	t.Run("error - invalid service ids", func(t *testing.T) {
+		p := make(patch.Patch)
+		p[patch.ActionKey] = patch.RemoveServiceEndpoints
+		p[patch.ServiceEndpointIdsKey] = "invalid"
+
+		err := NewRemoveServicesValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected array of interfaces")
+	})
+	t.Run("invalid service ids", func(t *testing.T) {
+		const ids = `["a123*b456"]`
+		p, err := patch.NewRemoveServiceEndpointsPatch(ids)
+		require.NoError(t, err)
+
+		err = NewRemoveServicesValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "id contains invalid characters")
+	})
+}
+
+const removeServiceEndpoints = `{
+  "action": "remove-service-endpoints",
+  "ids": ["sds1", "sds2"]
+}`

--- a/pkg/versions/0_1/operationparser/patchvalidator/replace.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/replace.go
@@ -1,0 +1,66 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewReplaceValidator creates new validator.
+func NewReplaceValidator() *ReplaceValidator {
+	return &ReplaceValidator{}
+}
+
+// ReplaceValidator implements validator for "replace" patch.
+type ReplaceValidator struct {
+}
+
+// Validate validates patch.
+func (v *ReplaceValidator) Validate(p patch.Patch) error {
+	value, err := p.GetValue()
+	if err != nil {
+		return err
+	}
+
+	entryMap, err := getRequiredMap(value)
+	if err != nil {
+		return err
+	}
+
+	doc := document.ReplaceDocumentFromJSONLDObject(entryMap)
+
+	allowedKeys := []string{document.ReplaceServiceProperty, document.ReplacePublicKeyProperty}
+
+	for key := range doc {
+		if !contains(allowedKeys, key) {
+			return fmt.Errorf("key '%s' is not allowed in replace document", key)
+		}
+	}
+
+	if err := validatePublicKeys(doc.PublicKeys()); err != nil {
+		return fmt.Errorf("failed to validate public keys for replace document: %s", err.Error())
+	}
+
+	if err := validateServices(doc.Services()); err != nil {
+		return fmt.Errorf("failed to validate services for replace document: %s", err.Error())
+	}
+
+	return nil
+}
+
+func getRequiredMap(entry interface{}) (map[string]interface{}, error) {
+	required, ok := entry.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("unexpected interface for document")
+	}
+
+	return required, nil
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/replace_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/replace_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestValidateReplacePatch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(replacePatch))
+		require.NoError(t, err)
+
+		err = NewReplaceValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("missing document", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(replacePatch))
+		require.NoError(t, err)
+		require.NotNil(t, p)
+
+		delete(p, patch.DocumentKey)
+		err = NewReplaceValidator().Validate(p)
+		require.Contains(t, err.Error(), "replace patch is missing key: document")
+	})
+	t.Run("error - document has invalid property", func(t *testing.T) {
+		doc, err := document.FromBytes([]byte(replaceDocWithExtraProperties))
+		require.NoError(t, err)
+
+		p := make(patch.Patch)
+		p[patch.ActionKey] = patch.Replace
+		p[patch.DocumentKey] = doc.JSONLdObject()
+
+		err = NewReplaceValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "key 'id' is not allowed in replace document")
+	})
+	t.Run("error - public keys (missing type)", func(t *testing.T) {
+		p, err := patch.NewReplacePatch(replaceDocInvalidPublicKey)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+
+		err = NewReplaceValidator().Validate(p)
+		require.Contains(t, err.Error(), "invalid number of public key properties")
+	})
+	t.Run("error - services (missing endpoint)", func(t *testing.T) {
+		p, err := patch.NewReplacePatch(replaceDocInvalidServiceEndpoint)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+
+		err = NewReplaceValidator().Validate(p)
+		require.Contains(t, err.Error(), "service endpoint is missing")
+	})
+}
+
+const replacePatch = `{
+   "action": "replace",
+   "document": {
+      "public_keys": [
+      {
+         "id": "key-1",
+         "purpose": ["auth"],
+         "type": "EcdsaSecp256k1VerificationKey2019",
+         "jwk": {
+            "kty": "EC",
+            "crv": "P-256K",
+            "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+            "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+         }
+      }],
+      "service_endpoints": [
+      {
+         "id": "sds3",
+         "type": "SecureDataStore",
+         "endpoint": "http://hub.my-personal-server.com"
+      }]
+   }
+}`
+
+const replaceDocWithExtraProperties = `{
+   "id": "some-id",
+   "public_keys": [
+   {
+      "id": "key-1",
+      "purpose": ["auth"],
+      "type": "EcdsaSecp256k1VerificationKey2019",
+      "jwk": {
+         "kty": "EC",
+         "crv": "P-256K",
+         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+   }]
+}`
+
+const replaceDocInvalidPublicKey = `{
+   "public_keys": [
+   {
+      "id": "key-1",
+      "purpose": ["auth"],
+      "jwk": {
+         "kty": "EC",
+         "crv": "P-256K",
+         "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+         "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+   }]
+}`
+
+const replaceDocInvalidServiceEndpoint = `{
+   "service_endpoints": [
+   {
+      "id": "sds3",
+      "type": "SecureDataStore"
+   }]
+}`

--- a/pkg/versions/0_1/operationparser/patchvalidator/testdata/doc.json
+++ b/pkg/versions/0_1/operationparser/patchvalidator/testdata/doc.json
@@ -1,0 +1,145 @@
+{
+  "publicKey": [
+    {
+      "id": "master",
+      "type": "EcdsaSecp256k1VerificationKey2019",
+      "purpose": ["general", "auth", "assertion", "agreement", "delegation", "invocation"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-auth-gen",
+      "type": "JsonWebKey2020",
+      "purpose": ["auth", "general"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "auth-only",
+      "type": "JsonWebKey2020",
+      "purpose": ["auth"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-assertion-gen",
+      "type": "JsonWebKey2020",
+      "purpose": ["assertion", "general"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "assertion-only",
+      "type": "JsonWebKey2020",
+      "purpose": ["assertion"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-agreement-gen",
+      "type": "JsonWebKey2020",
+      "purpose": ["agreement", "general"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "agreement-only",
+      "type": "JsonWebKey2020",
+      "purpose": ["agreement"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-invocation-gen",
+      "type": "JsonWebKey2020",
+      "purpose": ["invocation", "general"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "invocation-only",
+      "type": "JsonWebKey2020",
+      "purpose": ["invocation"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "dual-delegation-gen",
+      "type": "JsonWebKey2020",
+      "purpose": ["delegation", "general"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "delegation-only",
+      "type": "JsonWebKey2020",
+      "purpose": ["delegation"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    },
+    {
+      "id": "general-only",
+      "type": "JsonWebKey2020",
+      "purpose": ["general"],
+      "jwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    }
+  ],
+  "service": [
+    {
+      "id": "hub",
+      "type": "IdentityHub",
+      "routingKeys": "routingKeysValue",
+      "recipientKeys": "recipientKeysValue",
+      "endpoint": "https://example.com/hub/"
+    }
+  ]
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/validator.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/validator.go
@@ -1,0 +1,32 @@
+package patchvalidator
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// Validate validates patch.
+func Validate(p patch.Patch) error {
+	action, err := p.GetAction()
+	if err != nil {
+		return err
+	}
+
+	switch action {
+	case patch.Replace:
+		return NewReplaceValidator().Validate(p)
+	case patch.JSONPatch:
+		return NewJSONValidator().Validate(p)
+	case patch.AddPublicKeys:
+		return NewAddPublicKeysValidator().Validate(p)
+	case patch.RemovePublicKeys:
+		return NewRemovePublicKeysValidator().Validate(p)
+	case patch.AddServiceEndpoints:
+		return NewAddServicesValidator().Validate(p)
+	case patch.RemoveServiceEndpoints:
+		return NewRemoveServicesValidator().Validate(p)
+	}
+
+	return fmt.Errorf(" validation for action '%s' is not supported", action)
+}

--- a/pkg/versions/0_1/operationparser/patchvalidator/validator_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/validator_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestValidate(t *testing.T) {
+	t.Run("success - add public keys", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addPublicKeysPatch))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("success - remove public keys", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(removePublicKeysPatch))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("success - add service endpoints", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addServiceEndpoints))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("success - remove service endpoints", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(removeServiceEndpoints))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("success - ietf patch", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(ietfPatch))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("success - replace patch", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(replacePatch))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("error - patch not supported", func(t *testing.T) {
+		p := make(patch.Patch)
+		p[patch.ActionKey] = "invalid"
+
+		err := Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "action 'invalid' is not supported")
+	})
+}


### PR DESCRIPTION
The following logic has been moved to versioned code:
- move patch validation to patch validator package in operation parser (separate patch definition from validation)
- move common validation code from document package to patch validator in operation parser
Also included:
- move transformation dependencies from document package to transformer package (not versioned yet)

Closes #443

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>