### PR TITLE
chore: Move canonical id from doc to resolution result (method metadata)

### DIFF
--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -38,8 +38,6 @@ var logger = log.New("sidetree-core-dochandler")
 
 const (
 	keyID = "id"
-	// name may change based on https://github.com/w3c/did-core/issues/421
-	canonicalID = "canonicalId"
 
 	badRequest = "bad request"
 )
@@ -213,7 +211,7 @@ func (r *DocumentHandler) resolveRequestWithID(namespace, uniquePortion string) 
 
 	if r.namespace != namespace {
 		// we got here using alias; suggest using namespace
-		externalResult.Document[canonicalID] = r.namespace + docutil.NamespaceDelimiter + uniquePortion
+		externalResult.MethodMetadata.CanonicalID = r.namespace + docutil.NamespaceDelimiter + uniquePortion
 	}
 
 	externalResult.MethodMetadata.Published = true

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -132,7 +132,7 @@ func TestDocumentHandler_ResolveDocument_DID(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, true, result.MethodMetadata.Published)
-	require.Equal(t, result.Document[canonicalID], docID)
+	require.Equal(t, result.MethodMetadata.CanonicalID, docID)
 	require.Equal(t, result.Document[keyID], aliasID)
 
 	// scenario: invalid namespace

--- a/pkg/document/resolution.go
+++ b/pkg/document/resolution.go
@@ -18,4 +18,5 @@ type MethodMetadata struct {
 	UpdateCommitment   string `json:"updateCommitment"`
 	RecoveryCommitment string `json:"recoveryCommitment"`
 	Published          bool   `json:"published"`
+	CanonicalID        string `json:"canonicalID"`
 }


### PR DESCRIPTION
Currently we have canonical ID in DID document. Since there is no movement in adding canonical ID to did-core @troyronda requested we are going to move this field to method metadata.

Closes #435

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>