### PR TITLE
chore: Version parsing of initial state

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -59,6 +59,7 @@ type TxnProcessor interface {
 // OperationParser defines the functions for parsing operations.
 type OperationParser interface {
 	Parse(namespace string, operation []byte) (*batchapi.Operation, error)
+	ParseDID(namespace, shortOrLongFormDID string) (string, []byte, error)
 	GetRevealValue(operation []byte) (*jws.JWK, error)
 	GetCommitment(operation []byte) (string, error)
 }

--- a/pkg/mocks/dochandler.go
+++ b/pkg/mocks/dochandler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
-	"github.com/trustbloc/sidetree-core-go/pkg/internal/request"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doccomposer"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
@@ -146,7 +145,12 @@ func (m *MockDocumentHandler) ResolveDocument(didOrDocument string) (*document.R
 		return nil, fmt.Errorf("%s: must start with supported namespace", badRequest)
 	}
 
-	did, initial, err := request.GetParts(m.namespace, didOrDocument)
+	pv, err := m.Protocol().Current()
+	if err != nil {
+		return nil, err
+	}
+
+	did, initial, err := pv.OperationParser().ParseDID(m.namespace, didOrDocument)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", badRequest, err.Error())
 	}

--- a/pkg/mocks/operationparser.gen.go
+++ b/pkg/mocks/operationparser.gen.go
@@ -50,6 +50,22 @@ type OperationParser struct {
 		result1 *batch.Operation
 		result2 error
 	}
+	ParseDIDStub        func(string, string) (string, []byte, error)
+	parseDIDMutex       sync.RWMutex
+	parseDIDArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	parseDIDReturns struct {
+		result1 string
+		result2 []byte
+		result3 error
+	}
+	parseDIDReturnsOnCall map[int]struct {
+		result1 string
+		result2 []byte
+		result3 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -259,6 +275,73 @@ func (fake *OperationParser) ParseReturnsOnCall(i int, result1 *batch.Operation,
 	}{result1, result2}
 }
 
+func (fake *OperationParser) ParseDID(arg1 string, arg2 string) (string, []byte, error) {
+	fake.parseDIDMutex.Lock()
+	ret, specificReturn := fake.parseDIDReturnsOnCall[len(fake.parseDIDArgsForCall)]
+	fake.parseDIDArgsForCall = append(fake.parseDIDArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("ParseDID", []interface{}{arg1, arg2})
+	fake.parseDIDMutex.Unlock()
+	if fake.ParseDIDStub != nil {
+		return fake.ParseDIDStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.parseDIDReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *OperationParser) ParseDIDCallCount() int {
+	fake.parseDIDMutex.RLock()
+	defer fake.parseDIDMutex.RUnlock()
+	return len(fake.parseDIDArgsForCall)
+}
+
+func (fake *OperationParser) ParseDIDCalls(stub func(string, string) (string, []byte, error)) {
+	fake.parseDIDMutex.Lock()
+	defer fake.parseDIDMutex.Unlock()
+	fake.ParseDIDStub = stub
+}
+
+func (fake *OperationParser) ParseDIDArgsForCall(i int) (string, string) {
+	fake.parseDIDMutex.RLock()
+	defer fake.parseDIDMutex.RUnlock()
+	argsForCall := fake.parseDIDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *OperationParser) ParseDIDReturns(result1 string, result2 []byte, result3 error) {
+	fake.parseDIDMutex.Lock()
+	defer fake.parseDIDMutex.Unlock()
+	fake.ParseDIDStub = nil
+	fake.parseDIDReturns = struct {
+		result1 string
+		result2 []byte
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *OperationParser) ParseDIDReturnsOnCall(i int, result1 string, result2 []byte, result3 error) {
+	fake.parseDIDMutex.Lock()
+	defer fake.parseDIDMutex.Unlock()
+	fake.ParseDIDStub = nil
+	if fake.parseDIDReturnsOnCall == nil {
+		fake.parseDIDReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 []byte
+			result3 error
+		})
+	}
+	fake.parseDIDReturnsOnCall[i] = struct {
+		result1 string
+		result2 []byte
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *OperationParser) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -268,6 +351,8 @@ func (fake *OperationParser) Invocations() map[string][][]interface{} {
 	defer fake.getRevealValueMutex.RUnlock()
 	fake.parseMutex.RLock()
 	defer fake.parseMutex.RUnlock()
+	fake.parseDIDMutex.RLock()
+	defer fake.parseDIDMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -49,7 +49,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 	})
 	t.Run("Success with initial value", func(t *testing.T) {
 		docHandler := mocks.NewMockDocumentHandler().
-			WithNamespace(namespace)
+			WithNamespace(namespace).WithProtocolClient(newMockProtocolClient())
 
 		create, err := getCreateRequest()
 		require.NoError(t, err)


### PR DESCRIPTION
Parsing of initial state during long form resolution should be versioned. Move this functionality to operation parser.

Closes #441

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>