### PR TITLE
chore: rename and version REST helper

### DIFF
--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doccomposer"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationapplier"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationparser"
@@ -478,14 +478,14 @@ func generateOperation(num int) (*batch.OperationInfo, error) {
 	}
 
 	doc := fmt.Sprintf(`{"test":%d}`, num)
-	info := &helper.CreateRequestInfo{
+	info := &client.CreateRequestInfo{
 		OpaqueDocument:     doc,
 		RecoveryCommitment: c,
 		UpdateCommitment:   c,
 		MultihashCode:      sha2_256,
 	}
 
-	request, err := helper.NewCreateRequest(info)
+	request, err := client.NewCreateRequest(info)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doccomposer"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationapplier"
@@ -842,7 +842,7 @@ func getAnchoredUpdateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix strin
 	return getAnchoredOperation(op, blockNumber), nextUpdateKey, nil
 }
 
-func getUpdateOperationWithSigner(s helper.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string, blockNumber uint64) (*model.Operation, *ecdsa.PrivateKey, error) {
+func getUpdateOperationWithSigner(s client.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string, blockNumber uint64) (*model.Operation, *ecdsa.PrivateKey, error) {
 	p := map[string]interface{}{
 		"op":    "replace",
 		"path":  "/test",
@@ -935,7 +935,7 @@ func getAnchoredDeactivateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix s
 	return getAnchoredOperation(op, defaultBlockNumber), nil
 }
 
-func getDeactivateOperationWithSigner(singer helper.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string) (*model.Operation, error) {
+func getDeactivateOperationWithSigner(singer client.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string) (*model.Operation, error) {
 	recoverPubKey, err := pubkey.GetPublicKeyJWK(&privateKey.PublicKey)
 	if err != nil {
 		return nil, err
@@ -979,7 +979,7 @@ func getAnchoredRecoverOperation(recoveryKey, updateKey *ecdsa.PrivateKey, uniqu
 	return getAnchoredOperation(op, blockNumber), nextRecoveryKey, nil
 }
 
-func getRecoverOperationWithSigner(signer helper.Signer, recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix string, blockNum uint64) (*model.Operation, *ecdsa.PrivateKey, error) {
+func getRecoverOperationWithSigner(signer client.Signer, recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix string, blockNum uint64) (*model.Operation, *ecdsa.PrivateKey, error) {
 	recoverRequest, nextRecoveryKey, err := getDefaultRecoverRequest(signer, recoveryKey, updateKey, blockNum)
 	if err != nil {
 		return nil, nil, err
@@ -995,7 +995,7 @@ func getRecoverOperationWithSigner(signer helper.Signer, recoveryKey, updateKey 
 	}, nextRecoveryKey, nil
 }
 
-func getRecoverRequest(signer helper.Signer, deltaModel *model.DeltaModel, signedDataModel *model.RecoverSignedDataModel, blockNum uint64) (*model.RecoverRequest, error) {
+func getRecoverRequest(signer client.Signer, deltaModel *model.DeltaModel, signedDataModel *model.RecoverSignedDataModel, blockNum uint64) (*model.RecoverRequest, error) {
 	deltaHash, err := docutil.CalculateModelMultihash(deltaModel, getProtocol(blockNum).HashAlgorithmInMultiHashCode)
 	if err != nil {
 		return nil, err
@@ -1016,7 +1016,7 @@ func getRecoverRequest(signer helper.Signer, deltaModel *model.DeltaModel, signe
 	}, nil
 }
 
-func getDefaultRecoverRequest(signer helper.Signer, recoveryKey, updateKey *ecdsa.PrivateKey, blockNum uint64) (*model.RecoverRequest, *ecdsa.PrivateKey, error) {
+func getDefaultRecoverRequest(signer client.Signer, recoveryKey, updateKey *ecdsa.PrivateKey, blockNum uint64) (*model.RecoverRequest, *ecdsa.PrivateKey, error) {
 	p := getProtocol(blockNum)
 
 	updateCommitment, err := getCommitment(updateKey, p)

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doccomposer"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationapplier"
@@ -51,7 +51,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 	req, err := getCreateRequestInfo()
 	require.NoError(t, err)
 
-	create, err := helper.NewCreateRequest(req)
+	create, err := client.NewCreateRequest(req)
 	require.NoError(t, err)
 
 	var createReq model.CreateRequest
@@ -83,7 +83,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 		require.Equal(t, len(doc.PublicKeys()), 1)
 	})
 	t.Run("Update", func(t *testing.T) {
-		update, err := helper.NewUpdateRequest(getUpdateRequestInfo(uniqueSuffix))
+		update, err := client.NewUpdateRequest(getUpdateRequestInfo(uniqueSuffix))
 		require.NoError(t, err)
 
 		rw := httptest.NewRecorder()
@@ -93,7 +93,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
 	t.Run("Deactivate", func(t *testing.T) {
-		deactivate, err := helper.NewDeactivateRequest(getDeactivateRequestInfo(id))
+		deactivate, err := client.NewDeactivateRequest(getDeactivateRequestInfo(id))
 		require.NoError(t, err)
 
 		rw := httptest.NewRecorder()
@@ -103,7 +103,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
 	t.Run("Recover", func(t *testing.T) {
-		recover, err := helper.NewRecoverRequest(getRecoverRequestInfo(uniqueSuffix))
+		recover, err := client.NewRecoverRequest(getRecoverRequestInfo(uniqueSuffix))
 		require.NoError(t, err)
 
 		rw := httptest.NewRecorder()
@@ -137,7 +137,7 @@ func TestUpdateHandler_Update(t *testing.T) {
 	})
 }
 
-func getCreateRequestInfo() (*helper.CreateRequestInfo, error) {
+func getCreateRequestInfo() (*client.CreateRequestInfo, error) {
 	recoveryCommitment, err := commitment.Calculate(testJWK, sha2_256, crypto.SHA256)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func getCreateRequestInfo() (*helper.CreateRequestInfo, error) {
 		return nil, err
 	}
 
-	return &helper.CreateRequestInfo{
+	return &client.CreateRequestInfo{
 		OpaqueDocument:     validDoc,
 		RecoveryCommitment: recoveryCommitment,
 		UpdateCommitment:   updateCommitment,
@@ -156,7 +156,7 @@ func getCreateRequestInfo() (*helper.CreateRequestInfo, error) {
 	}, nil
 }
 
-func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
+func getUpdateRequestInfo(uniqueSuffix string) *client.UpdateRequestInfo {
 	patchJSON, err := patch.NewJSONPatch(`[{"op": "replace", "path": "/name", "value": "value"}]`)
 	if err != nil {
 		panic(err)
@@ -178,7 +178,7 @@ func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
 		panic(err)
 	}
 
-	return &helper.UpdateRequestInfo{
+	return &client.UpdateRequestInfo{
 		DidSuffix:        uniqueSuffix,
 		Patches:          []patch.Patch{patchJSON},
 		UpdateKey:        pubKey,
@@ -188,21 +188,21 @@ func getUpdateRequestInfo(uniqueSuffix string) *helper.UpdateRequestInfo {
 	}
 }
 
-func getDeactivateRequestInfo(uniqueSuffix string) *helper.DeactivateRequestInfo {
+func getDeactivateRequestInfo(uniqueSuffix string) *client.DeactivateRequestInfo {
 	curve := elliptic.P256()
 	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		panic(err)
 	}
 
-	return &helper.DeactivateRequestInfo{
+	return &client.DeactivateRequestInfo{
 		DidSuffix:   uniqueSuffix,
 		RecoveryKey: testJWK,
 		Signer:      ecsigner.New(privateKey, "ES256", ""),
 	}
 }
 
-func getRecoverRequestInfo(uniqueSuffix string) *helper.RecoverRequestInfo {
+func getRecoverRequestInfo(uniqueSuffix string) *client.RecoverRequestInfo {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		panic(err)
@@ -223,7 +223,7 @@ func getRecoverRequestInfo(uniqueSuffix string) *helper.RecoverRequestInfo {
 		panic(err)
 	}
 
-	return &helper.RecoverRequestInfo{
+	return &client.RecoverRequestInfo{
 		DidSuffix:          uniqueSuffix,
 		OpaqueDocument:     recoverDoc,
 		RecoveryKey:        recoveryKey,

--- a/pkg/versions/0_1/client/create.go
+++ b/pkg/versions/0_1/client/create.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"errors"

--- a/pkg/versions/0_1/client/create_test.go
+++ b/pkg/versions/0_1/client/create_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"crypto"

--- a/pkg/versions/0_1/client/deactivate.go
+++ b/pkg/versions/0_1/client/deactivate.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"errors"

--- a/pkg/versions/0_1/client/deactivate_test.go
+++ b/pkg/versions/0_1/client/deactivate_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"crypto/ecdsa"

--- a/pkg/versions/0_1/client/recover.go
+++ b/pkg/versions/0_1/client/recover.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"errors"

--- a/pkg/versions/0_1/client/recover_test.go
+++ b/pkg/versions/0_1/client/recover_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"crypto/ecdsa"

--- a/pkg/versions/0_1/client/update.go
+++ b/pkg/versions/0_1/client/update.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"errors"

--- a/pkg/versions/0_1/client/update_test.go
+++ b/pkg/versions/0_1/client/update_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package helper
+package client
 
 import (
 	"crypto/ecdsa"

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/doccomposer"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationparser"
@@ -706,7 +706,7 @@ func getAnchoredUpdateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix strin
 	return getAnchoredOperationWithBlockNum(op, uint64(operationNumber)), nextUpdateKey, nil
 }
 
-func getUpdateOperationWithSigner(s helper.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string, operationNumber uint) (*model.Operation, *ecdsa.PrivateKey, error) {
+func getUpdateOperationWithSigner(s client.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string, operationNumber uint) (*model.Operation, *ecdsa.PrivateKey, error) {
 	p := map[string]interface{}{
 		"op":    "replace",
 		"path":  "/test",
@@ -799,7 +799,7 @@ func getAnchoredDeactivateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix s
 	return getAnchoredOperation(op), nil
 }
 
-func getDeactivateOperationWithSigner(singer helper.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string) (*model.Operation, error) {
+func getDeactivateOperationWithSigner(singer client.Signer, privateKey *ecdsa.PrivateKey, uniqueSuffix string) (*model.Operation, error) {
 	recoverPubKey, err := pubkey.GetPublicKeyJWK(&privateKey.PublicKey)
 	if err != nil {
 		return nil, err
@@ -839,7 +839,7 @@ func getAnchoredRecoverOperation(recoveryKey, updateKey *ecdsa.PrivateKey, uniqu
 	return getAnchoredOperationWithBlockNum(op, uint64(operationNumber)), nextRecoveryKey, nil
 }
 
-func getRecoverOperationWithSigner(signer helper.Signer, recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix string) (*model.Operation, *ecdsa.PrivateKey, error) {
+func getRecoverOperationWithSigner(signer client.Signer, recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix string) (*model.Operation, *ecdsa.PrivateKey, error) {
 	recoverRequest, nextRecoveryKey, err := getDefaultRecoverRequest(signer, recoveryKey, updateKey)
 	if err != nil {
 		return nil, nil, err
@@ -860,7 +860,7 @@ func getRecoverOperationWithSigner(signer helper.Signer, recoveryKey, updateKey 
 	}, nextRecoveryKey, nil
 }
 
-func getRecoverRequest(signer helper.Signer, delta *model.DeltaModel, signedDataModel *model.RecoverSignedDataModel) (*model.RecoverRequest, error) {
+func getRecoverRequest(signer client.Signer, delta *model.DeltaModel, signedDataModel *model.RecoverSignedDataModel) (*model.RecoverRequest, error) {
 	deltaHash, err := docutil.CalculateModelMultihash(delta, sha2_256)
 	if err != nil {
 		return nil, err
@@ -881,7 +881,7 @@ func getRecoverRequest(signer helper.Signer, delta *model.DeltaModel, signedData
 	}, nil
 }
 
-func getDefaultRecoverRequest(signer helper.Signer, recoveryKey, updateKey *ecdsa.PrivateKey) (*model.RecoverRequest, *ecdsa.PrivateKey, error) {
+func getDefaultRecoverRequest(signer client.Signer, recoveryKey, updateKey *ecdsa.PrivateKey) (*model.RecoverRequest, *ecdsa.PrivateKey, error) {
 	updateCommitment, err := getCommitment(updateKey)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/versions/0_1/operationparser/commitment_test.go
+++ b/pkg/versions/0_1/operationparser/commitment_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 )
 
 func TestParser_GetCommitment(t *testing.T) {
@@ -182,7 +182,7 @@ func generateRecoverRequest(recoveryKey *ecdsa.PrivateKey, commitment string, p 
 		return nil, err
 	}
 
-	info := &helper.RecoverRequestInfo{
+	info := &client.RecoverRequestInfo{
 		DidSuffix:          "recover-suffix",
 		OpaqueDocument:     `{"test":"value"}`,
 		RecoveryCommitment: commitment,
@@ -192,18 +192,18 @@ func generateRecoverRequest(recoveryKey *ecdsa.PrivateKey, commitment string, p 
 		Signer:             ecsigner.New(recoveryKey, "ES256", ""),
 	}
 
-	return helper.NewRecoverRequest(info)
+	return client.NewRecoverRequest(info)
 }
 
 func generateCreateRequest(recoveryCommitment, updateCommitment string, p protocol.Protocol) ([]byte, error) {
-	info := &helper.CreateRequestInfo{
+	info := &client.CreateRequestInfo{
 		OpaqueDocument:     `{"test":"value"}`,
 		RecoveryCommitment: recoveryCommitment,
 		UpdateCommitment:   updateCommitment,
 		MultihashCode:      p.HashAlgorithmInMultiHashCode,
 	}
 
-	return helper.NewCreateRequest(info)
+	return client.NewCreateRequest(info)
 }
 
 func generateDeactivateRequest(recoveryKey *ecdsa.PrivateKey) ([]byte, error) {
@@ -211,13 +211,13 @@ func generateDeactivateRequest(recoveryKey *ecdsa.PrivateKey) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	info := &helper.DeactivateRequestInfo{
+	info := &client.DeactivateRequestInfo{
 		DidSuffix:   "deactivate-suffix",
 		Signer:      ecsigner.New(recoveryKey, "ES256", ""),
 		RecoveryKey: jwk,
 	}
 
-	return helper.NewDeactivateRequest(info)
+	return client.NewDeactivateRequest(info)
 }
 
 func generateUpdateRequest(updateKey *ecdsa.PrivateKey, commitment string, p protocol.Protocol) ([]byte, error) {
@@ -231,7 +231,7 @@ func generateUpdateRequest(updateKey *ecdsa.PrivateKey, commitment string, p pro
 		return nil, err
 	}
 
-	info := &helper.UpdateRequestInfo{
+	info := &client.UpdateRequestInfo{
 		DidSuffix:        "update-suffix",
 		Signer:           ecsigner.New(updateKey, "ES256", "key-1"),
 		UpdateCommitment: commitment,
@@ -240,7 +240,7 @@ func generateUpdateRequest(updateKey *ecdsa.PrivateKey, commitment string, p pro
 		MultihashCode:    p.HashAlgorithmInMultiHashCode,
 	}
 
-	return helper.NewUpdateRequest(info)
+	return client.NewUpdateRequest(info)
 }
 
 func generateKeyAndCommitment(p protocol.Protocol) (*ecdsa.PrivateKey, string, error) {

--- a/pkg/versions/0_1/txnprovider/handler_test.go
+++ b/pkg/versions/0_1/txnprovider/handler_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/operationparser"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprovider/models"
@@ -318,14 +318,14 @@ func generateCreateOperation(num int) ([]byte, error) {
 	}
 
 	doc := fmt.Sprintf(`{"test":%d}`, num)
-	info := &helper.CreateRequestInfo{
+	info := &client.CreateRequestInfo{
 		OpaqueDocument:     doc,
 		RecoveryCommitment: c,
 		UpdateCommitment:   c,
 		MultihashCode:      sha2_256,
 	}
 
-	return helper.NewCreateRequest(info)
+	return client.NewCreateRequest(info)
 }
 
 func generateRecoverOperation(num int) ([]byte, error) {
@@ -344,7 +344,7 @@ func generateRecoverOperation(num int) ([]byte, error) {
 		return nil, err
 	}
 
-	info := &helper.RecoverRequestInfo{
+	info := &client.RecoverRequestInfo{
 		DidSuffix:          fmt.Sprintf("recover-%d", num),
 		OpaqueDocument:     `{"test":"value"}`,
 		RecoveryCommitment: c,
@@ -354,7 +354,7 @@ func generateRecoverOperation(num int) ([]byte, error) {
 		Signer:             ecsigner.New(privKey, "ES256", ""),
 	}
 
-	return helper.NewRecoverRequest(info)
+	return client.NewRecoverRequest(info)
 }
 
 func generateDeactivateOperation(num int) ([]byte, error) {
@@ -363,13 +363,13 @@ func generateDeactivateOperation(num int) ([]byte, error) {
 		return nil, err
 	}
 
-	info := &helper.DeactivateRequestInfo{
+	info := &client.DeactivateRequestInfo{
 		DidSuffix:   fmt.Sprintf("deactivate-%d", num),
 		Signer:      ecsigner.New(privateKey, "ES256", ""),
 		RecoveryKey: testJWK,
 	}
 
-	return helper.NewDeactivateRequest(info)
+	return client.NewDeactivateRequest(info)
 }
 
 func generateUpdateOperation(num int) ([]byte, error) {
@@ -388,7 +388,7 @@ func generateUpdateOperation(num int) ([]byte, error) {
 		return nil, err
 	}
 
-	info := &helper.UpdateRequestInfo{
+	info := &client.UpdateRequestInfo{
 		DidSuffix:        fmt.Sprintf("update-%d", num),
 		Signer:           ecsigner.New(privateKey, "ES256", "key-1"),
 		UpdateCommitment: c,
@@ -397,7 +397,7 @@ func generateUpdateOperation(num int) ([]byte, error) {
 		MultihashCode:    sha2_256,
 	}
 
-	return helper.NewUpdateRequest(info)
+	return client.NewUpdateRequest(info)
 }
 
 func getTestPatch() (patch.Patch, error) {


### PR DESCRIPTION
Currently package restapi/helper  is used to assemble Sidetree request based on provided information. 

Included:
- rename helper to client
- move helper/client to versioned folder

Closes #443

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>