### PR TITLE
chore: Remove public keys processing from generic document transformer

### DIFF
--- a/pkg/dochandler/transformer/doctransformer/transformer.go
+++ b/pkg/dochandler/transformer/doctransformer/transformer.go
@@ -26,30 +26,5 @@ func (v *Transformer) TransformDocument(internal document.Document) (*document.R
 		MethodMetadata: document.MethodMetadata{},
 	}
 
-	processKeys(internal)
-
 	return resolutionResult, nil
-}
-
-// generic documents will most likely not contain keys.
-func processKeys(internal document.Document) {
-	var pubKeysKeys []document.PublicKey
-
-	for _, pk := range internal.PublicKeys() {
-		relativeID := "#" + pk.ID()
-
-		externalPK := make(document.PublicKey)
-		externalPK[document.IDProperty] = internal.ID() + relativeID
-		externalPK[document.TypeProperty] = pk.Type()
-		externalPK[document.ControllerProperty] = internal[document.IDProperty]
-		externalPK[document.PublicKeyJwkProperty] = pk.PublicKeyJwk()
-
-		pubKeysKeys = append(pubKeysKeys, externalPK)
-	}
-
-	if len(pubKeysKeys) > 0 {
-		internal[document.PublicKeyProperty] = pubKeysKeys
-	} else {
-		delete(internal, document.PublicKeyProperty)
-	}
 }

--- a/pkg/dochandler/transformer/doctransformer/transformer_test.go
+++ b/pkg/dochandler/transformer/doctransformer/transformer_test.go
@@ -34,7 +34,7 @@ func TestTransformDocument(t *testing.T) {
 	require.NoError(t, err)
 	result, err = transformer.TransformDocument(doc)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(result.Document.PublicKeys()))
+	require.Equal(t, doc, result.Document)
 }
 
 func getDefaultTransformer() *Transformer {
@@ -46,19 +46,6 @@ var validDoc = []byte(`{ "name": "John Smith" }`)
 const validDocWithOpsKeys = `
 {
   "id" : "doc:method:abc",
-  "publicKey": [
-    {
-      "id": "update-key",
-      "type": "JsonWebKey2020",
-      "purposes": ["verificationMethod"],
-      "publicKeyJwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    }
-  ],
   "other": [
     {
       "name": "name"


### PR DESCRIPTION
There is no need for generic document to have public keys in the document. The requirement for update key to be part of the document has been removed couple of months ago. This is leftover code - not used any more.

Closes #450

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>