### PR TITLE
chore: Remove-public-keys patch should use ids tag instead of publicKeys

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -56,11 +56,11 @@ const (
 	// PublicKeys captures "publicKeys" key.
 	PublicKeys Key = "publicKeys"
 
-	// ServiceEndpointsKey captures "services" key.
-	ServiceEndpointsKey Key = "services"
+	// ServicesKey captures "services" key.
+	ServicesKey Key = "services"
 
-	// ServiceEndpointIdsKey captures "ids" key.
-	ServiceEndpointIdsKey Key = "ids"
+	// IdsKey captures "ids" key.
+	IdsKey Key = "ids"
 
 	// ActionKey captures "action" key.
 	ActionKey Key = "action"
@@ -68,9 +68,9 @@ const (
 
 var actionConfig = map[Action]Key{
 	AddPublicKeys:          PublicKeys,
-	RemovePublicKeys:       PublicKeys,
-	AddServiceEndpoints:    ServiceEndpointsKey,
-	RemoveServiceEndpoints: ServiceEndpointIdsKey,
+	RemovePublicKeys:       IdsKey,
+	AddServiceEndpoints:    ServicesKey,
+	RemoveServiceEndpoints: IdsKey,
 	JSONPatch:              PatchesKey,
 	Replace:                DocumentKey,
 }
@@ -189,7 +189,7 @@ func NewRemovePublicKeysPatch(publicKeyIds string) (Patch, error) {
 
 	patch := make(Patch)
 	patch[ActionKey] = RemovePublicKeys
-	patch[PublicKeys] = getGenericArray(ids)
+	patch[IdsKey] = getGenericArray(ids)
 
 	return patch, nil
 }
@@ -203,7 +203,7 @@ func NewAddServiceEndpointsPatch(serviceEndpoints string) (Patch, error) {
 
 	patch := make(Patch)
 	patch[ActionKey] = AddServiceEndpoints
-	patch[ServiceEndpointsKey] = services
+	patch[ServicesKey] = services
 
 	return patch, nil
 }
@@ -221,7 +221,7 @@ func NewRemoveServiceEndpointsPatch(serviceEndpointIds string) (Patch, error) {
 
 	patch := make(Patch)
 	patch[ActionKey] = RemoveServiceEndpoints
-	patch[ServiceEndpointIdsKey] = getGenericArray(ids)
+	patch[IdsKey] = getGenericArray(ids)
 
 	return patch, nil
 }

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -235,13 +235,13 @@ func TestRemovePublicKeysPatch(t *testing.T) {
 		value, err := patch.GetValue()
 		require.NoError(t, err)
 		require.NotEmpty(t, value)
-		require.Equal(t, value, patch[PublicKeys])
+		require.Equal(t, value, patch[IdsKey])
 	})
 	t.Run("missing public key ids", func(t *testing.T) {
 		patch, err := FromBytes([]byte(`{"action": "remove-public-keys"}`))
 		require.Error(t, err)
 		require.Nil(t, patch)
-		require.Contains(t, err.Error(), "remove-public-keys patch is missing key: publicKeys")
+		require.Contains(t, err.Error(), "remove-public-keys patch is missing key: ids")
 	})
 	t.Run("success from new", func(t *testing.T) {
 		const ids = `["key1", "key2"]`
@@ -256,7 +256,7 @@ func TestRemovePublicKeysPatch(t *testing.T) {
 		value, err := p.GetValue()
 		require.NoError(t, err)
 		require.NotEmpty(t, value)
-		require.Equal(t, value, p[PublicKeys])
+		require.Equal(t, value, p[IdsKey])
 	})
 	t.Run("empty public key ids", func(t *testing.T) {
 		const ids = `[]`
@@ -287,7 +287,7 @@ func TestAddServiceEndpointsPatch(t *testing.T) {
 		value, err := patch.GetValue()
 		require.NoError(t, err)
 		require.NotEmpty(t, value)
-		require.Equal(t, value, patch[ServiceEndpointsKey])
+		require.Equal(t, value, patch[ServicesKey])
 	})
 	t.Run("missing service endpoints", func(t *testing.T) {
 		patch, err := FromBytes([]byte(`{"action": "add-services"}`))
@@ -307,7 +307,7 @@ func TestAddServiceEndpointsPatch(t *testing.T) {
 		value, err := p.GetValue()
 		require.NoError(t, err)
 		require.NotEmpty(t, value)
-		require.Equal(t, value, p[ServiceEndpointsKey])
+		require.Equal(t, value, p[ServicesKey])
 	})
 	t.Run("error - not json", func(t *testing.T) {
 		p, err := NewAddServiceEndpointsPatch("not-json")
@@ -330,7 +330,7 @@ func TestRemoveServiceEndpointsPatch(t *testing.T) {
 		value, err := p.GetValue()
 		require.NoError(t, err)
 		require.NotEmpty(t, value)
-		require.Equal(t, value, p[ServiceEndpointIdsKey])
+		require.Equal(t, value, p[IdsKey])
 	})
 	t.Run("missing public key ids", func(t *testing.T) {
 		patch, err := FromBytes([]byte(`{"action": "remove-services"}`))
@@ -351,7 +351,7 @@ func TestRemoveServiceEndpointsPatch(t *testing.T) {
 		value, err := p.GetValue()
 		require.NoError(t, err)
 		require.NotEmpty(t, value)
-		require.Equal(t, value, p[ServiceEndpointIdsKey])
+		require.Equal(t, value, p[IdsKey])
 	})
 	t.Run("empty service ids", func(t *testing.T) {
 		const ids = `[]`
@@ -450,7 +450,7 @@ const testAddPublicKeys = `[{
 
 const removePublicKeysPatch = `{
   "action": "remove-public-keys",
-  "publicKeys": ["key1", "key2"]
+  "ids": ["key1", "key2"]
 }`
 
 const addServiceEndpoints = `{

--- a/pkg/versions/0_1/operationparser/patchvalidator/addservices_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/addservices_test.go
@@ -20,7 +20,7 @@ func TestAddServiceEndpointsPatch(t *testing.T) {
 		p, err := patch.FromBytes([]byte(addServiceEndpoints))
 		require.NoError(t, err)
 
-		delete(p, patch.ServiceEndpointsKey)
+		delete(p, patch.ServicesKey)
 		err = NewAddServicesValidator().Validate(p)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "add-services patch is missing key: services")

--- a/pkg/versions/0_1/operationparser/patchvalidator/removekeys_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/removekeys_test.go
@@ -22,12 +22,12 @@ func TestRemovePublicKeysPatch(t *testing.T) {
 
 		err := NewRemovePublicKeysValidator().Validate(p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "remove-public-keys patch is missing key: publicKeys")
+		require.Contains(t, err.Error(), "remove-public-keys patch is missing key: ids")
 	})
 	t.Run("error - invalid add public keys value", func(t *testing.T) {
 		p := make(patch.Patch)
 		p[patch.ActionKey] = patch.RemovePublicKeys
-		p[patch.PublicKeys] = "whatever"
+		p[patch.IdsKey] = "whatever"
 
 		err := NewRemovePublicKeysValidator().Validate(p)
 		require.Error(t, err)
@@ -46,5 +46,5 @@ func TestRemovePublicKeysPatch(t *testing.T) {
 
 const removePublicKeysPatch = `{
   "action": "remove-public-keys",
-  "publicKeys": ["key1", "key2"]
+  "ids": ["key1", "key2"]
 }`

--- a/pkg/versions/0_1/operationparser/patchvalidator/removeservices_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/removeservices_test.go
@@ -27,7 +27,7 @@ func TestRemoveServiceEndpointsPatch(t *testing.T) {
 	t.Run("error - invalid service ids", func(t *testing.T) {
 		p := make(patch.Patch)
 		p[patch.ActionKey] = patch.RemoveServiceEndpoints
-		p[patch.ServiceEndpointIdsKey] = "invalid"
+		p[patch.IdsKey] = "invalid"
 
 		err := NewRemoveServicesValidator().Validate(p)
 		require.Error(t, err)


### PR DESCRIPTION
Spec has been changed for remove-public-keys patch to use ids tag instead of publicKeys.

Closes #451

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>