### PR TITLE
chore: Rename HashAlgorithmInMultiHashCode to MultihashAlgorithm

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -27,8 +27,8 @@ type Protocol struct {
 	// GenesisTime is inclusive starting logical blockchain time that this protocol applies to.
 	// (e.g. block number in a blockchain)
 	GenesisTime uint64 `json:"genesisTime"`
-	// HashAlgorithmInMultiHashCode is hash algorithm in multihash code.
-	HashAlgorithmInMultiHashCode uint `json:"multiHashAlgorithm"`
+	// MultihashAlgorithm is multihash algorithm code.
+	MultihashAlgorithm uint `json:"multihashAlgorithm"`
 	// HashAlgorithm is hash algorithm
 	HashAlgorithm uint `json:"hashAlgorithm"`
 	// MaxOperationCount defines maximum number of operations per batch.

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -42,18 +42,18 @@ type MockProtocolClient struct {
 func NewMockProtocolClient() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:                  0,
-		HashAlgorithmInMultiHashCode: sha2_256,
-		HashAlgorithm:                5, // crypto code for sha256 hash function
-		MaxOperationCount:            2,
-		MaxOperationSize:             MaxOperationByteSize,
-		CompressionAlgorithm:         "GZIP",
-		MaxChunkFileSize:             MaxBatchFileSize,
-		MaxMapFileSize:               MaxBatchFileSize,
-		MaxAnchorFileSize:            MaxBatchFileSize,
-		SignatureAlgorithms:          []string{"EdDSA", "ES256"},
-		KeyAlgorithms:                []string{"Ed25519", "P-256"},
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		GenesisTime:          0,
+		MultihashAlgorithm:   sha2_256,
+		HashAlgorithm:        5, // crypto code for sha256 hash function
+		MaxOperationCount:    2,
+		MaxOperationSize:     MaxOperationByteSize,
+		CompressionAlgorithm: "GZIP",
+		MaxChunkFileSize:     MaxBatchFileSize,
+		MaxMapFileSize:       MaxBatchFileSize,
+		MaxAnchorFileSize:    MaxBatchFileSize,
+		SignatureAlgorithms:  []string{"EdDSA", "ES256"},
+		KeyAlgorithms:        []string{"Ed25519", "P-256"},
+		Patches:              []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	latestVersion := GetProtocolVersion(latest)

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -114,12 +114,12 @@ func (s *OperationProcessor) createOperationHashMap(ops []*batch.AnchoredOperati
 			continue
 		}
 
-		key := fmt.Sprintf(keyFormat, uintToStr(p.HashAlgorithmInMultiHashCode), uintToStr(p.HashAlgorithm))
+		key := fmt.Sprintf(keyFormat, uintToStr(p.MultihashAlgorithm), uintToStr(p.HashAlgorithm))
 
 		if _, ok := previousVersions[key]; !ok {
 			previousVersions[key] = &commitmentParams{
 				HashCode:      p.HashAlgorithm,
-				MultihashCode: p.HashAlgorithmInMultiHashCode,
+				MultihashCode: p.MultihashAlgorithm,
 			}
 		}
 		for _, val := range previousVersions {
@@ -192,7 +192,7 @@ func (s *OperationProcessor) applyOperations(ops []*batch.AnchoredOperation, rm 
 
 	opMap := s.createOperationHashMap(ops, &commitmentParams{
 		HashCode:      p.Protocol().HashAlgorithm,
-		MultihashCode: p.Protocol().HashAlgorithmInMultiHashCode,
+		MultihashCode: p.Protocol().MultihashAlgorithm,
 	})
 
 	// holds applied commitments

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -540,7 +540,7 @@ func TestGetOperationCommitment(t *testing.T) {
 		require.NotNil(t, reveal)
 		require.NotEmpty(t, p)
 
-		value, err := commitment.Calculate(reveal, p.HashAlgorithmInMultiHashCode, crypto.Hash(p.HashAlgorithm))
+		value, err := commitment.Calculate(reveal, p.MultihashAlgorithm, crypto.Hash(p.HashAlgorithm))
 		require.NoError(t, err)
 
 		c, err := getCommitment(recoveryKey, getProtocol(1))
@@ -556,7 +556,7 @@ func TestGetOperationCommitment(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, reveal)
 
-		value, err := commitment.Calculate(reveal, p.HashAlgorithmInMultiHashCode, crypto.Hash(p.HashAlgorithm))
+		value, err := commitment.Calculate(reveal, p.MultihashAlgorithm, crypto.Hash(p.HashAlgorithm))
 		require.NoError(t, err)
 
 		c, err := getCommitment(updateKey, getProtocol(1))
@@ -572,7 +572,7 @@ func TestGetOperationCommitment(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, reveal)
 
-		value, err := commitment.Calculate(reveal, p.HashAlgorithmInMultiHashCode, crypto.Hash(p.HashAlgorithm))
+		value, err := commitment.Calculate(reveal, p.MultihashAlgorithm, crypto.Hash(p.HashAlgorithm))
 		require.NoError(t, err)
 
 		c, err := getCommitment(recoveryKey, getProtocol(1))
@@ -869,7 +869,7 @@ func getUpdateOperationWithSigner(s client.Signer, privateKey *ecdsa.PrivateKey,
 		Patches:          []patch.Patch{jsonPatch},
 	}
 
-	deltaHash, err := docutil.CalculateModelMultihash(delta, getProtocol(blockNumber).HashAlgorithmInMultiHashCode)
+	deltaHash, err := docutil.CalculateModelMultihash(delta, getProtocol(blockNumber).MultihashAlgorithm)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -912,7 +912,7 @@ func generateKeyAndCommitment(p protocol.Protocol) (*ecdsa.PrivateKey, string, e
 		return nil, "", err
 	}
 
-	c, err := commitment.Calculate(pubKey, p.HashAlgorithmInMultiHashCode, crypto.Hash(p.HashAlgorithm))
+	c, err := commitment.Calculate(pubKey, p.MultihashAlgorithm, crypto.Hash(p.HashAlgorithm))
 	if err != nil {
 		return nil, "", err
 	}
@@ -996,7 +996,7 @@ func getRecoverOperationWithSigner(signer client.Signer, recoveryKey, updateKey 
 }
 
 func getRecoverRequest(signer client.Signer, deltaModel *model.DeltaModel, signedDataModel *model.RecoverSignedDataModel, blockNum uint64) (*model.RecoverRequest, error) {
-	deltaHash, err := docutil.CalculateModelMultihash(deltaModel, getProtocol(blockNum).HashAlgorithmInMultiHashCode)
+	deltaHash, err := docutil.CalculateModelMultihash(deltaModel, getProtocol(blockNum).MultihashAlgorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -1031,7 +1031,7 @@ func getDefaultRecoverRequest(signer client.Signer, recoveryKey, updateKey *ecds
 		return nil, nil, err
 	}
 
-	deltaHash, err := docutil.CalculateModelMultihash(delta, p.HashAlgorithmInMultiHashCode)
+	deltaHash, err := docutil.CalculateModelMultihash(delta, p.MultihashAlgorithm)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1197,7 +1197,7 @@ func getCommitment(key *ecdsa.PrivateKey, p protocol.Protocol) (string, error) {
 		return "", err
 	}
 
-	return commitment.Calculate(pubKey, p.HashAlgorithmInMultiHashCode, crypto.Hash(p.HashAlgorithm))
+	return commitment.Calculate(pubKey, p.MultihashAlgorithm, crypto.Hash(p.HashAlgorithm))
 }
 
 func getSuffixData(privateKey *ecdsa.PrivateKey, delta *model.DeltaModel, p protocol.Protocol) (*model.SuffixDataModel, error) {
@@ -1206,7 +1206,7 @@ func getSuffixData(privateKey *ecdsa.PrivateKey, delta *model.DeltaModel, p prot
 		return nil, err
 	}
 
-	deltaHash, err := docutil.CalculateModelMultihash(delta, p.HashAlgorithmInMultiHashCode)
+	deltaHash, err := docutil.CalculateModelMultihash(delta, p.MultihashAlgorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -1264,18 +1264,18 @@ func newMockProtocolClient() *mocks.MockProtocolClient {
 
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:                  100,
-		HashAlgorithmInMultiHashCode: sha2_256,
-		HashAlgorithm:                7, // crypto code for sha512 hash function
-		MaxOperationCount:            2,
-		MaxOperationSize:             mocks.MaxOperationByteSize,
-		CompressionAlgorithm:         "GZIP",
-		MaxChunkFileSize:             mocks.MaxBatchFileSize,
-		MaxMapFileSize:               mocks.MaxBatchFileSize,
-		MaxAnchorFileSize:            mocks.MaxBatchFileSize,
-		SignatureAlgorithms:          []string{"EdDSA", "ES256"},
-		KeyAlgorithms:                []string{"Ed25519", "P-256"},
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		GenesisTime:          100,
+		MultihashAlgorithm:   sha2_256,
+		HashAlgorithm:        7, // crypto code for sha512 hash function
+		MaxOperationCount:    2,
+		MaxOperationSize:     mocks.MaxOperationByteSize,
+		CompressionAlgorithm: "GZIP",
+		MaxChunkFileSize:     mocks.MaxBatchFileSize,
+		MaxMapFileSize:       mocks.MaxBatchFileSize,
+		MaxAnchorFileSize:    mocks.MaxBatchFileSize,
+		SignatureAlgorithms:  []string{"EdDSA", "ES256"},
+		KeyAlgorithms:        []string{"Ed25519", "P-256"},
+		Patches:              []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	latestVersion := mocks.GetProtocolVersion(latest)

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -44,18 +44,18 @@ const (
 
 var (
 	p = protocol.Protocol{
-		GenesisTime:                  0,
-		HashAlgorithmInMultiHashCode: sha2_256,
-		HashAlgorithm:                5,
-		MaxOperationCount:            2,
-		MaxOperationSize:             1024,
-		CompressionAlgorithm:         "GZIP",
-		MaxChunkFileSize:             1024,
-		MaxMapFileSize:               1024,
-		MaxAnchorFileSize:            1024,
-		SignatureAlgorithms:          []string{"EdDSA", "ES256"},
-		KeyAlgorithms:                []string{"Ed25519", "P-256"},
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		GenesisTime:          0,
+		MultihashAlgorithm:   sha2_256,
+		HashAlgorithm:        5,
+		MaxOperationCount:    2,
+		MaxOperationSize:     1024,
+		CompressionAlgorithm: "GZIP",
+		MaxChunkFileSize:     1024,
+		MaxMapFileSize:       1024,
+		MaxAnchorFileSize:    1024,
+		SignatureAlgorithms:  []string{"EdDSA", "ES256"},
+		KeyAlgorithms:        []string{"Ed25519", "P-256"},
+		Patches:              []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser = operationparser.New(p)

--- a/pkg/versions/0_1/operationparser/commitment_test.go
+++ b/pkg/versions/0_1/operationparser/commitment_test.go
@@ -188,7 +188,7 @@ func generateRecoverRequest(recoveryKey *ecdsa.PrivateKey, commitment string, p 
 		RecoveryCommitment: commitment,
 		UpdateCommitment:   commitment, // not evaluated in operation getting commitment/reveal value
 		RecoveryKey:        jwk,
-		MultihashCode:      p.HashAlgorithmInMultiHashCode,
+		MultihashCode:      p.MultihashAlgorithm,
 		Signer:             ecsigner.New(recoveryKey, "ES256", ""),
 	}
 
@@ -200,7 +200,7 @@ func generateCreateRequest(recoveryCommitment, updateCommitment string, p protoc
 		OpaqueDocument:     `{"test":"value"}`,
 		RecoveryCommitment: recoveryCommitment,
 		UpdateCommitment:   updateCommitment,
-		MultihashCode:      p.HashAlgorithmInMultiHashCode,
+		MultihashCode:      p.MultihashAlgorithm,
 	}
 
 	return client.NewCreateRequest(info)
@@ -237,7 +237,7 @@ func generateUpdateRequest(updateKey *ecdsa.PrivateKey, commitment string, p pro
 		UpdateCommitment: commitment,
 		UpdateKey:        jwk,
 		Patches:          []patch.Patch{testPatch},
-		MultihashCode:    p.HashAlgorithmInMultiHashCode,
+		MultihashCode:    p.MultihashAlgorithm,
 	}
 
 	return client.NewUpdateRequest(info)
@@ -254,7 +254,7 @@ func generateKeyAndCommitment(p protocol.Protocol) (*ecdsa.PrivateKey, string, e
 		return nil, "", err
 	}
 
-	c, err := commitment.Calculate(pubKey, p.HashAlgorithmInMultiHashCode, crypto.Hash(p.HashAlgorithm))
+	c, err := commitment.Calculate(pubKey, p.MultihashAlgorithm, crypto.Hash(p.HashAlgorithm))
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/versions/0_1/operationparser/create.go
+++ b/pkg/versions/0_1/operationparser/create.go
@@ -44,7 +44,7 @@ func (p *Parser) ParseCreateOperation(request []byte, anchor bool) (*model.Opera
 		}
 	}
 
-	uniqueSuffix, err := docutil.CalculateModelMultihash(schema.SuffixData, p.HashAlgorithmInMultiHashCode)
+	uniqueSuffix, err := docutil.CalculateModelMultihash(schema.SuffixData, p.MultihashAlgorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +94,8 @@ func (p *Parser) ValidateDelta(delta *model.DeltaModel) error {
 		}
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(delta.UpdateCommitment, uint64(p.HashAlgorithmInMultiHashCode)) {
-		return fmt.Errorf("next update commitment hash is not computed with the required supported hash algorithm: %d", p.HashAlgorithmInMultiHashCode)
+	if !docutil.IsComputedUsingHashAlgorithm(delta.UpdateCommitment, uint64(p.MultihashAlgorithm)) {
+		return fmt.Errorf("next update commitment hash is not computed with the required supported hash algorithm: %d", p.MultihashAlgorithm)
 	}
 
 	return nil
@@ -117,12 +117,12 @@ func (p *Parser) ValidateSuffixData(suffixData *model.SuffixDataModel) error {
 		return errors.New("missing suffix data")
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(suffixData.RecoveryCommitment, uint64(p.HashAlgorithmInMultiHashCode)) {
-		return fmt.Errorf("next recovery commitment hash is not computed with the required supported hash algorithm: %d", p.HashAlgorithmInMultiHashCode)
+	if !docutil.IsComputedUsingHashAlgorithm(suffixData.RecoveryCommitment, uint64(p.MultihashAlgorithm)) {
+		return fmt.Errorf("next recovery commitment hash is not computed with the required supported hash algorithm: %d", p.MultihashAlgorithm)
 	}
 
-	if !docutil.IsComputedUsingHashAlgorithm(suffixData.DeltaHash, uint64(p.HashAlgorithmInMultiHashCode)) {
-		return fmt.Errorf("patch data hash is not computed with the required supported hash algorithm: %d", p.HashAlgorithmInMultiHashCode)
+	if !docutil.IsComputedUsingHashAlgorithm(suffixData.DeltaHash, uint64(p.MultihashAlgorithm)) {
+		return fmt.Errorf("patch data hash is not computed with the required supported hash algorithm: %d", p.MultihashAlgorithm)
 	}
 
 	return nil

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -26,8 +26,8 @@ const invalid = "invalid"
 
 func TestParseCreateOperation(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		Patches:                      []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MultihashAlgorithm: sha2_256,
+		Patches:            []string{"replace", "add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)
@@ -142,7 +142,7 @@ func TestParseCreateOperation(t *testing.T) {
 
 func TestValidateSuffixData(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
+		MultihashAlgorithm: sha2_256,
 	}
 
 	parser := New(p)
@@ -169,8 +169,8 @@ func TestValidateSuffixData(t *testing.T) {
 
 func TestValidateDelta(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MultihashAlgorithm: sha2_256,
+		Patches:            []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)

--- a/pkg/versions/0_1/operationparser/deactivate_test.go
+++ b/pkg/versions/0_1/operationparser/deactivate_test.go
@@ -23,9 +23,9 @@ const sha2_256 = 18
 
 func TestParseDeactivateOperation(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		SignatureAlgorithms:          []string{"alg"},
-		KeyAlgorithms:                []string{"crv"},
+		MultihashAlgorithm:  sha2_256,
+		SignatureAlgorithms: []string{"alg"},
+		KeyAlgorithms:       []string{"crv"},
 	}
 
 	parser := New(p)
@@ -105,9 +105,9 @@ func TestParseDeactivateOperation(t *testing.T) {
 	})
 	t.Run("error - key algorithm not supported", func(t *testing.T) {
 		p := protocol.Protocol{
-			HashAlgorithmInMultiHashCode: sha2_256,
-			SignatureAlgorithms:          []string{"alg"},
-			KeyAlgorithms:                []string{"other"},
+			MultihashAlgorithm:  sha2_256,
+			SignatureAlgorithms: []string{"alg"},
+			KeyAlgorithms:       []string{"other"},
 		}
 		parser := New(p)
 

--- a/pkg/versions/0_1/operationparser/operation_test.go
+++ b/pkg/versions/0_1/operationparser/operation_test.go
@@ -19,10 +19,10 @@ const namespace = "did:sidetree"
 
 func TestGetOperation(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		SignatureAlgorithms:          []string{"alg"},
-		KeyAlgorithms:                []string{"crv"},
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MultihashAlgorithm:  sha2_256,
+		SignatureAlgorithms: []string{"alg"},
+		KeyAlgorithms:       []string{"crv"},
+		Patches:             []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -86,7 +86,7 @@ func (p *Parser) validateSignedDataForRecovery(signedData *model.RecoverSignedDa
 		return fmt.Errorf("signed data for recovery: %s", err.Error())
 	}
 
-	code := uint64(p.HashAlgorithmInMultiHashCode)
+	code := uint64(p.MultihashAlgorithm)
 	if !docutil.IsComputedUsingHashAlgorithm(signedData.RecoveryCommitment, code) {
 		return fmt.Errorf("next recovery commitment hash is not computed with the required hash algorithm: %d", code)
 	}

--- a/pkg/versions/0_1/operationparser/recover_test.go
+++ b/pkg/versions/0_1/operationparser/recover_test.go
@@ -28,10 +28,10 @@ const (
 
 func TestParseRecoverOperation(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		SignatureAlgorithms:          []string{"alg"},
-		KeyAlgorithms:                []string{"crv"},
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MultihashAlgorithm:  sha2_256,
+		SignatureAlgorithms: []string{"alg"},
+		KeyAlgorithms:       []string{"crv"},
+		Patches:             []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)
@@ -143,8 +143,8 @@ func TestParseRecoverOperation(t *testing.T) {
 
 func TestValidateSignedDataForRecovery(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		KeyAlgorithms:                []string{"crv"},
+		MultihashAlgorithm: sha2_256,
+		KeyAlgorithms:      []string{"crv"},
 	}
 
 	parser := New(p)
@@ -177,8 +177,8 @@ func TestParseSignedData(t *testing.T) {
 	mockSigner := NewMockSigner()
 
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		SignatureAlgorithms:          []string{"alg"},
+		MultihashAlgorithm:  sha2_256,
+		SignatureAlgorithms: []string{"alg"},
 	}
 
 	parser := New(p)

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -95,7 +95,7 @@ func (p *Parser) validateSignedDataForUpdate(signedData *model.UpdateSignedDataM
 		return fmt.Errorf("signed data for update: %s", err.Error())
 	}
 
-	code := uint64(p.HashAlgorithmInMultiHashCode)
+	code := uint64(p.MultihashAlgorithm)
 	if !docutil.IsComputedUsingHashAlgorithm(signedData.DeltaHash, code) {
 		return fmt.Errorf("delta hash is not computed with the required hash algorithm: %d", code)
 	}

--- a/pkg/versions/0_1/operationparser/update_test.go
+++ b/pkg/versions/0_1/operationparser/update_test.go
@@ -23,10 +23,10 @@ import (
 
 func TestParseUpdateOperation(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		SignatureAlgorithms:          []string{"alg"},
-		KeyAlgorithms:                []string{"crv"},
-		Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MultihashAlgorithm:  sha2_256,
+		SignatureAlgorithms: []string{"alg"},
+		KeyAlgorithms:       []string{"crv"},
+		Patches:             []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)
@@ -110,9 +110,9 @@ func TestParseUpdateOperation(t *testing.T) {
 
 func TestParseSignedDataForUpdate(t *testing.T) {
 	p := protocol.Protocol{
-		HashAlgorithmInMultiHashCode: sha2_256,
-		SignatureAlgorithms:          []string{"alg"},
-		KeyAlgorithms:                []string{"crv"},
+		MultihashAlgorithm:  sha2_256,
+		SignatureAlgorithms: []string{"alg"},
+		KeyAlgorithms:       []string{"crv"},
 	}
 
 	parser := New(p)
@@ -161,8 +161,8 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 func TestValidateUpdateDelta(t *testing.T) {
 	t.Run("invalid next update commitment hash", func(t *testing.T) {
 		p := protocol.Protocol{
-			HashAlgorithmInMultiHashCode: sha2_256,
-			Patches:                      []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+			MultihashAlgorithm: sha2_256,
+			Patches:            []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 		}
 
 		parser := New(p)

--- a/pkg/versions/0_1/txnprovider/provider.go
+++ b/pkg/versions/0_1/txnprovider/provider.go
@@ -261,7 +261,7 @@ func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *tx
 
 	var createOps []*model.Operation
 	for _, op := range af.Operations.Create {
-		suffix, err := docutil.CalculateModelMultihash(op.SuffixData, h.HashAlgorithmInMultiHashCode)
+		suffix, err := docutil.CalculateModelMultihash(op.SuffixData, h.MultihashAlgorithm)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/versions/0_1/txnprovider/provider_test.go
+++ b/pkg/versions/0_1/txnprovider/provider_test.go
@@ -132,7 +132,7 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		require.NotEmpty(t, anchorString)
 
 		invalid := mocks.NewMockProtocolClient().Protocol
-		invalid.HashAlgorithmInMultiHashCode = 55
+		invalid.MultihashAlgorithm = 55
 
 		provider := NewOperationProvider(invalid, operationparser.New(invalid), cas, cp)
 


### PR DESCRIPTION
Rename:
- rename tag multiHashAlgorithm to multihashAlgorithm
- rename corresponding struct field HashAlgorithmInMultiHashCode

Closes #449

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>