### PR TITLE
chore: rename api/batch to api/operation

### DIFF
--- a/pkg/api/operation/models.go
+++ b/pkg/api/operation/models.go
@@ -4,30 +4,29 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package batch
+package operation
 
-// Operation defines minimum information.
-// TODO: See if you can merge OperationInfo and Operation.
+// Operation holds minimum information required for parsing/validating client request.
 type Operation struct {
 
 	// Type defines operation type.
-	Type OperationType `json:"type"`
+	Type Type
 
 	// UniqueSuffix defines document unique suffix.
-	UniqueSuffix string `json:"uniqueSuffix"`
+	UniqueSuffix string
 
 	// ID defines ID
-	ID string `json:"id"`
+	ID string
 
 	// OperationBuffer is the original operation request
-	OperationBuffer []byte `json:"operationBuffer"`
+	OperationBuffer []byte
 }
 
 // AnchoredOperation defines an anchored operation (stored in document operation store).
 type AnchoredOperation struct {
 
 	// Type defines operation type.
-	Type OperationType `json:"type"`
+	Type Type `json:"type"`
 
 	// UniqueSuffix defines document unique suffix.
 	UniqueSuffix string `json:"uniqueSuffix"`
@@ -45,33 +44,33 @@ type AnchoredOperation struct {
 	ProtocolGenesisTime uint64 `json:"protocolGenesisTime"`
 }
 
-// OperationType defines valid values for operation type.
-type OperationType string
+// Type defines valid values for operation type.
+type Type string
 
 const (
 
-	// OperationTypeCreate captures "create" operation type.
-	OperationTypeCreate OperationType = "create"
+	// TypeCreate captures "create" operation type.
+	TypeCreate Type = "create"
 
-	// OperationTypeUpdate captures "update" operation type.
-	OperationTypeUpdate OperationType = "update"
+	// TypeUpdate captures "update" operation type.
+	TypeUpdate Type = "update"
 
-	// OperationTypeDeactivate captures "deactivate" operation type.
-	OperationTypeDeactivate OperationType = "deactivate"
+	// TypeDeactivate captures "deactivate" operation type.
+	TypeDeactivate Type = "deactivate"
 
-	// OperationTypeRecover captures "recover" operation type.
-	OperationTypeRecover OperationType = "recover"
+	// TypeRecover captures "recover" operation type.
+	TypeRecover Type = "recover"
 )
 
-// OperationInfo contains the unique suffix and namespace as well as the operation buffer.
-type OperationInfo struct {
-	Data         []byte
-	UniqueSuffix string
-	Namespace    string
+// QueuedOperation stores minimum required operation info for operations queue.
+type QueuedOperation struct {
+	OperationBuffer []byte
+	UniqueSuffix    string
+	Namespace       string
 }
 
-// OperationInfoAtTime contains OperationInfo at a given protocol genesis time.
-type OperationInfoAtTime struct {
-	OperationInfo
+// QueuedOperationAtTime contains queued operation info with protocol genesis time.
+type QueuedOperationAtTime struct {
+	QueuedOperation
 	ProtocolGenesisTime uint64
 }

--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package protocol
 
 import (
-	batchapi "github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -58,7 +58,7 @@ type TxnProcessor interface {
 
 // OperationParser defines the functions for parsing operations.
 type OperationParser interface {
-	Parse(namespace string, operation []byte) (*batchapi.Operation, error)
+	Parse(namespace string, operation []byte) (*operation.Operation, error)
 	ParseDID(namespace, shortOrLongFormDID string) (string, []byte, error)
 	GetRevealValue(operation []byte) (*jws.JWK, error)
 	GetCommitment(operation []byte) (string, error)
@@ -76,7 +76,7 @@ type ResolutionModel struct {
 
 // OperationApplier applies the given operation to the document.
 type OperationApplier interface {
-	Apply(op *batchapi.AnchoredOperation, rm *ResolutionModel) (*ResolutionModel, error)
+	Apply(op *operation.AnchoredOperation, rm *ResolutionModel) (*ResolutionModel, error)
 }
 
 // DocumentComposer applies patches to the given document.
@@ -87,12 +87,12 @@ type DocumentComposer interface {
 // OperationHandler defines an interface for creating chunks, map and anchor files.
 type OperationHandler interface {
 	// GetTxnOperations operations will create relevant files, store them in CAS and return anchor string.
-	PrepareTxnFiles(ops []*batchapi.OperationInfo) (string, error)
+	PrepareTxnFiles(ops []*operation.QueuedOperation) (string, error)
 }
 
 // OperationProvider retrieves the anchored operations for  the given sidetree transaction.
 type OperationProvider interface {
-	GetTxnOperations(sidetreeTxn *txn.SidetreeTxn) ([]*batchapi.AnchoredOperation, error)
+	GetTxnOperations(sidetreeTxn *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error)
 }
 
 // DocumentValidator is an interface for validating document operations.

--- a/pkg/batch/cutter/cutter_test.go
+++ b/pkg/batch/cutter/cutter_test.go
@@ -12,18 +12,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/opqueue"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
 var (
-	operation1 = &batch.OperationInfo{UniqueSuffix: "1", Data: []byte("operation1")}
-	operation2 = &batch.OperationInfo{UniqueSuffix: "2", Data: []byte("operation2")}
-	operation3 = &batch.OperationInfo{UniqueSuffix: "3", Data: []byte("operation3")}
-	operation4 = &batch.OperationInfo{UniqueSuffix: "4", Data: []byte("operation4")}
-	operation5 = &batch.OperationInfo{UniqueSuffix: "5", Data: []byte("operation5")}
-	operation6 = &batch.OperationInfo{UniqueSuffix: "6", Data: []byte("operation6")}
+	operation1 = &operation.QueuedOperation{UniqueSuffix: "1", OperationBuffer: []byte("operation1")}
+	operation2 = &operation.QueuedOperation{UniqueSuffix: "2", OperationBuffer: []byte("operation2")}
+	operation3 = &operation.QueuedOperation{UniqueSuffix: "3", OperationBuffer: []byte("operation3")}
+	operation4 = &operation.QueuedOperation{UniqueSuffix: "4", OperationBuffer: []byte("operation4")}
+	operation5 = &operation.QueuedOperation{UniqueSuffix: "5", OperationBuffer: []byte("operation5")}
+	operation6 = &operation.QueuedOperation{UniqueSuffix: "6", OperationBuffer: []byte("operation6")}
 )
 
 func TestBatchCutter(t *testing.T) {

--- a/pkg/batch/opqueue/memqueue.go
+++ b/pkg/batch/opqueue/memqueue.go
@@ -9,22 +9,22 @@ package opqueue
 import (
 	"sync"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 )
 
 // MemQueue implements an in-memory operation queue.
 type MemQueue struct {
-	items []*batch.OperationInfoAtTime
+	items []*operation.QueuedOperationAtTime
 	mutex sync.RWMutex
 }
 
 // Add adds the given data to the tail of the queue and returns the new length of the queue.
-func (q *MemQueue) Add(data *batch.OperationInfo, protocolGenesisTime uint64) (uint, error) {
+func (q *MemQueue) Add(data *operation.QueuedOperation, protocolGenesisTime uint64) (uint, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	q.items = append(q.items, &batch.OperationInfoAtTime{
-		OperationInfo:       *data,
+	q.items = append(q.items, &operation.QueuedOperationAtTime{
+		QueuedOperation:     *data,
 		ProtocolGenesisTime: protocolGenesisTime,
 	})
 
@@ -32,7 +32,7 @@ func (q *MemQueue) Add(data *batch.OperationInfo, protocolGenesisTime uint64) (u
 }
 
 // Peek returns (up to) the given number of operations from the head of the queue but does not remove them.
-func (q *MemQueue) Peek(num uint) ([]*batch.OperationInfoAtTime, error) {
+func (q *MemQueue) Peek(num uint) ([]*operation.QueuedOperationAtTime, error) {
 	q.mutex.RLock()
 	defer q.mutex.RUnlock()
 

--- a/pkg/batch/opqueue/memqueue_test.go
+++ b/pkg/batch/opqueue/memqueue_test.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 )
 
 var (
-	op1 = &batch.OperationInfo{Namespace: "ns", UniqueSuffix: "op1", Data: []byte("op1")}
-	op2 = &batch.OperationInfo{Namespace: "ns", UniqueSuffix: "op2", Data: []byte("op2")}
-	op3 = &batch.OperationInfo{Namespace: "ns", UniqueSuffix: "op3", Data: []byte("op3")}
+	op1 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op1", OperationBuffer: []byte("op1")}
+	op2 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op2", OperationBuffer: []byte("op2")}
+	op3 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op3", OperationBuffer: []byte("op3")}
 )
 
 func TestMemQueue(t *testing.T) {
@@ -46,14 +46,14 @@ func TestMemQueue(t *testing.T) {
 	ops, err = q.Peek(1)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
-	require.Equal(t, *op1, ops[0].OperationInfo)
+	require.Equal(t, *op1, ops[0].QueuedOperation)
 
 	ops, err = q.Peek(4)
 	require.NoError(t, err)
 	require.Len(t, ops, 3)
-	require.Equal(t, *op1, ops[0].OperationInfo)
-	require.Equal(t, *op2, ops[1].OperationInfo)
-	require.Equal(t, *op3, ops[2].OperationInfo)
+	require.Equal(t, *op1, ops[0].QueuedOperation)
+	require.Equal(t, *op2, ops[1].QueuedOperation)
+	require.Equal(t, *op3, ops[2].QueuedOperation)
 
 	n, l, err := q.Remove(1)
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestMemQueue(t *testing.T) {
 	ops, err = q.Peek(1)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
-	require.Equal(t, *op2, ops[0].OperationInfo)
+	require.Equal(t, *op2, ops[0].QueuedOperation)
 
 	n, l, err = q.Remove(5)
 	require.NoError(t, err)

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	batchapi "github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/cutter"
@@ -432,7 +432,7 @@ func getCreateOperation() *model.Operation {
 
 func getCreateOperationWithInitialState(suffixData *model.SuffixDataModel, delta *model.DeltaModel) (*model.Operation, error) {
 	request := &model.CreateRequest{
-		Operation:  batchapi.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		SuffixData: suffixData,
 		Delta:      delta,
 	}
@@ -448,7 +448,7 @@ func getCreateOperationWithInitialState(suffixData *model.SuffixDataModel, delta
 	}
 
 	return &model.Operation{
-		Type:            batchapi.OperationTypeCreate,
+		Type:            operation.TypeCreate,
 		UniqueSuffix:    uniqueSuffix,
 		ID:              namespace + docutil.NamespaceDelimiter + uniqueSuffix,
 		OperationBuffer: payload,
@@ -457,13 +457,13 @@ func getCreateOperationWithInitialState(suffixData *model.SuffixDataModel, delta
 	}, nil
 }
 
-func getAnchoredCreateOperation() *batchapi.AnchoredOperation {
+func getAnchoredCreateOperation() *operation.AnchoredOperation {
 	op := getCreateOperation()
 
 	return getAnchoredOperation(op)
 }
 
-func getAnchoredOperation(op *model.Operation) *batchapi.AnchoredOperation {
+func getAnchoredOperation(op *model.Operation) *operation.AnchoredOperation {
 	anchoredOp, err := model.GetAnchoredOperation(op)
 	if err != nil {
 		panic(err)
@@ -516,7 +516,7 @@ func getCreateRequestWithDoc(doc string) (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:  batchapi.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		Delta:      delta,
 		SuffixData: suffixData,
 	}, nil
@@ -586,9 +586,9 @@ func getUpdateDelta() *model.DeltaModel {
 	}
 }
 
-func getUpdateOperation() *batchapi.Operation {
+func getUpdateOperation() *operation.Operation {
 	request := &model.UpdateRequest{
-		Operation: batchapi.OperationTypeUpdate,
+		Operation: operation.TypeUpdate,
 		DidSuffix: getCreateOperation().UniqueSuffix,
 		Delta:     getUpdateDelta(),
 	}
@@ -598,9 +598,9 @@ func getUpdateOperation() *batchapi.Operation {
 		panic(err)
 	}
 
-	return &batchapi.Operation{
+	return &operation.Operation{
 		OperationBuffer: payload,
-		Type:            batchapi.OperationTypeUpdate,
+		Type:            operation.TypeUpdate,
 		UniqueSuffix:    request.DidSuffix,
 		ID:              namespace + docutil.NamespaceDelimiter + request.DidSuffix,
 	}

--- a/pkg/mocks/operationapplier.gen.go
+++ b/pkg/mocks/operationapplier.gen.go
@@ -4,15 +4,15 @@ package mocks
 import (
 	"sync"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 )
 
 type OperationApplier struct {
-	ApplyStub        func(*batch.AnchoredOperation, *protocol.ResolutionModel) (*protocol.ResolutionModel, error)
+	ApplyStub        func(*operation.AnchoredOperation, *protocol.ResolutionModel) (*protocol.ResolutionModel, error)
 	applyMutex       sync.RWMutex
 	applyArgsForCall []struct {
-		arg1 *batch.AnchoredOperation
+		arg1 *operation.AnchoredOperation
 		arg2 *protocol.ResolutionModel
 	}
 	applyReturns struct {
@@ -27,11 +27,11 @@ type OperationApplier struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OperationApplier) Apply(arg1 *batch.AnchoredOperation, arg2 *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
+func (fake *OperationApplier) Apply(arg1 *operation.AnchoredOperation, arg2 *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
 	fake.applyMutex.Lock()
 	ret, specificReturn := fake.applyReturnsOnCall[len(fake.applyArgsForCall)]
 	fake.applyArgsForCall = append(fake.applyArgsForCall, struct {
-		arg1 *batch.AnchoredOperation
+		arg1 *operation.AnchoredOperation
 		arg2 *protocol.ResolutionModel
 	}{arg1, arg2})
 	fake.recordInvocation("Apply", []interface{}{arg1, arg2})
@@ -52,13 +52,13 @@ func (fake *OperationApplier) ApplyCallCount() int {
 	return len(fake.applyArgsForCall)
 }
 
-func (fake *OperationApplier) ApplyCalls(stub func(*batch.AnchoredOperation, *protocol.ResolutionModel) (*protocol.ResolutionModel, error)) {
+func (fake *OperationApplier) ApplyCalls(stub func(*operation.AnchoredOperation, *protocol.ResolutionModel) (*protocol.ResolutionModel, error)) {
 	fake.applyMutex.Lock()
 	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = stub
 }
 
-func (fake *OperationApplier) ApplyArgsForCall(i int) (*batch.AnchoredOperation, *protocol.ResolutionModel) {
+func (fake *OperationApplier) ApplyArgsForCall(i int) (*operation.AnchoredOperation, *protocol.ResolutionModel) {
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
 	argsForCall := fake.applyArgsForCall[i]

--- a/pkg/mocks/operationparser.gen.go
+++ b/pkg/mocks/operationparser.gen.go
@@ -4,7 +4,7 @@ package mocks
 import (
 	"sync"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 )
@@ -36,18 +36,18 @@ type OperationParser struct {
 		result1 *jws.JWK
 		result2 error
 	}
-	ParseStub        func(string, []byte) (*batch.Operation, error)
+	ParseStub        func(string, []byte) (*operation.Operation, error)
 	parseMutex       sync.RWMutex
 	parseArgsForCall []struct {
 		arg1 string
 		arg2 []byte
 	}
 	parseReturns struct {
-		result1 *batch.Operation
+		result1 *operation.Operation
 		result2 error
 	}
 	parseReturnsOnCall map[int]struct {
-		result1 *batch.Operation
+		result1 *operation.Operation
 		result2 error
 	}
 	ParseDIDStub        func(string, string) (string, []byte, error)
@@ -206,7 +206,7 @@ func (fake *OperationParser) GetRevealValueReturnsOnCall(i int, result1 *jws.JWK
 	}{result1, result2}
 }
 
-func (fake *OperationParser) Parse(arg1 string, arg2 []byte) (*batch.Operation, error) {
+func (fake *OperationParser) Parse(arg1 string, arg2 []byte) (*operation.Operation, error) {
 	var arg2Copy []byte
 	if arg2 != nil {
 		arg2Copy = make([]byte, len(arg2))
@@ -236,7 +236,7 @@ func (fake *OperationParser) ParseCallCount() int {
 	return len(fake.parseArgsForCall)
 }
 
-func (fake *OperationParser) ParseCalls(stub func(string, []byte) (*batch.Operation, error)) {
+func (fake *OperationParser) ParseCalls(stub func(string, []byte) (*operation.Operation, error)) {
 	fake.parseMutex.Lock()
 	defer fake.parseMutex.Unlock()
 	fake.ParseStub = stub
@@ -249,28 +249,28 @@ func (fake *OperationParser) ParseArgsForCall(i int) (string, []byte) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *OperationParser) ParseReturns(result1 *batch.Operation, result2 error) {
+func (fake *OperationParser) ParseReturns(result1 *operation.Operation, result2 error) {
 	fake.parseMutex.Lock()
 	defer fake.parseMutex.Unlock()
 	fake.ParseStub = nil
 	fake.parseReturns = struct {
-		result1 *batch.Operation
+		result1 *operation.Operation
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *OperationParser) ParseReturnsOnCall(i int, result1 *batch.Operation, result2 error) {
+func (fake *OperationParser) ParseReturnsOnCall(i int, result1 *operation.Operation, result2 error) {
 	fake.parseMutex.Lock()
 	defer fake.parseMutex.Unlock()
 	fake.ParseStub = nil
 	if fake.parseReturnsOnCall == nil {
 		fake.parseReturnsOnCall = make(map[int]struct {
-			result1 *batch.Operation
+			result1 *operation.Operation
 			result2 error
 		})
 	}
 	fake.parseReturnsOnCall[i] = struct {
-		result1 *batch.Operation
+		result1 *operation.Operation
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/mocks/operationqueue.gen.go
+++ b/pkg/mocks/operationqueue.gen.go
@@ -4,14 +4,14 @@ package mocks
 import (
 	"sync"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 )
 
 type OperationQueue struct {
-	AddStub        func(data *batch.OperationInfo, protocolGenesisTime uint64) (uint, error)
+	AddStub        func(data *operation.QueuedOperation, protocolGenesisTime uint64) (uint, error)
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
-		data                *batch.OperationInfo
+		data                *operation.QueuedOperation
 		protocolGenesisTime uint64
 	}
 	addReturns struct {
@@ -37,17 +37,17 @@ type OperationQueue struct {
 		result2 uint
 		result3 error
 	}
-	PeekStub        func(num uint) ([]*batch.OperationInfoAtTime, error)
+	PeekStub        func(num uint) ([]*operation.QueuedOperationAtTime, error)
 	peekMutex       sync.RWMutex
 	peekArgsForCall []struct {
 		num uint
 	}
 	peekReturns struct {
-		result1 []*batch.OperationInfoAtTime
+		result1 []*operation.QueuedOperationAtTime
 		result2 error
 	}
 	peekReturnsOnCall map[int]struct {
-		result1 []*batch.OperationInfoAtTime
+		result1 []*operation.QueuedOperationAtTime
 		result2 error
 	}
 	LenStub        func() uint
@@ -63,11 +63,11 @@ type OperationQueue struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OperationQueue) Add(data *batch.OperationInfo, protocolGenesisTime uint64) (uint, error) {
+func (fake *OperationQueue) Add(data *operation.QueuedOperation, protocolGenesisTime uint64) (uint, error) {
 	fake.addMutex.Lock()
 	ret, specificReturn := fake.addReturnsOnCall[len(fake.addArgsForCall)]
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
-		data                *batch.OperationInfo
+		data                *operation.QueuedOperation
 		protocolGenesisTime uint64
 	}{data, protocolGenesisTime})
 	fake.recordInvocation("Add", []interface{}{data, protocolGenesisTime})
@@ -87,7 +87,7 @@ func (fake *OperationQueue) AddCallCount() int {
 	return len(fake.addArgsForCall)
 }
 
-func (fake *OperationQueue) AddArgsForCall(i int) (*batch.OperationInfo, uint64) {
+func (fake *OperationQueue) AddArgsForCall(i int) (*operation.QueuedOperation, uint64) {
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
 	return fake.addArgsForCall[i].data, fake.addArgsForCall[i].protocolGenesisTime
@@ -169,7 +169,7 @@ func (fake *OperationQueue) RemoveReturnsOnCall(i int, result1 uint, result2 uin
 	}{result1, result2, result3}
 }
 
-func (fake *OperationQueue) Peek(num uint) ([]*batch.OperationInfoAtTime, error) {
+func (fake *OperationQueue) Peek(num uint) ([]*operation.QueuedOperationAtTime, error) {
 	fake.peekMutex.Lock()
 	ret, specificReturn := fake.peekReturnsOnCall[len(fake.peekArgsForCall)]
 	fake.peekArgsForCall = append(fake.peekArgsForCall, struct {
@@ -198,24 +198,24 @@ func (fake *OperationQueue) PeekArgsForCall(i int) uint {
 	return fake.peekArgsForCall[i].num
 }
 
-func (fake *OperationQueue) PeekReturns(result1 []*batch.OperationInfoAtTime, result2 error) {
+func (fake *OperationQueue) PeekReturns(result1 []*operation.QueuedOperationAtTime, result2 error) {
 	fake.PeekStub = nil
 	fake.peekReturns = struct {
-		result1 []*batch.OperationInfoAtTime
+		result1 []*operation.QueuedOperationAtTime
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *OperationQueue) PeekReturnsOnCall(i int, result1 []*batch.OperationInfoAtTime, result2 error) {
+func (fake *OperationQueue) PeekReturnsOnCall(i int, result1 []*operation.QueuedOperationAtTime, result2 error) {
 	fake.PeekStub = nil
 	if fake.peekReturnsOnCall == nil {
 		fake.peekReturnsOnCall = make(map[int]struct {
-			result1 []*batch.OperationInfoAtTime
+			result1 []*operation.QueuedOperationAtTime
 			result2 error
 		})
 	}
 	fake.peekReturnsOnCall[i] = struct {
-		result1 []*batch.OperationInfoAtTime
+		result1 []*operation.QueuedOperationAtTime
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/mocks/store.go
+++ b/pkg/mocks/store.go
@@ -10,24 +10,24 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 )
 
 // MockOperationStore mocks store for testing purposes.
 type MockOperationStore struct {
 	sync.RWMutex
-	operations map[string][]*batch.AnchoredOperation
+	operations map[string][]*operation.AnchoredOperation
 	Err        error
 	Validate   bool
 }
 
 // NewMockOperationStore creates mock operations store.
 func NewMockOperationStore(err error) *MockOperationStore {
-	return &MockOperationStore{operations: make(map[string][]*batch.AnchoredOperation), Err: err, Validate: true}
+	return &MockOperationStore{operations: make(map[string][]*operation.AnchoredOperation), Err: err, Validate: true}
 }
 
 // Put mocks storing operation.
-func (m *MockOperationStore) Put(op *batch.AnchoredOperation) error {
+func (m *MockOperationStore) Put(op *operation.AnchoredOperation) error {
 	if m.Err != nil {
 		return m.Err
 	}
@@ -37,7 +37,7 @@ func (m *MockOperationStore) Put(op *batch.AnchoredOperation) error {
 	opsSize = len(m.operations[op.UniqueSuffix])
 	m.RUnlock()
 
-	if m.Validate && op.Type == batch.OperationTypeCreate && opsSize > 0 {
+	if m.Validate && op.Type == operation.TypeCreate && opsSize > 0 {
 		// Nothing to do; already created
 		return nil
 	}
@@ -51,7 +51,7 @@ func (m *MockOperationStore) Put(op *batch.AnchoredOperation) error {
 }
 
 // Get mocks retrieving operations from the store.
-func (m *MockOperationStore) Get(uniqueSuffix string) ([]*batch.AnchoredOperation, error) {
+func (m *MockOperationStore) Get(uniqueSuffix string) ([]*operation.AnchoredOperation, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -9,7 +9,7 @@ package observer
 import (
 	"github.com/trustbloc/edge-core/pkg/log"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 )
@@ -23,12 +23,12 @@ type Ledger interface {
 
 // OperationStore interface to access operation store.
 type OperationStore interface {
-	Put(ops []*batch.AnchoredOperation) error
+	Put(ops []*operation.AnchoredOperation) error
 }
 
 // OperationFilter filters out operations before they are persisted.
 type OperationFilter interface {
-	Filter(uniqueSuffix string, ops []*batch.AnchoredOperation) ([]*batch.AnchoredOperation, error)
+	Filter(uniqueSuffix string, ops []*operation.AnchoredOperation) ([]*operation.AnchoredOperation, error)
 }
 
 // Providers contains all of the providers required by the TxnProcessor.

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/txnprocessor"
@@ -103,11 +103,11 @@ func (m mockLedger) RegisterForSidetreeTxn() <-chan []txn.SidetreeTxn {
 }
 
 type mockOperationStore struct {
-	putFunc func(ops []*batch.AnchoredOperation) error
-	getFunc func(suffix string) ([]*batch.AnchoredOperation, error)
+	putFunc func(ops []*operation.AnchoredOperation) error
+	getFunc func(suffix string) ([]*operation.AnchoredOperation, error)
 }
 
-func (m *mockOperationStore) Put(ops []*batch.AnchoredOperation) error {
+func (m *mockOperationStore) Put(ops []*operation.AnchoredOperation) error {
 	if m.putFunc != nil {
 		return m.putFunc(ops)
 	}
@@ -115,7 +115,7 @@ func (m *mockOperationStore) Put(ops []*batch.AnchoredOperation) error {
 	return nil
 }
 
-func (m *mockOperationStore) Get(suffix string) ([]*batch.AnchoredOperation, error) {
+func (m *mockOperationStore) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 	if m.getFunc != nil {
 		return m.getFunc(suffix)
 	}
@@ -127,14 +127,14 @@ type mockTxnOpsProvider struct {
 	err error
 }
 
-func (m *mockTxnOpsProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.AnchoredOperation, error) {
+func (m *mockTxnOpsProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
 
-	op := &batch.AnchoredOperation{
+	op := &operation.AnchoredOperation{
 		UniqueSuffix: "abc",
 	}
 
-	return []*batch.AnchoredOperation{op}, nil
+	return []*operation.AnchoredOperation{op}, nil
 }

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
@@ -105,7 +105,7 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:  batch.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		Delta:      delta,
 		SuffixData: suffixData,
 	}, nil

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -124,7 +124,7 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.NoError(t, err)
 
 		deactivate := &model.DeactivateRequest{
-			Operation: batch.OperationTypeDeactivate,
+			Operation: operation.TypeDeactivate,
 			DidSuffix: suffix,
 		}
 
@@ -153,7 +153,7 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	suffixData := getSuffixData()
 
 	return &model.CreateRequest{
-		Operation:  batch.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		Delta:      delta,
 		SuffixData: suffixData,
 	}, nil

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
@@ -260,7 +260,7 @@ func getUnsupportedRequest() []byte {
 type operationSchema struct {
 
 	// operation
-	Operation batch.OperationType `json:"type"`
+	Operation operation.Type `json:"type"`
 }
 
 const validDoc = `{

--- a/pkg/versions/0_1/client/create.go
+++ b/pkg/versions/0_1/client/create.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/multiformats/go-multihash"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
@@ -69,7 +69,7 @@ func NewCreateRequest(info *CreateRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.CreateRequest{
-		Operation:  batch.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		Delta:      delta,
 		SuffixData: suffixData,
 	}

--- a/pkg/versions/0_1/client/deactivate.go
+++ b/pkg/versions/0_1/client/deactivate.go
@@ -9,7 +9,7 @@ package client
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -56,7 +56,7 @@ func NewDeactivateRequest(info *DeactivateRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.DeactivateRequest{
-		Operation:  batch.OperationTypeDeactivate,
+		Operation:  operation.TypeDeactivate,
 		DidSuffix:  info.DidSuffix,
 		SignedData: jws,
 	}

--- a/pkg/versions/0_1/client/recover.go
+++ b/pkg/versions/0_1/client/recover.go
@@ -9,7 +9,7 @@ package client
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
@@ -82,7 +82,7 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.RecoverRequest{
-		Operation:  batch.OperationTypeRecover,
+		Operation:  operation.TypeRecover,
 		DidSuffix:  info.DidSuffix,
 		Delta:      delta,
 		SignedData: jws,

--- a/pkg/versions/0_1/client/update.go
+++ b/pkg/versions/0_1/client/update.go
@@ -9,7 +9,7 @@ package client
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
@@ -67,7 +67,7 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.UpdateRequest{
-		Operation:  batch.OperationTypeUpdate,
+		Operation:  operation.TypeUpdate,
 		DidSuffix:  info.DidSuffix,
 		Delta:      delta,
 		SignedData: jws,

--- a/pkg/versions/0_1/docvalidator/didvalidator/validator.go
+++ b/pkg/versions/0_1/docvalidator/didvalidator/validator.go
@@ -9,7 +9,7 @@ package didvalidator
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 )
 
@@ -25,7 +25,7 @@ type Validator struct {
 // OperationStoreClient defines interface for retrieving all operations related to document.
 type OperationStoreClient interface {
 	// Get retrieves all operations related to document
-	Get(uniqueSuffix string) ([]*batch.AnchoredOperation, error)
+	Get(uniqueSuffix string) ([]*operation.AnchoredOperation, error)
 }
 
 // New creates a new did validator.

--- a/pkg/versions/0_1/docvalidator/didvalidator/validator_test.go
+++ b/pkg/versions/0_1/docvalidator/didvalidator/validator_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
@@ -57,7 +57,7 @@ func TestIsValidPayload(t *testing.T) {
 	store := mocks.NewMockOperationStore(nil)
 	v := New(store)
 
-	store.Put(&batch.AnchoredOperation{UniqueSuffix: "abc"})
+	store.Put(&operation.AnchoredOperation{UniqueSuffix: "abc"})
 
 	err := v.IsValidPayload(validUpdate)
 	require.Nil(t, err)
@@ -81,7 +81,7 @@ func TestIsValidPayload_StoreErrors(t *testing.T) {
 	require.Contains(t, err.Error(), "not found")
 
 	// scenario: found in the store and is valid
-	store.Put(&batch.AnchoredOperation{UniqueSuffix: "abc"})
+	store.Put(&operation.AnchoredOperation{UniqueSuffix: "abc"})
 	err = v.IsValidPayload(validUpdate)
 	require.Nil(t, err)
 

--- a/pkg/versions/0_1/docvalidator/docvalidator/validator.go
+++ b/pkg/versions/0_1/docvalidator/docvalidator/validator.go
@@ -9,7 +9,7 @@ package docvalidator
 import (
 	"errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 )
 
@@ -23,7 +23,7 @@ type Validator struct {
 // OperationStoreClient defines interface for retrieving all operations related to document.
 type OperationStoreClient interface {
 	// Get retrieves all operations related to document
-	Get(uniqueSuffix string) ([]*batch.AnchoredOperation, error)
+	Get(uniqueSuffix string) ([]*operation.AnchoredOperation, error)
 }
 
 // New creates a new document validator.

--- a/pkg/versions/0_1/docvalidator/docvalidator/validator_test.go
+++ b/pkg/versions/0_1/docvalidator/docvalidator/validator_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
@@ -40,7 +40,7 @@ func TestValidatorIsValidPayload(t *testing.T) {
 	store := mocks.NewMockOperationStore(nil)
 	v := New(store)
 
-	store.Put(&batch.AnchoredOperation{UniqueSuffix: "abc"})
+	store.Put(&operation.AnchoredOperation{UniqueSuffix: "abc"})
 
 	err := v.IsValidPayload(validUpdate)
 	require.Nil(t, err)
@@ -79,7 +79,7 @@ func TestIsValidPayload_StoreErrors(t *testing.T) {
 	require.Contains(t, err.Error(), "not found")
 
 	// scenario: found in the store and is valid
-	store.Put(&batch.AnchoredOperation{UniqueSuffix: "abc"})
+	store.Put(&operation.AnchoredOperation{UniqueSuffix: "abc"})
 	err = v.IsValidPayload(validUpdate)
 	require.Nil(t, err)
 

--- a/pkg/versions/0_1/model/operation.go
+++ b/pkg/versions/0_1/model/operation.go
@@ -7,14 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package model
 
 import (
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 )
 
 // Operation is used for parsing operation request.
 type Operation struct {
 
 	// Type defines operation type
-	Type batch.OperationType
+	Type operation.Type
 
 	// Namespace defines document namespace
 	Namespace string

--- a/pkg/versions/0_1/model/request.go
+++ b/pkg/versions/0_1/model/request.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package model
 
 import (
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 )
@@ -16,7 +16,7 @@ import (
 type CreateRequest struct {
 	// operation
 	// Required: true
-	Operation batch.OperationType `json:"type,omitempty"`
+	Operation operation.Type `json:"type,omitempty"`
 
 	// Suffix data object
 	// Required: true
@@ -50,7 +50,7 @@ type DeltaModel struct {
 // UpdateRequest is the struct for update request.
 type UpdateRequest struct {
 	// Operation defines operation type
-	Operation batch.OperationType `json:"type"`
+	Operation operation.Type `json:"type"`
 
 	// DidSuffix is the suffix of the DID
 	DidSuffix string `json:"didSuffix"`
@@ -66,7 +66,7 @@ type UpdateRequest struct {
 type DeactivateRequest struct {
 	// Operation
 	// Required: true
-	Operation batch.OperationType `json:"type"`
+	Operation operation.Type `json:"type"`
 
 	// DidSuffix of the DID
 	// Required: true
@@ -113,7 +113,7 @@ type DeactivateSignedDataModel struct {
 type RecoverRequest struct {
 	// operation
 	// Required: true
-	Operation batch.OperationType `json:"type"`
+	Operation operation.Type `json:"type"`
 
 	// DidSuffix is the suffix of the DID
 	// Required: true

--- a/pkg/versions/0_1/model/util.go
+++ b/pkg/versions/0_1/model/util.go
@@ -9,22 +9,22 @@ package model
 import (
 	"fmt"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
 // GetAnchoredOperation is utility method for converting operation model into anchored operation.
-func GetAnchoredOperation(op *Operation) (*batch.AnchoredOperation, error) {
+func GetAnchoredOperation(op *Operation) (*operation.AnchoredOperation, error) {
 	var request interface{}
 	switch op.Type {
-	case batch.OperationTypeCreate:
+	case operation.TypeCreate:
 		request = CreateRequest{
 			Operation:  op.Type,
 			SuffixData: op.SuffixData,
 			Delta:      op.Delta,
 		}
 
-	case batch.OperationTypeUpdate:
+	case operation.TypeUpdate:
 		request = UpdateRequest{
 			Operation:  op.Type,
 			DidSuffix:  op.UniqueSuffix,
@@ -32,14 +32,14 @@ func GetAnchoredOperation(op *Operation) (*batch.AnchoredOperation, error) {
 			SignedData: op.SignedData,
 		}
 
-	case batch.OperationTypeDeactivate:
+	case operation.TypeDeactivate:
 		request = DeactivateRequest{
 			Operation:  op.Type,
 			DidSuffix:  op.UniqueSuffix,
 			SignedData: op.SignedData,
 		}
 
-	case batch.OperationTypeRecover:
+	case operation.TypeRecover:
 		request = RecoverRequest{
 			Operation:  op.Type,
 			DidSuffix:  op.UniqueSuffix,
@@ -56,7 +56,7 @@ func GetAnchoredOperation(op *Operation) (*batch.AnchoredOperation, error) {
 		return nil, fmt.Errorf("failed to canonicalize anchored operation[%v]: %s", op, err.Error())
 	}
 
-	return &batch.AnchoredOperation{
+	return &operation.AnchoredOperation{
 		Type:            op.Type,
 		UniqueSuffix:    op.UniqueSuffix,
 		OperationBuffer: operationBuffer,

--- a/pkg/versions/0_1/operationapplier/operationapplier.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/trustbloc/edge-core/pkg/log"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
@@ -54,22 +54,22 @@ func New(p protocol.Protocol, parser OperationParser, dc protocol.DocumentCompos
 }
 
 // Apply applies the given anchored operation.
-func (s *Applier) Apply(operation *batch.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
-	switch operation.Type {
-	case batch.OperationTypeCreate:
-		return s.applyCreateOperation(operation, rm)
-	case batch.OperationTypeUpdate:
-		return s.applyUpdateOperation(operation, rm)
-	case batch.OperationTypeDeactivate:
-		return s.applyDeactivateOperation(operation, rm)
-	case batch.OperationTypeRecover:
-		return s.applyRecoverOperation(operation, rm)
+func (s *Applier) Apply(op *operation.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
+	switch op.Type {
+	case operation.TypeCreate:
+		return s.applyCreateOperation(op, rm)
+	case operation.TypeUpdate:
+		return s.applyUpdateOperation(op, rm)
+	case operation.TypeDeactivate:
+		return s.applyDeactivateOperation(op, rm)
+	case operation.TypeRecover:
+		return s.applyRecoverOperation(op, rm)
 	default:
 		return nil, fmt.Errorf("operation type not supported for process operation")
 	}
 }
 
-func (s *Applier) applyCreateOperation(anchoredOp *batch.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
+func (s *Applier) applyCreateOperation(anchoredOp *operation.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
 	logger.Debugf("Applying create operation: %+v", anchoredOp)
 
 	if rm.Doc != nil {
@@ -119,7 +119,7 @@ func (s *Applier) applyCreateOperation(anchoredOp *batch.AnchoredOperation, rm *
 	return result, nil
 }
 
-func (s *Applier) applyUpdateOperation(anchoredOp *batch.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) { //nolint:dupl
+func (s *Applier) applyUpdateOperation(anchoredOp *operation.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) { //nolint:dupl
 	logger.Debugf("Applying update operation: %+v", anchoredOp)
 
 	if rm.Doc == nil {
@@ -168,7 +168,7 @@ func (s *Applier) applyUpdateOperation(anchoredOp *batch.AnchoredOperation, rm *
 	}, nil
 }
 
-func (s *Applier) applyDeactivateOperation(anchoredOp *batch.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
+func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) {
 	logger.Debugf("[%s] Applying deactivate operation: %+v", anchoredOp)
 
 	if rm.Doc == nil {
@@ -206,7 +206,7 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *batch.AnchoredOperation, 
 	}, nil
 }
 
-func (s *Applier) applyRecoverOperation(anchoredOp *batch.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) { //nolint:dupl
+func (s *Applier) applyRecoverOperation(anchoredOp *operation.AnchoredOperation, rm *protocol.ResolutionModel) (*protocol.ResolutionModel, error) { //nolint:dupl
 	logger.Debugf("Applying recover operation: %+v", anchoredOp)
 
 	if rm.Doc == nil {

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
@@ -115,7 +115,7 @@ func TestApplier_Apply(t *testing.T) {
 	t.Run("invalid operation type error", func(t *testing.T) {
 		applier := New(p, parser, dc)
 
-		doc, err := applier.Apply(&batch.AnchoredOperation{Type: "invalid"}, &protocol.ResolutionModel{Doc: make(document.Document)})
+		doc, err := applier.Apply(&operation.AnchoredOperation{Type: "invalid"}, &protocol.ResolutionModel{Doc: make(document.Document)})
 		require.Error(t, err)
 		require.Equal(t, "operation type not supported for process operation", err.Error())
 		require.Nil(t, doc)
@@ -697,7 +697,7 @@ func getUpdateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string, opera
 	return getUpdateOperationWithSigner(s, privateKey, uniqueSuffix, operationNumber)
 }
 
-func getAnchoredUpdateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string, operationNumber uint) (*batch.AnchoredOperation, *ecdsa.PrivateKey, error) {
+func getAnchoredUpdateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string, operationNumber uint) (*operation.AnchoredOperation, *ecdsa.PrivateKey, error) {
 	op, nextUpdateKey, err := getUpdateOperation(privateKey, uniqueSuffix, operationNumber)
 	if err != nil {
 		return nil, nil, err
@@ -753,16 +753,16 @@ func getUpdateOperationWithSigner(s client.Signer, privateKey *ecdsa.PrivateKey,
 		return nil, nil, err
 	}
 
-	operation := &model.Operation{
+	op := &model.Operation{
 		Namespace:    mocks.DefaultNS,
 		ID:           "did:sidetree:" + uniqueSuffix,
 		UniqueSuffix: uniqueSuffix,
 		Delta:        delta,
-		Type:         batch.OperationTypeUpdate,
+		Type:         operation.TypeUpdate,
 		SignedData:   jws,
 	}
 
-	return operation, nextUpdateKey, nil
+	return op, nextUpdateKey, nil
 }
 
 func generateKeyAndCommitment() (*ecdsa.PrivateKey, string, error) {
@@ -790,7 +790,7 @@ func getDeactivateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string) (
 	return getDeactivateOperationWithSigner(signer, privateKey, uniqueSuffix)
 }
 
-func getAnchoredDeactivateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string) (*batch.AnchoredOperation, error) {
+func getAnchoredDeactivateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string) (*operation.AnchoredOperation, error) {
 	op, err := getDeactivateOperation(privateKey, uniqueSuffix)
 	if err != nil {
 		return nil, err
@@ -819,7 +819,7 @@ func getDeactivateOperationWithSigner(singer client.Signer, privateKey *ecdsa.Pr
 		Namespace:    mocks.DefaultNS,
 		ID:           "did:sidetree:" + uniqueSuffix,
 		UniqueSuffix: uniqueSuffix,
-		Type:         batch.OperationTypeDeactivate,
+		Type:         operation.TypeDeactivate,
 		SignedData:   jws,
 	}, nil
 }
@@ -830,7 +830,7 @@ func getRecoverOperation(recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix 
 	return getRecoverOperationWithSigner(signer, recoveryKey, updateKey, uniqueSuffix)
 }
 
-func getAnchoredRecoverOperation(recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix string, operationNumber uint) (*batch.AnchoredOperation, *ecdsa.PrivateKey, error) {
+func getAnchoredRecoverOperation(recoveryKey, updateKey *ecdsa.PrivateKey, uniqueSuffix string, operationNumber uint) (*operation.AnchoredOperation, *ecdsa.PrivateKey, error) {
 	op, nextRecoveryKey, err := getRecoverOperation(recoveryKey, updateKey, uniqueSuffix)
 	if err != nil {
 		return nil, nil, err
@@ -853,7 +853,7 @@ func getRecoverOperationWithSigner(signer client.Signer, recoveryKey, updateKey 
 	return &model.Operation{
 		Namespace:       mocks.DefaultNS,
 		UniqueSuffix:    uniqueSuffix,
-		Type:            batch.OperationTypeRecover,
+		Type:            operation.TypeRecover,
 		OperationBuffer: operationBuffer,
 		Delta:           recoverRequest.Delta,
 		SignedData:      recoverRequest.SignedData,
@@ -874,7 +874,7 @@ func getRecoverRequest(signer client.Signer, delta *model.DeltaModel, signedData
 	}
 
 	return &model.RecoverRequest{
-		Operation:  batch.OperationTypeRecover,
+		Operation:  operation.TypeRecover,
 		DidSuffix:  "suffix",
 		Delta:      delta,
 		SignedData: jws,
@@ -973,7 +973,7 @@ func getCreateOperationWithDoc(recoveryKey, updateKey *ecdsa.PrivateKey, doc str
 		Namespace:       mocks.DefaultNS,
 		ID:              "did:sidetree:" + uniqueSuffix,
 		UniqueSuffix:    uniqueSuffix,
-		Type:            batch.OperationTypeCreate,
+		Type:            operation.TypeCreate,
 		OperationBuffer: operationBuffer,
 		Delta:           delta,
 		SuffixData:      suffixData,
@@ -984,7 +984,7 @@ func getCreateOperation(recoveryKey, updateKey *ecdsa.PrivateKey) (*model.Operat
 	return getCreateOperationWithDoc(recoveryKey, updateKey, validDoc)
 }
 
-func getAnchoredCreateOperation(recoveryKey, updateKey *ecdsa.PrivateKey) (*batch.AnchoredOperation, error) {
+func getAnchoredCreateOperation(recoveryKey, updateKey *ecdsa.PrivateKey) (*operation.AnchoredOperation, error) {
 	op, err := getCreateOperation(recoveryKey, updateKey)
 	if err != nil {
 		return nil, err
@@ -993,7 +993,7 @@ func getAnchoredCreateOperation(recoveryKey, updateKey *ecdsa.PrivateKey) (*batc
 	return getAnchoredOperation(op), nil
 }
 
-func getAnchoredOperation(op *model.Operation) *batch.AnchoredOperation {
+func getAnchoredOperation(op *model.Operation) *operation.AnchoredOperation {
 	anchoredOp, err := model.GetAnchoredOperation(op)
 	if err != nil {
 		panic(err)
@@ -1002,7 +1002,7 @@ func getAnchoredOperation(op *model.Operation) *batch.AnchoredOperation {
 	return anchoredOp
 }
 
-func getAnchoredOperationWithBlockNum(op *model.Operation, blockNum uint64) *batch.AnchoredOperation {
+func getAnchoredOperationWithBlockNum(op *model.Operation, blockNum uint64) *operation.AnchoredOperation {
 	anchored := getAnchoredOperation(op)
 	anchored.TransactionTime = blockNum
 
@@ -1026,7 +1026,7 @@ func getCreateRequest(recoveryKey, updateKey *ecdsa.PrivateKey) (*model.CreateRe
 	}
 
 	return &model.CreateRequest{
-		Operation:  batch.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		Delta:      delta,
 		SuffixData: suffixData,
 	}, nil

--- a/pkg/versions/0_1/operationparser/commitment.go
+++ b/pkg/versions/0_1/operationparser/commitment.go
@@ -3,20 +3,20 @@ package operationparser
 import (
 	"fmt"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 )
 
 // GetRevealValue returns this operation reveal value.
-func (p *Parser) GetRevealValue(operation []byte) (*jws.JWK, error) {
+func (p *Parser) GetRevealValue(opBytes []byte) (*jws.JWK, error) {
 	// namespace is irrelevant in this case
-	op, err := p.ParseOperation("", operation)
+	op, err := p.ParseOperation("", opBytes)
 	if err != nil {
 		return nil, fmt.Errorf("get reveal value - parse operation error: %s", err.Error())
 	}
 
 	switch op.Type { //nolint:exhaustive
-	case batch.OperationTypeUpdate:
+	case operation.TypeUpdate:
 		signedDataModel, innerErr := p.ParseSignedDataForUpdate(op.SignedData)
 		if innerErr != nil {
 			return nil, fmt.Errorf("failed to parse signed data model for update: %s", innerErr.Error())
@@ -24,7 +24,7 @@ func (p *Parser) GetRevealValue(operation []byte) (*jws.JWK, error) {
 
 		return signedDataModel.UpdateKey, nil
 
-	case batch.OperationTypeDeactivate:
+	case operation.TypeDeactivate:
 		signedDataModel, innerErr := p.ParseSignedDataForDeactivate(op.SignedData)
 		if innerErr != nil {
 			return nil, fmt.Errorf("failed to parse signed data model for deactivate: %s", innerErr.Error())
@@ -32,7 +32,7 @@ func (p *Parser) GetRevealValue(operation []byte) (*jws.JWK, error) {
 
 		return signedDataModel.RecoveryKey, nil
 
-	case batch.OperationTypeRecover:
+	case operation.TypeRecover:
 		signedDataModel, innerErr := p.ParseSignedDataForRecover(op.SignedData)
 		if innerErr != nil {
 			return nil, fmt.Errorf("failed to parse signed data model for recover: %s", innerErr.Error())
@@ -45,21 +45,21 @@ func (p *Parser) GetRevealValue(operation []byte) (*jws.JWK, error) {
 }
 
 // GetCommitment returns next operation commitment.
-func (p *Parser) GetCommitment(operation []byte) (string, error) {
+func (p *Parser) GetCommitment(opBytes []byte) (string, error) {
 	// namespace is irrelevant in this case
-	op, err := p.ParseOperation("", operation)
+	op, err := p.ParseOperation("", opBytes)
 	if err != nil {
 		return "", fmt.Errorf("get commitment - parse operation error: %s", err.Error())
 	}
 
 	switch op.Type { //nolint:exhaustive
-	case batch.OperationTypeUpdate:
+	case operation.TypeUpdate:
 		return op.Delta.UpdateCommitment, nil
 
-	case batch.OperationTypeDeactivate:
+	case operation.TypeDeactivate:
 		return "", nil
 
-	case batch.OperationTypeRecover:
+	case operation.TypeRecover:
 		signedDataModel, innerErr := p.ParseSignedDataForRecover(op.SignedData)
 		if innerErr != nil {
 			return "", fmt.Errorf("failed to parse signed data model for recover: %s", innerErr.Error())

--- a/pkg/versions/0_1/operationparser/create.go
+++ b/pkg/versions/0_1/operationparser/create.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
@@ -51,7 +51,7 @@ func (p *Parser) ParseCreateOperation(request []byte, anchor bool) (*model.Opera
 
 	return &model.Operation{
 		OperationBuffer: request,
-		Type:            batch.OperationTypeCreate,
+		Type:            operation.TypeCreate,
 		UniqueSuffix:    uniqueSuffix,
 		Delta:           schema.Delta,
 		SuffixData:      schema.SuffixData,

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
@@ -38,13 +38,13 @@ func TestParseCreateOperation(t *testing.T) {
 
 		op, err := parser.ParseCreateOperation(request, false)
 		require.NoError(t, err)
-		require.Equal(t, batch.OperationTypeCreate, op.Type)
+		require.Equal(t, operation.TypeCreate, op.Type)
 	})
 
 	t.Run("success - JCS", func(t *testing.T) {
 		op, err := parser.ParseCreateOperation([]byte(jcsRequest), true)
 		require.NoError(t, err)
-		require.Equal(t, batch.OperationTypeCreate, op.Type)
+		require.Equal(t, operation.TypeCreate, op.Type)
 	})
 
 	t.Run("parse create request error", func(t *testing.T) {
@@ -233,7 +233,7 @@ func getCreateRequest() (*model.CreateRequest, error) {
 	}
 
 	return &model.CreateRequest{
-		Operation:  batch.OperationTypeCreate,
+		Operation:  operation.TypeCreate,
 		Delta:      delta,
 		SuffixData: suffixData,
 	}, nil

--- a/pkg/versions/0_1/operationparser/deactivate.go
+++ b/pkg/versions/0_1/operationparser/deactivate.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -32,7 +32,7 @@ func (p *Parser) ParseDeactivateOperation(request []byte, anchor bool) (*model.O
 	}
 
 	return &model.Operation{
-		Type:            batch.OperationTypeDeactivate,
+		Type:            operation.TypeDeactivate,
 		OperationBuffer: request,
 		UniqueSuffix:    schema.DidSuffix,
 		SignedData:      schema.SignedData,

--- a/pkg/versions/0_1/operationparser/deactivate_test.go
+++ b/pkg/versions/0_1/operationparser/deactivate_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -36,7 +36,7 @@ func TestParseDeactivateOperation(t *testing.T) {
 
 		op, err := parser.ParseDeactivateOperation(payload, false)
 		require.NoError(t, err)
-		require.Equal(t, batch.OperationTypeDeactivate, op.Type)
+		require.Equal(t, operation.TypeDeactivate, op.Type)
 	})
 	t.Run("missing unique suffix", func(t *testing.T) {
 		schema, err := parser.ParseDeactivateOperation([]byte("{}"), false)
@@ -128,7 +128,7 @@ func getDeactivateRequest(signedData *model.DeactivateSignedDataModel) (*model.D
 	}
 
 	return &model.DeactivateRequest{
-		Operation:  batch.OperationTypeDeactivate,
+		Operation:  operation.TypeDeactivate,
 		DidSuffix:  "did",
 		SignedData: compactJWS,
 	}, nil

--- a/pkg/versions/0_1/operationparser/method.go
+++ b/pkg/versions/0_1/operationparser/method.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
@@ -83,7 +83,7 @@ func parseInitialState(initialState string) (*model.CreateRequest, error) {
 		return nil, errors.New("initial state is not valid")
 	}
 
-	createRequest.Operation = batch.OperationTypeCreate
+	createRequest.Operation = operation.TypeCreate
 
 	return &createRequest, nil
 }

--- a/pkg/versions/0_1/operationparser/operation.go
+++ b/pkg/versions/0_1/operationparser/operation.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
@@ -29,14 +29,14 @@ func New(p protocol.Protocol) *Parser {
 }
 
 // Parse parses and validates operation.
-func (p *Parser) Parse(namespace string, operationBuffer []byte) (*batch.Operation, error) {
+func (p *Parser) Parse(namespace string, operationBuffer []byte) (*operation.Operation, error) {
 	// parse and validate operation buffer using this versions model and validation rules
 	internal, err := p.ParseOperation(namespace, operationBuffer)
 	if err != nil {
 		return nil, err
 	}
 
-	return &batch.Operation{
+	return &operation.Operation{
 		Type:            internal.Type,
 		UniqueSuffix:    internal.UniqueSuffix,
 		ID:              internal.ID,
@@ -55,13 +55,13 @@ func (p *Parser) ParseOperation(namespace string, operationBuffer []byte) (*mode
 	var op *model.Operation
 	var parseErr error
 	switch schema.Operation {
-	case batch.OperationTypeCreate:
+	case operation.TypeCreate:
 		op, parseErr = p.ParseCreateOperation(operationBuffer, false)
-	case batch.OperationTypeUpdate:
+	case operation.TypeUpdate:
 		op, parseErr = p.ParseUpdateOperation(operationBuffer, false)
-	case batch.OperationTypeDeactivate:
+	case operation.TypeDeactivate:
 		op, parseErr = p.ParseDeactivateOperation(operationBuffer, false)
-	case batch.OperationTypeRecover:
+	case operation.TypeRecover:
 		op, parseErr = p.ParseRecoverOperation(operationBuffer, false)
 	default:
 		return nil, fmt.Errorf("parse operation: operation type [%s] not supported", schema.Operation)
@@ -81,5 +81,5 @@ func (p *Parser) ParseOperation(namespace string, operationBuffer []byte) (*mode
 type operationSchema struct {
 
 	// operation
-	Operation batch.OperationType `json:"type"`
+	Operation operation.Type `json:"type"`
 }

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	internal "github.com/trustbloc/sidetree-core-go/pkg/internal/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -40,7 +40,7 @@ func (p *Parser) ParseRecoverOperation(request []byte, anchor bool) (*model.Oper
 
 	return &model.Operation{
 		OperationBuffer: request,
-		Type:            batch.OperationTypeRecover,
+		Type:            operation.TypeRecover,
 		UniqueSuffix:    schema.DidSuffix,
 		Delta:           schema.Delta,
 		SignedData:      schema.SignedData,

--- a/pkg/versions/0_1/operationparser/recover_test.go
+++ b/pkg/versions/0_1/operationparser/recover_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	internal "github.com/trustbloc/sidetree-core-go/pkg/internal/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
@@ -42,7 +42,7 @@ func TestParseRecoverOperation(t *testing.T) {
 
 		op, err := parser.ParseRecoverOperation(request, false)
 		require.NoError(t, err)
-		require.Equal(t, batch.OperationTypeRecover, op.Type)
+		require.Equal(t, operation.TypeRecover, op.Type)
 	})
 	t.Run("parse recover request error", func(t *testing.T) {
 		schema, err := parser.ParseRecoverOperation([]byte(""), false)
@@ -386,7 +386,7 @@ func getRecoverRequest(delta *model.DeltaModel, signedData *model.RecoverSignedD
 	}
 
 	return &model.RecoverRequest{
-		Operation:  batch.OperationTypeRecover,
+		Operation:  operation.TypeRecover,
 		DidSuffix:  "suffix",
 		Delta:      delta,
 		SignedData: compactJWS,

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
@@ -36,7 +36,7 @@ func (p *Parser) ParseUpdateOperation(request []byte, anchor bool) (*model.Opera
 	}
 
 	return &model.Operation{
-		Type:            batch.OperationTypeUpdate,
+		Type:            operation.TypeUpdate,
 		OperationBuffer: request,
 		UniqueSuffix:    schema.DidSuffix,
 		Delta:           schema.Delta,

--- a/pkg/versions/0_1/operationparser/update_test.go
+++ b/pkg/versions/0_1/operationparser/update_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/internal/signutil"
@@ -37,7 +37,7 @@ func TestParseUpdateOperation(t *testing.T) {
 
 		op, err := parser.ParseUpdateOperation(payload, false)
 		require.NoError(t, err)
-		require.Equal(t, batch.OperationTypeUpdate, op.Type)
+		require.Equal(t, operation.TypeUpdate, op.Type)
 	})
 	t.Run("invalid json", func(t *testing.T) {
 		schema, err := parser.ParseUpdateOperation([]byte(""), false)
@@ -233,7 +233,7 @@ func getUpdateRequest(delta *model.DeltaModel) (*model.UpdateRequest, error) {
 	return &model.UpdateRequest{
 		DidSuffix:  "suffix",
 		SignedData: compactJWS,
-		Operation:  batch.OperationTypeUpdate,
+		Operation:  operation.TypeUpdate,
 		Delta:      delta,
 	}, nil
 }

--- a/pkg/versions/0_1/txnprocessor/txnprocessor.go
+++ b/pkg/versions/0_1/txnprocessor/txnprocessor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/trustbloc/edge-core/pkg/log"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 )
@@ -21,7 +21,7 @@ var logger = log.New("sidetree-core-observer")
 
 // OperationStore interface to access operation store.
 type OperationStore interface {
-	Put(ops []*batch.AnchoredOperation) error
+	Put(ops []*operation.AnchoredOperation) error
 }
 
 // Providers contains the providers required by the TxnProcessor.
@@ -54,12 +54,12 @@ func (p *TxnProcessor) Process(sidetreeTxn txn.SidetreeTxn) error {
 	return p.processTxnOperations(txnOps, sidetreeTxn)
 }
 
-func (p *TxnProcessor) processTxnOperations(txnOps []*batch.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) error {
+func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) error {
 	logger.Debugf("processing %d transaction operations", len(txnOps))
 
 	batchSuffixes := make(map[string]bool)
 
-	var ops []*batch.AnchoredOperation
+	var ops []*operation.AnchoredOperation
 	for _, op := range txnOps {
 		_, ok := batchSuffixes[op.UniqueSuffix]
 		if ok {
@@ -84,7 +84,7 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*batch.AnchoredOperation, s
 	return nil
 }
 
-func updateAnchoredOperation(op *batch.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) *batch.AnchoredOperation {
+func updateAnchoredOperation(op *operation.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) *operation.AnchoredOperation {
 	//  The logical blockchain time that this operation was anchored on the blockchain
 	op.TransactionTime = sidetreeTxn.TransactionTime
 	// The transaction number of the transaction this operation was batched within

--- a/pkg/versions/0_1/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/0_1/txnprocessor/txnprocessor_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 )
 
@@ -41,13 +41,13 @@ func TestTxnProcessor_Process(t *testing.T) {
 func TestProcessTxnOperations(t *testing.T) {
 	t.Run("test error from operationStore Put", func(t *testing.T) {
 		providers := &Providers{
-			OpStore: &mockOperationStore{putFunc: func(ops []*batch.AnchoredOperation) error {
+			OpStore: &mockOperationStore{putFunc: func(ops []*operation.AnchoredOperation) error {
 				return fmt.Errorf("put error")
 			}},
 		}
 
 		p := New(providers)
-		err := p.processTxnOperations([]*batch.AnchoredOperation{{UniqueSuffix: "abc"}}, txn.SidetreeTxn{AnchorString: anchorString})
+		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}}, txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to store operation from anchor string")
 	})
@@ -87,7 +87,7 @@ func TestProcessTxnOperations(t *testing.T) {
 
 func TestUpdateOperation(t *testing.T) {
 	t.Run("test success", func(t *testing.T) {
-		updatedOps := updateAnchoredOperation(&batch.AnchoredOperation{UniqueSuffix: "abc"},
+		updatedOps := updateAnchoredOperation(&operation.AnchoredOperation{UniqueSuffix: "abc"},
 			txn.SidetreeTxn{TransactionTime: 20, TransactionNumber: 2})
 		require.Equal(t, uint64(20), updatedOps.TransactionTime)
 		require.Equal(t, uint64(2), updatedOps.TransactionNumber)
@@ -95,11 +95,11 @@ func TestUpdateOperation(t *testing.T) {
 }
 
 type mockOperationStore struct {
-	putFunc func(ops []*batch.AnchoredOperation) error
-	getFunc func(suffix string) ([]*batch.AnchoredOperation, error)
+	putFunc func(ops []*operation.AnchoredOperation) error
+	getFunc func(suffix string) ([]*operation.AnchoredOperation, error)
 }
 
-func (m *mockOperationStore) Put(ops []*batch.AnchoredOperation) error {
+func (m *mockOperationStore) Put(ops []*operation.AnchoredOperation) error {
 	if m.putFunc != nil {
 		return m.putFunc(ops)
 	}
@@ -107,7 +107,7 @@ func (m *mockOperationStore) Put(ops []*batch.AnchoredOperation) error {
 	return nil
 }
 
-func (m *mockOperationStore) Get(suffix string) ([]*batch.AnchoredOperation, error) {
+func (m *mockOperationStore) Get(suffix string) ([]*operation.AnchoredOperation, error) {
 	if m.getFunc != nil {
 		return m.getFunc(suffix)
 	}
@@ -119,14 +119,14 @@ type mockTxnOpsProvider struct {
 	err error
 }
 
-func (m *mockTxnOpsProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.AnchoredOperation, error) {
+func (m *mockTxnOpsProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
 
-	op := &batch.AnchoredOperation{
+	op := &operation.AnchoredOperation{
 		UniqueSuffix: "abc",
 	}
 
-	return []*batch.AnchoredOperation{op}, nil
+	return []*operation.AnchoredOperation{op}, nil
 }

--- a/pkg/versions/0_1/txnprovider/models/anchor.go
+++ b/pkg/versions/0_1/txnprovider/models/anchor.go
@@ -9,7 +9,7 @@ package models
 import (
 	"encoding/json"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -52,8 +52,8 @@ func CreateAnchorFile(mapAddress string, ops []*model.Operation) *AnchorFile {
 		MapFileURI: mapAddress,
 		Operations: Operations{
 			Create:     getCreateOperations(ops),
-			Recover:    getSignedOperations(batch.OperationTypeRecover, ops),
-			Deactivate: getSignedOperations(batch.OperationTypeDeactivate, ops),
+			Recover:    getSignedOperations(operation.TypeRecover, ops),
+			Deactivate: getSignedOperations(operation.TypeDeactivate, ops),
 		},
 	}
 }
@@ -61,7 +61,7 @@ func CreateAnchorFile(mapAddress string, ops []*model.Operation) *AnchorFile {
 func getCreateOperations(ops []*model.Operation) []CreateOperation {
 	var result []CreateOperation
 	for _, op := range ops {
-		if op.Type == batch.OperationTypeCreate {
+		if op.Type == operation.TypeCreate {
 			create := CreateOperation{SuffixData: op.SuffixData}
 
 			result = append(result, create)

--- a/pkg/versions/0_1/txnprovider/models/anchor_test.go
+++ b/pkg/versions/0_1/txnprovider/models/anchor_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -57,15 +57,15 @@ func TestParseAnchorFile(t *testing.T) {
 
 func getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum int) []*model.Operation {
 	var ops []*model.Operation
-	ops = append(ops, generateOperations(createOpsNum, batch.OperationTypeCreate)...)
-	ops = append(ops, generateOperations(recoverOpsNum, batch.OperationTypeRecover)...)
-	ops = append(ops, generateOperations(deactivateOpsNum, batch.OperationTypeDeactivate)...)
-	ops = append(ops, generateOperations(updateOpsNum, batch.OperationTypeUpdate)...)
+	ops = append(ops, generateOperations(createOpsNum, operation.TypeCreate)...)
+	ops = append(ops, generateOperations(recoverOpsNum, operation.TypeRecover)...)
+	ops = append(ops, generateOperations(deactivateOpsNum, operation.TypeDeactivate)...)
+	ops = append(ops, generateOperations(updateOpsNum, operation.TypeUpdate)...)
 
 	return ops
 }
 
-func generateOperations(numOfOperations int, opType batch.OperationType) (ops []*model.Operation) {
+func generateOperations(numOfOperations int, opType operation.Type) (ops []*model.Operation) {
 	for j := 1; j <= numOfOperations; j++ {
 		ops = append(ops, generateOperation(j, opType))
 	}
@@ -73,7 +73,7 @@ func generateOperations(numOfOperations int, opType batch.OperationType) (ops []
 	return
 }
 
-func generateOperation(num int, opType batch.OperationType) *model.Operation {
+func generateOperation(num int, opType operation.Type) *model.Operation {
 	return &model.Operation{
 		Type:         opType,
 		UniqueSuffix: fmt.Sprintf("%s-%d", opType, num),

--- a/pkg/versions/0_1/txnprovider/models/chunk.go
+++ b/pkg/versions/0_1/txnprovider/models/chunk.go
@@ -9,7 +9,7 @@ package models
 import (
 	"encoding/json"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -24,9 +24,9 @@ type ChunkFile struct {
 func CreateChunkFile(ops []*model.Operation) *ChunkFile {
 	var deltas []*model.DeltaModel
 
-	deltas = append(deltas, getDeltas(batch.OperationTypeCreate, ops)...)
-	deltas = append(deltas, getDeltas(batch.OperationTypeRecover, ops)...)
-	deltas = append(deltas, getDeltas(batch.OperationTypeUpdate, ops)...)
+	deltas = append(deltas, getDeltas(operation.TypeCreate, ops)...)
+	deltas = append(deltas, getDeltas(operation.TypeRecover, ops)...)
+	deltas = append(deltas, getDeltas(operation.TypeUpdate, ops)...)
 
 	return &ChunkFile{Deltas: deltas}
 }
@@ -41,7 +41,7 @@ func ParseChunkFile(content []byte) (*ChunkFile, error) {
 	return cf, nil
 }
 
-func getDeltas(filter batch.OperationType, ops []*model.Operation) []*model.DeltaModel {
+func getDeltas(filter operation.Type, ops []*model.Operation) []*model.DeltaModel {
 	var deltas []*model.DeltaModel
 	for _, op := range ops {
 		if op.Type == filter {

--- a/pkg/versions/0_1/txnprovider/models/map.go
+++ b/pkg/versions/0_1/txnprovider/models/map.go
@@ -9,7 +9,7 @@ package models
 import (
 	"encoding/json"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -30,7 +30,7 @@ func CreateMapFile(uri []string, ops []*model.Operation) *MapFile {
 	return &MapFile{
 		Chunks: getChunks(uri),
 		Operations: Operations{
-			Update: getSignedOperations(batch.OperationTypeUpdate, ops),
+			Update: getSignedOperations(operation.TypeUpdate, ops),
 		},
 	}
 }
@@ -56,7 +56,7 @@ func getChunks(uris []string) []Chunk {
 	return chunks
 }
 
-func getSignedOperations(filter batch.OperationType, ops []*model.Operation) []SignedOperation {
+func getSignedOperations(filter operation.Type, ops []*model.Operation) []SignedOperation {
 	var result []SignedOperation
 	for _, op := range ops {
 		if op.Type == filter {

--- a/pkg/versions/0_1/txnprovider/provider.go
+++ b/pkg/versions/0_1/txnprovider/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/trustbloc/edge-core/pkg/log"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
@@ -57,7 +57,7 @@ func NewOperationProvider(p protocol.Protocol, parser OperationParser, cas DCAS,
 }
 
 // GetTxnOperations will read batch files(Chunk, map, anchor) and assemble batch operations from those files.
-func (h *OperationProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.AnchoredOperation, error) {
+func (h *OperationProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error) {
 	// ParseAnchorData anchor address and number of operations from anchor string
 	anchorData, err := ParseAnchorData(txn.AnchorString)
 	if err != nil {
@@ -102,8 +102,8 @@ func (h *OperationProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*batch.Anc
 	return txnOps, nil
 }
 
-func createAnchoredOperations(ops []*model.Operation) ([]*batch.AnchoredOperation, error) {
-	var anchoredOps []*batch.AnchoredOperation
+func createAnchoredOperations(ops []*model.Operation) ([]*operation.AnchoredOperation, error) {
+	var anchoredOps []*operation.AnchoredOperation
 	for _, op := range ops {
 		anchoredOp, err := model.GetAnchoredOperation(op)
 		if err != nil {
@@ -115,7 +115,7 @@ func createAnchoredOperations(ops []*model.Operation) ([]*batch.AnchoredOperatio
 	return anchoredOps, nil
 }
 
-func (h *OperationProvider) assembleBatchOperations(af *models.AnchorFile, mf *models.MapFile, cf *models.ChunkFile, txn *txn.SidetreeTxn) ([]*batch.AnchoredOperation, error) {
+func (h *OperationProvider) assembleBatchOperations(af *models.AnchorFile, mf *models.MapFile, cf *models.ChunkFile, txn *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error) {
 	anchorOps, err := h.parseAnchorOperations(af, txn)
 	if err != nil {
 		return nil, fmt.Errorf("parse anchor operations: %s", err.Error())
@@ -272,7 +272,7 @@ func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *tx
 		}
 
 		create := &model.Operation{
-			Type:         batch.OperationTypeCreate,
+			Type:         operation.TypeCreate,
 			UniqueSuffix: suffix,
 			SuffixData:   op.SuffixData,
 		}
@@ -284,7 +284,7 @@ func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *tx
 	var recoverOps []*model.Operation
 	for _, op := range af.Operations.Recover {
 		recover := &model.Operation{
-			Type:         batch.OperationTypeRecover,
+			Type:         operation.TypeRecover,
 			UniqueSuffix: op.DidSuffix,
 			SignedData:   op.SignedData,
 		}
@@ -296,7 +296,7 @@ func (h *OperationProvider) parseAnchorOperations(af *models.AnchorFile, txn *tx
 	var deactivateOps []*model.Operation
 	for _, op := range af.Operations.Deactivate {
 		deactivate := &model.Operation{
-			Type:         batch.OperationTypeDeactivate,
+			Type:         operation.TypeDeactivate,
 			UniqueSuffix: op.DidSuffix,
 			SignedData:   op.SignedData,
 		}
@@ -325,7 +325,7 @@ func parseMapOperations(mf *models.MapFile) *MapOperations {
 	var updateOps []*model.Operation
 	for _, op := range mf.Operations.Update {
 		update := &model.Operation{
-			Type:         batch.OperationTypeUpdate,
+			Type:         operation.TypeUpdate,
 			UniqueSuffix: op.DidSuffix,
 			SignedData:   op.SignedData,
 		}
@@ -337,7 +337,7 @@ func parseMapOperations(mf *models.MapFile) *MapOperations {
 	return &MapOperations{Update: updateOps, Suffixes: suffixes}
 }
 
-func getOperations(filter batch.OperationType, ops []*model.Operation) []*model.Operation {
+func getOperations(filter operation.Type, ops []*model.Operation) []*model.Operation {
 	var result []*model.Operation
 	for _, op := range ops {
 		if op.Type == filter {

--- a/pkg/versions/0_1/txnprovider/provider_test.go
+++ b/pkg/versions/0_1/txnprovider/provider_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/compression"
@@ -166,8 +166,8 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 	t.Run("success - deactivate only", func(t *testing.T) {
 		const deactivateOpsNum = 2
 
-		var ops []*batch.OperationInfo
-		ops = append(ops, generateOperations(deactivateOpsNum, batch.OperationTypeDeactivate)...)
+		var ops []*operation.QueuedOperation
+		ops = append(ops, generateOperations(deactivateOpsNum, operation.TypeDeactivate)...)
 
 		cas := mocks.NewMockCasClient(nil)
 		handler := NewOperationHandler(pc.Protocol, cas, cp, operationparser.New(pc.Protocol))
@@ -371,13 +371,13 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		provider := NewOperationProvider(p, operationparser.New(p), nil, nil)
 
-		createOp, err := generateOperation(1, batch.OperationTypeCreate)
+		createOp, err := generateOperation(1, operation.TypeCreate)
 		require.NoError(t, err)
 
-		updateOp, err := generateOperation(2, batch.OperationTypeUpdate)
+		updateOp, err := generateOperation(2, operation.TypeUpdate)
 		require.NoError(t, err)
 
-		deactivateOp, err := generateOperation(3, batch.OperationTypeDeactivate)
+		deactivateOp, err := generateOperation(3, operation.TypeDeactivate)
 		require.NoError(t, err)
 
 		af := &models.AnchorFile{
@@ -405,13 +405,13 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 	t.Run("error - anchor, map, chunk file operation number mismatch", func(t *testing.T) {
 		provider := NewOperationProvider(p, operationparser.New(p), nil, nil)
 
-		createOp, err := generateOperation(1, batch.OperationTypeCreate)
+		createOp, err := generateOperation(1, operation.TypeCreate)
 		require.NoError(t, err)
 
-		updateOp, err := generateOperation(2, batch.OperationTypeUpdate)
+		updateOp, err := generateOperation(2, operation.TypeUpdate)
 		require.NoError(t, err)
 
-		deactivateOp, err := generateOperation(3, batch.OperationTypeDeactivate)
+		deactivateOp, err := generateOperation(3, operation.TypeDeactivate)
 		require.NoError(t, err)
 
 		af := &models.AnchorFile{
@@ -444,13 +444,13 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 	t.Run("error - duplicate operations found in anchor/map files", func(t *testing.T) {
 		provider := NewOperationProvider(p, operationparser.New(p), nil, nil)
 
-		createOp, err := generateOperation(1, batch.OperationTypeCreate)
+		createOp, err := generateOperation(1, operation.TypeCreate)
 		require.NoError(t, err)
 
-		updateOp, err := generateOperation(2, batch.OperationTypeUpdate)
+		updateOp, err := generateOperation(2, operation.TypeUpdate)
 		require.NoError(t, err)
 
-		deactivateOp, err := generateOperation(3, batch.OperationTypeDeactivate)
+		deactivateOp, err := generateOperation(3, operation.TypeDeactivate)
 		require.NoError(t, err)
 
 		af := &models.AnchorFile{
@@ -486,7 +486,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 	t.Run("error - invalid delta", func(t *testing.T) {
 		provider := NewOperationProvider(p, operationparser.New(p), nil, nil)
 
-		createOp, err := generateOperation(1, batch.OperationTypeCreate)
+		createOp, err := generateOperation(1, operation.TypeCreate)
 		require.NoError(t, err)
 
 		af := &models.AnchorFile{


### PR DESCRIPTION
Batch folder currently contains various operation models:
- model for parsing request
- model for adding to the queue
- model for storing

It is renamed to reflect its usage - batch is legacy name.

Closes #455

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>