### PR TITLE
feat: Add core, provisional proof files

### DIFF
--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -492,7 +492,7 @@ func generateOperation(num int) (*operation.QueuedOperation, error) {
 
 	op := &operation.QueuedOperation{
 		Namespace:       "did:sidetree",
-		UniqueSuffix:    string(num),
+		UniqueSuffix:    fmt.Sprint(num),
 		OperationBuffer: request,
 	}
 

--- a/pkg/versions/0_1/txnprovider/models/anchor.go
+++ b/pkg/versions/0_1/txnprovider/models/anchor.go
@@ -15,8 +15,15 @@ import (
 
 // AnchorFile defines the schema of an anchor file.
 type AnchorFile struct {
+
 	// MapFileURI is map file URI
 	MapFileURI string `json:"mapFileUri,omitempty"`
+
+	// CoreProofFileURI is core proof file URI
+	CoreProofFileURI string `json:"coreProofFileUri,omitempty"`
+
+	// ProvisionalProofFileURI is provisional proof file URI
+	ProvisionalProofFileURI string `json:"provisionalProofFileUri,omitempty"`
 
 	// Operations contain proving data for create, recover and deactivate operations.
 	Operations Operations `json:"operations"`
@@ -26,15 +33,6 @@ type AnchorFile struct {
 type CreateOperation struct {
 	// SuffixData object
 	SuffixData *model.SuffixDataModel `json:"suffixData"`
-}
-
-// SignedOperation contains operation proving data.
-type SignedOperation struct {
-	// DidSuffix is the suffix of the DID
-	DidSuffix string `json:"didSuffix"`
-
-	// SignedData is compact JWS
-	SignedData string `json:"signedData"`
 }
 
 // Operations contains operation proving data.
@@ -47,9 +45,11 @@ type Operations struct {
 
 // CreateAnchorFile will create anchor file from provided operations.
 // returns anchor file model.
-func CreateAnchorFile(mapAddress string, ops []*model.Operation) *AnchorFile {
+func CreateAnchorFile(coreProofURI, provisionalProofURI, mapURI string, ops []*model.Operation) *AnchorFile {
 	return &AnchorFile{
-		MapFileURI: mapAddress,
+		CoreProofFileURI:        coreProofURI,
+		ProvisionalProofFileURI: provisionalProofURI,
+		MapFileURI:              mapURI,
 		Operations: Operations{
 			Create:     getCreateOperations(ops),
 			Recover:    getSignedOperations(operation.TypeRecover, ops),

--- a/pkg/versions/0_1/txnprovider/models/anchor_test.go
+++ b/pkg/versions/0_1/txnprovider/models/anchor_test.go
@@ -25,7 +25,7 @@ func TestCreateAnchorFile(t *testing.T) {
 
 	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-	af := CreateAnchorFile("address", ops)
+	af := CreateAnchorFile("coreURI", "provisionalURI", "mapURI", ops)
 	require.NotNil(t, af)
 	require.Equal(t, createOpsNum, len(af.Operations.Create))
 	require.Equal(t, 0, len(af.Operations.Update))
@@ -41,7 +41,7 @@ func TestParseAnchorFile(t *testing.T) {
 
 	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-	model := CreateAnchorFile("address", ops)
+	model := CreateAnchorFile("coreURI", "provisionalURI", "mapURI", ops)
 
 	bytes, err := json.Marshal(model)
 	require.NoError(t, err)

--- a/pkg/versions/0_1/txnprovider/models/coreproof.go
+++ b/pkg/versions/0_1/txnprovider/models/coreproof.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
+)
+
+// CoreProofFile defines the schema for core proof file. Core proof file contains the cryptographic proofs
+// (signatures, hashes, etc.) that form the signature-chained backbone for the state lineages of all DIDs in the system.
+// The cryptographic proofs present in core proof file also link a given operation to its verbose state data,
+// which resides in a related chunk file.
+type CoreProofFile struct {
+
+	// Operations contain proving data for recover and deactivate operations.
+	Operations CoreProofOperations `json:"operations"`
+}
+
+// CoreProofOperations contains proving data for any recover and deactivate operations to be included in a batch.
+type CoreProofOperations struct {
+	Recover    []SignedOperation `json:"recover,omitempty"`
+	Deactivate []SignedOperation `json:"deactivate,omitempty"`
+}
+
+// CreateCoreProofFile will create core proof file from provided operations.
+// returns core proof file model.
+func CreateCoreProofFile(recoverOps, deactivateOps []*model.Operation) *CoreProofFile {
+	return &CoreProofFile{
+		Operations: CoreProofOperations{
+			Recover:    getSignedOperations(operation.TypeRecover, recoverOps),
+			Deactivate: getSignedOperations(operation.TypeDeactivate, deactivateOps),
+		},
+	}
+}
+
+// ParseCoreProofFile will parse core proof model from content.
+func ParseCoreProofFile(content []byte) (*CoreProofFile, error) {
+	file := &CoreProofFile{}
+	err := json.Unmarshal(content, file)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to unmarshal core proof file")
+	}
+
+	return file, nil
+}

--- a/pkg/versions/0_1/txnprovider/models/coreproof_test.go
+++ b/pkg/versions/0_1/txnprovider/models/coreproof_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+)
+
+func TestCreateCoreProofFile(t *testing.T) {
+	const deactivateOpsNum = 2
+	const recoverOpsNum = 2
+
+	recoverOps := generateOperations(recoverOpsNum, operation.TypeRecover)
+	deactivateOps := generateOperations(deactivateOpsNum, operation.TypeDeactivate)
+
+	af := CreateCoreProofFile(recoverOps, deactivateOps)
+	require.NotNil(t, af)
+	require.Equal(t, deactivateOpsNum, len(af.Operations.Deactivate))
+	require.Equal(t, recoverOpsNum, len(af.Operations.Recover))
+}
+
+func TestParseCoreProofFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		const deactivateOpsNum = 3
+		const recoverOpsNum = 1
+
+		recoverOps := generateOperations(recoverOpsNum, operation.TypeRecover)
+		deactivateOps := generateOperations(deactivateOpsNum, operation.TypeDeactivate)
+
+		model := CreateCoreProofFile(recoverOps, deactivateOps)
+
+		bytes, err := json.Marshal(model)
+		require.NoError(t, err)
+
+		parsed, err := ParseCoreProofFile(bytes)
+		require.NoError(t, err)
+
+		require.Equal(t, deactivateOpsNum, len(parsed.Operations.Deactivate))
+		require.Equal(t, recoverOpsNum, len(parsed.Operations.Recover))
+	})
+
+	t.Run("error - unmarshal error", func(t *testing.T) {
+		parsed, err := ParseCoreProofFile([]byte("not JSON"))
+		require.Error(t, err)
+		require.Nil(t, parsed)
+		require.Contains(t, err.Error(), "failed to unmarshal core proof file")
+	})
+}

--- a/pkg/versions/0_1/txnprovider/models/map.go
+++ b/pkg/versions/0_1/txnprovider/models/map.go
@@ -56,22 +56,6 @@ func getChunks(uris []string) []Chunk {
 	return chunks
 }
 
-func getSignedOperations(filter operation.Type, ops []*model.Operation) []SignedOperation {
-	var result []SignedOperation
-	for _, op := range ops {
-		if op.Type == filter {
-			upd := SignedOperation{
-				DidSuffix:  op.UniqueSuffix,
-				SignedData: op.SignedData,
-			}
-
-			result = append(result, upd)
-		}
-	}
-
-	return result
-}
-
 //  get map file struct from bytes.
 var getMapFile = func(bytes []byte) (*MapFile, error) {
 	return unmarshalMapFile(bytes)

--- a/pkg/versions/0_1/txnprovider/models/provisionalproof.go
+++ b/pkg/versions/0_1/txnprovider/models/provisionalproof.go
@@ -1,0 +1,50 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
+)
+
+// ProvisionalProofFile defines the schema for provisional proof file. Provisional proof file contains the cryptographic
+// proofs (signatures, hashes, etc.) for all the (eventually) prunable DID operations in the system. The cryptographic
+// proofs present in provisional proof file also link a given operation to its verbose state data, which resides
+// in a related chunk file.
+type ProvisionalProofFile struct {
+	Operations ProvisionalProofOperations `json:"operations,omitempty"`
+}
+
+// ProvisionalProofOperations contains proving data for any update operation to be included in the batch.
+type ProvisionalProofOperations struct {
+	Update []SignedOperation `json:"update,omitempty"`
+}
+
+// CreateProvisionalProofFile will create provisional proof file model from operations.
+// returns provisional proof file model.
+func CreateProvisionalProofFile(updateOps []*model.Operation) *ProvisionalProofFile {
+	return &ProvisionalProofFile{
+		Operations: ProvisionalProofOperations{
+			Update: getSignedOperations(operation.TypeUpdate, updateOps),
+		},
+	}
+}
+
+// ParseProvisionalProofFile will parse provisional proof file model from content.
+func ParseProvisionalProofFile(content []byte) (*ProvisionalProofFile, error) {
+	file := &ProvisionalProofFile{}
+	err := json.Unmarshal(content, file)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to unmarshal provisional proof file")
+	}
+
+	return file, nil
+}

--- a/pkg/versions/0_1/txnprovider/models/provisionalproof_test.go
+++ b/pkg/versions/0_1/txnprovider/models/provisionalproof_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+)
+
+func TestCreateProvisionalProofFileFile(t *testing.T) {
+	const updateOpsNum = 2
+
+	updateOps := generateOperations(updateOpsNum, operation.TypeUpdate)
+
+	batch := CreateProvisionalProofFile(updateOps)
+	require.NotNil(t, batch)
+	require.Equal(t, updateOpsNum, len(batch.Operations.Update))
+}
+
+func TestParseProvisionalProofFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		const updateOpsNum = 2
+
+		updateOps := generateOperations(updateOpsNum, operation.TypeUpdate)
+
+		model := CreateProvisionalProofFile(updateOps)
+
+		bytes, err := json.Marshal(model)
+		require.NoError(t, err)
+
+		parsed, err := ParseProvisionalProofFile(bytes)
+		require.NoError(t, err)
+
+		require.Equal(t, updateOpsNum, len(parsed.Operations.Update))
+	})
+
+	t.Run("error - unmarshal error", func(t *testing.T) {
+		parsed, err := ParseProvisionalProofFile([]byte("not JSON"))
+		require.Error(t, err)
+		require.Nil(t, parsed)
+		require.Contains(t, err.Error(), "failed to unmarshal provisional proof file")
+	})
+}

--- a/pkg/versions/0_1/txnprovider/models/signed.go
+++ b/pkg/versions/0_1/txnprovider/models/signed.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package models
+
+import (
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
+)
+
+// SignedOperation contains operation proving data.
+type SignedOperation struct {
+	// DidSuffix is the suffix of the DID
+	DidSuffix string `json:"didSuffix"`
+
+	// SignedData is compact JWS
+	SignedData string `json:"signedData"`
+}
+
+// TODO: Remove type check when SIP-1 fully completed.
+func getSignedOperations(filter operation.Type, ops []*model.Operation) []SignedOperation {
+	var result []SignedOperation
+	for _, op := range ops {
+		if op.Type == filter {
+			upd := SignedOperation{
+				DidSuffix:  op.UniqueSuffix,
+				SignedData: op.SignedData,
+			}
+
+			result = append(result, upd)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
Included:
- core and provisional proof file models
- writing of proof files to CAS

Closes #459

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>