### PR TITLE
feat: Handle purposes as per latest spec

### DIFF
--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -287,7 +287,7 @@ func TestDocumentHandler_ResolveDocument_InitialDocumentNotValid(t *testing.T) {
 	require.NotNil(t, dochandler)
 	defer cleanup()
 
-	createReq, err := getCreateRequestWithDoc(invalidDocNoPurpose)
+	createReq, err := getCreateRequestWithDoc(invalidDocNoKeyType)
 	require.NoError(t, err)
 
 	createOp, err := getCreateOperationWithInitialState(createReq.SuffixData, createReq.Delta)
@@ -306,7 +306,7 @@ func TestDocumentHandler_ResolveDocument_InitialDocumentNotValid(t *testing.T) {
 	result, err := dochandler.ResolveDocument(docID + longFormPart)
 	require.Error(t, err)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "missing purpose")
+	require.Contains(t, err.Error(), "bad request: key 'type' is required for public key")
 }
 
 func TestTransformToExternalDocument(t *testing.T) {
@@ -476,7 +476,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["authentication"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -486,11 +486,9 @@ const validDoc = `{
 	}]
 }`
 
-const invalidDocNoPurpose = `{
+const invalidDocNoKeyType = `{
 	"publicKey": [{
 		  "id": "key1",
-		  "type": "JsonWebKey2020",	
-		  "purposes": [],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -607,7 +605,7 @@ func getUpdateOperation() *operation.Operation {
 }
 
 // test value taken from reference implementation.
-const interopResolveDidWithInitialState = "did:sidetree:EiA5vyaRzJIxbkuZbvwEXiC__u8ieFx50TAAo98tBzCuyA:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJzaWduaW5nS2V5IiwicHVibGljS2V5SndrIjp7ImNydiI6InNlY3AyNTZrMSIsImt0eSI6IkVDIiwieCI6ImRTYUJSTnRHdnlqMjJlOVQ0TjVMajdYdjd1eGlQTHdTRnhraHYwNC1tZzAiLCJ5IjoieDY3U0lmaURlMWxOdjhvS1MxeGNCb29iLTlsTm1hM2FmbzFlcmQzNXBnZyJ9LCJwdXJwb3NlcyI6WyJ2ZXJpZmljYXRpb25NZXRob2QiLCJhdXRoZW50aWNhdGlvbiIsImFzc2VydGlvbk1ldGhvZCIsImNhcGFiaWxpdHlJbnZvY2F0aW9uIiwiY2FwYWJpbGl0eURlbGVnYXRpb24iLCJrZXlBZ3JlZW1lbnQiXSwidHlwZSI6IkVjZHNhU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOSJ9XSwic2VydmljZXMiOlt7ImlkIjoic2VydmljZUlkMTIzIiwic2VydmljZUVuZHBvaW50IjoiaHR0cHM6Ly93d3cudXJsLmNvbSIsInR5cGUiOiJzb21lVHlwZSJ9XX19XSwidXBkYXRlQ29tbWl0bWVudCI6IkVpQXZUSVQtMFhCV1hhcnBqdk1QUGhaaTNjNHNVMUNpX3JPelBEN1c1djhTaHcifSwic3VmZml4RGF0YSI6eyJkZWx0YUhhc2giOiJFaUJPbWtQNmtuN3lqdDBWb2NtY1B1OU9RT3NaaTE5OUV2aC14QjQ4ZWJ1YlFBIiwicmVjb3ZlcnlDb21taXRtZW50IjoiRWlBQVpKWXJ5Mjl2SUNrd21zbzhGTDkyV0FJU01BaHNMOHhrQ204ZFlWbnFfdyJ9fQ"
+const interopResolveDidWithInitialState = "did:sidetree:EiDyOQbbZAa3aiRzeCkV7LOx3SERjjH93EXoIM3UoN4oWg:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJwdWJsaWNLZXlNb2RlbDFJZCIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJ0WFNLQl9ydWJYUzdzQ2pYcXVwVkpFelRjVzNNc2ptRXZxMVlwWG45NlpnIiwieSI6ImRPaWNYcWJqRnhvR0otSzAtR0oxa0hZSnFpY19EX09NdVV3a1E3T2w2bmsifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iLCJrZXlBZ3JlZW1lbnQiXSwidHlwZSI6IkVjZHNhU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOSJ9XSwic2VydmljZXMiOlt7ImlkIjoic2VydmljZTFJZCIsInNlcnZpY2VFbmRwb2ludCI6Imh0dHA6Ly93d3cuc2VydmljZTEuY29tIiwidHlwZSI6InNlcnZpY2UxVHlwZSJ9XX19XSwidXBkYXRlQ29tbWl0bWVudCI6IkVpREtJa3dxTzY5SVBHM3BPbEhrZGI4Nm5ZdDBhTnhTSFp1MnItYmhFem5qZEEifSwic3VmZml4RGF0YSI6eyJkZWx0YUhhc2giOiJFaUNmRFdSbllsY0Q5RUdBM2RfNVoxQUh1LWlZcU1iSjluZmlxZHo1UzhWRGJnIiwicmVjb3ZlcnlDb21taXRtZW50IjoiRWlCZk9aZE10VTZPQnc4UGs4NzlRdFotMkotOUZiYmpTWnlvYUFfYnFENHpoQSJ9fQ"
 
 func newMockProtocolClient() *mocks.MockProtocolClient {
 	pc := mocks.NewMockProtocolClient()

--- a/pkg/dochandler/transformer/didtransformer/testdata/doc.json
+++ b/pkg/dochandler/transformer/didtransformer/testdata/doc.json
@@ -3,7 +3,7 @@
     {
       "id": "master",
       "type": "EcdsaSecp256k1VerificationKey2019",
-      "purposes": ["verificationMethod", "authentication", "assertionMethod", "keyAgreement", "capabilityDelegation", "capabilityInvocation"],
+      "purposes": ["authentication", "assertionMethod", "keyAgreement", "capabilityDelegation", "capabilityInvocation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -12,18 +12,7 @@
       }
     },
     {
-      "id": "dual-auth-gen",
-      "type": "JsonWebKey2020",
-      "purposes": ["authentication", "verificationMethod"],
-      "publicKeyJwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "auth-only",
+      "id": "auth",
       "type": "JsonWebKey2020",
       "purposes": ["authentication"],
       "publicKeyJwk": {
@@ -34,18 +23,7 @@
       }
     },
     {
-      "id": "dual-assertion-gen",
-      "type": "JsonWebKey2020",
-      "purposes": ["assertionMethod", "verificationMethod"],
-      "publicKeyJwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "assertion-only",
+      "id": "assertion",
       "type": "JsonWebKey2020",
       "purposes": ["assertionMethod"],
       "publicKeyJwk": {
@@ -56,18 +34,7 @@
       }
     },
     {
-      "id": "dual-agreement-gen",
-      "type": "JsonWebKey2020",
-      "purposes": ["keyAgreement", "verificationMethod"],
-      "publicKeyJwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "agreement-only",
+      "id": "agreement",
       "type": "JsonWebKey2020",
       "purposes": ["keyAgreement"],
       "publicKeyJwk": {
@@ -78,18 +45,7 @@
       }
     },
     {
-      "id": "dual-invocation-gen",
-      "type": "JsonWebKey2020",
-      "purposes": ["capabilityInvocation", "verificationMethod"],
-      "publicKeyJwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "invocation-only",
+      "id": "invocation",
       "type": "JsonWebKey2020",
       "purposes": ["capabilityInvocation"],
       "publicKeyJwk": {
@@ -100,18 +56,7 @@
       }
     },
     {
-      "id": "dual-delegation-gen",
-      "type": "JsonWebKey2020",
-      "purposes": ["capabilityDelegation", "verificationMethod"],
-      "publicKeyJwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "delegation-only",
+      "id": "delegation",
       "type": "JsonWebKey2020",
       "purposes": ["capabilityDelegation"],
       "publicKeyJwk": {
@@ -122,9 +67,9 @@
       }
     },
     {
-      "id": "general-only",
+      "id": "general",
       "type": "JsonWebKey2020",
-      "purposes": ["verificationMethod"],
+      "purposes": [],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -23,6 +23,9 @@ const (
 	// PublicKeyProperty defines key for public key property.
 	PublicKeyProperty = "publicKey"
 
+	// VerificationMethodProperty defines key for verification method.
+	VerificationMethodProperty = "verificationMethod"
+
 	// AuthenticationProperty defines key for authentication property.
 	AuthenticationProperty = "authentication"
 
@@ -55,6 +58,11 @@ func (doc DIDDocument) Context() []interface{} {
 // PublicKeys are used for digital signatures, encryption and other cryptographic operations.
 func (doc DIDDocument) PublicKeys() []PublicKey {
 	return ParsePublicKeys(doc[PublicKeyProperty])
+}
+
+// VerificationMethods (formerly public keys) are used for digital signatures, encryption and other cryptographic operations.
+func (doc DIDDocument) VerificationMethods() []PublicKey {
+	return ParsePublicKeys(doc[VerificationMethodProperty])
 }
 
 // ParsePublicKeys is helper function for parsing public keys.
@@ -113,28 +121,28 @@ func (doc DIDDocument) JSONLdObject() map[string]interface{} {
 	return doc
 }
 
-// Authentication returns authentication array (mixture of strings and objects).
-func (doc DIDDocument) Authentication() []interface{} {
+// Authentications returns authentication array (mixture of strings and objects).
+func (doc DIDDocument) Authentications() []interface{} {
 	return interfaceArray(doc[AuthenticationProperty])
 }
 
-// AssertionMethod returns assertion method array (mixture of strings and objects).
-func (doc DIDDocument) AssertionMethod() []interface{} {
+// AssertionMethods returns assertion method array (mixture of strings and objects).
+func (doc DIDDocument) AssertionMethods() []interface{} {
 	return interfaceArray(doc[AssertionMethodProperty])
 }
 
-// AgreementKey returns agreement method array (mixture of strings and objects).
-func (doc DIDDocument) AgreementKey() []interface{} {
+// AgreementKeys returns agreement method array (mixture of strings and objects).
+func (doc DIDDocument) AgreementKeys() []interface{} {
 	return interfaceArray(doc[KeyAgreementProperty])
 }
 
-// DelegationKey returns delegation method array (mixture of strings and objects).
-func (doc DIDDocument) DelegationKey() []interface{} {
+// DelegationKeys returns delegation method array (mixture of strings and objects).
+func (doc DIDDocument) DelegationKeys() []interface{} {
 	return interfaceArray(doc[DelegationKeyProperty])
 }
 
-// InvocationKey returns invocation method array (mixture of strings and objects).
-func (doc DIDDocument) InvocationKey() []interface{} {
+// InvocationKeys returns invocation method array (mixture of strings and objects).
+func (doc DIDDocument) InvocationKeys() []interface{} {
 	return interfaceArray(doc[InvocationKeyProperty])
 }
 

--- a/pkg/document/diddocument_test.go
+++ b/pkg/document/diddocument_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestValid(t *testing.T) {
-	r := reader(t, "testdata/doc.json")
+	r := reader(t, "testdata/pk-doc.json")
 
 	doc, err := DIDDocumentFromReader(r)
 	require.Nil(t, err)
@@ -25,7 +25,7 @@ func TestValid(t *testing.T) {
 		{
 			"id":       "key1",
 			"type":     "JsonWebKey2020",
-			"purposes": []interface{}{"authentication", "verificationMethod"},
+			"purposes": []interface{}{"authentication"},
 			"publicKeyJwk": map[string]interface{}{
 				"kty": "EC",
 				"crv": "P-256K",
@@ -51,7 +51,31 @@ func TestValid(t *testing.T) {
 	require.NotNil(t, jsonld)
 
 	require.Empty(t, doc.Context())
-	require.Equal(t, "whatever", doc.Authentication()[0])
+	require.Equal(t, "whatever", doc.Authentications()[0])
+}
+
+func TestValidWithVerificationMethods(t *testing.T) {
+	r := reader(t, "testdata/vm-doc.json")
+
+	doc, err := DIDDocumentFromReader(r)
+	require.Nil(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, "", doc.ID())
+
+	publicKeys := doc.VerificationMethods()
+	require.Equal(t, []PublicKey{
+		{
+			"id":       "key1",
+			"type":     "JsonWebKey2020",
+			"purposes": []interface{}{"authentication"},
+			"publicKeyJwk": map[string]interface{}{
+				"kty": "EC",
+				"crv": "P-256K",
+				"x":   "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+				"y":   "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc",
+			},
+		},
+	}, publicKeys)
 }
 
 func TestEmptyDoc(t *testing.T) {
@@ -61,26 +85,13 @@ func TestEmptyDoc(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, doc)
 
-	publicKeys := doc.PublicKeys()
-	require.Equal(t, 0, len(publicKeys))
-
-	services := doc.Services()
-	require.Equal(t, 0, len(services))
-
-	authentication := doc.Authentication()
-	require.Equal(t, 0, len(authentication))
-
-	assertionMethod := doc.AssertionMethod()
-	require.Equal(t, 0, len(assertionMethod))
-
-	agreementKey := doc.AgreementKey()
-	require.Equal(t, 0, len(agreementKey))
-
-	delegationKey := doc.DelegationKey()
-	require.Equal(t, 0, len(delegationKey))
-
-	invocationKey := doc.InvocationKey()
-	require.Equal(t, 0, len(invocationKey))
+	require.Equal(t, 0, len(doc.PublicKeys()))
+	require.Equal(t, 0, len(doc.Services()))
+	require.Equal(t, 0, len(doc.Authentications()))
+	require.Equal(t, 0, len(doc.AssertionMethods()))
+	require.Equal(t, 0, len(doc.AgreementKeys()))
+	require.Equal(t, 0, len(doc.DelegationKeys()))
+	require.Equal(t, 0, len(doc.InvocationKeys()))
 }
 
 func TestInvalidLists(t *testing.T) {

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestFromBytes(t *testing.T) {
-	r := reader(t, "testdata/doc.json")
+	r := reader(t, "testdata/pk-doc.json")
 
 	data, err := ioutil.ReadAll(r)
 	require.Nil(t, err)

--- a/pkg/document/publickey.go
+++ b/pkg/document/publickey.go
@@ -38,8 +38,6 @@ const (
 	KeyPurposeCapabilityDelegation = "capabilityDelegation"
 	// KeyPurposeCapabilityInvocation defines key purpose as invocation key.
 	KeyPurposeCapabilityInvocation = "capabilityInvocation"
-	// KeyPurposeVerificationMethod defines key purpose as verification(general key).
-	KeyPurposeVerificationMethod = "verificationMethod"
 )
 
 // PublicKey must include id and type properties, and exactly one value property.

--- a/pkg/document/testdata/pk-doc.json
+++ b/pkg/document/testdata/pk-doc.json
@@ -3,7 +3,7 @@
     {
       "id": "key1",
       "type": "JsonWebKey2020",
-      "purposes": ["authentication", "verificationMethod"],
+      "purposes": ["authentication"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/document/testdata/vm-doc.json
+++ b/pkg/document/testdata/vm-doc.json
@@ -1,0 +1,15 @@
+{
+  "verificationMethod": [
+    {
+      "id": "key1",
+      "type": "JsonWebKey2020",
+      "purposes": ["authentication"],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "P-256K",
+        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
+        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
+      }
+    }
+  ]
+}

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -426,7 +426,7 @@ const addPublicKeysPatch = `{
 	"publicKeys": [{
 		"id": "key1",
 		"type": "JsonWebKey2020",
-		"purposes": ["verificationMethod"],
+		"purposes": ["assertionMethod"],
 		"publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -439,7 +439,6 @@ const addPublicKeysPatch = `{
 const testAddPublicKeys = `[{
 	"id": "key1",
 	"type": "JsonWebKey2020",
-	"purposes": ["verificationMethod"],
 	"publicKeyJwk": {
 		"kty": "EC",
 		"crv": "P-256K",
@@ -491,7 +490,7 @@ const testDoc = `{
 	"publicKey": [{
 		"id": "key1",
 		"type": "JsonWebKey2020",
-		"purposes": ["verificationMethod"],
+		"purposes": ["authentication"],
 		"publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1221,7 +1221,6 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -1235,7 +1234,6 @@ const recoveredDocTemplate = `{
 	"publicKey": [{
 		  "id": "recovered%s",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -158,7 +158,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["assertionMethod"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -267,7 +267,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["authentication"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -281,7 +281,7 @@ const recoverDoc = `{
 	"publicKey": [{
 		"id": "recoverKey",
 		"type": "JsonWebKey2020",
-		"purposes": ["verificationMethod"],
+		"purposes": ["assertionMethod"],
 		"publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/versions/0_1/client/create_test.go
+++ b/pkg/versions/0_1/client/create_test.go
@@ -125,7 +125,7 @@ func TestNewCreateRequest(t *testing.T) {
 const addKeys = `[{
 	"id": "test",
 	"type": "JsonWebKey2020",
-	"purposes": ["verificationMethod"],
+	"purposes": ["authentication"],
 	"publicKeyJwk": {
 		"kty": "EC",
 		"crv": "P-256K",

--- a/pkg/versions/0_1/doccomposer/composer_test.go
+++ b/pkg/versions/0_1/doccomposer/composer_test.go
@@ -374,7 +374,7 @@ const testDoc = `{
 		{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["assertionMethod"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -385,7 +385,7 @@ const testDoc = `{
 		{
 		  "id": "key2",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["authentication"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -411,7 +411,6 @@ const testDoc = `{
 const addKeys = `[{
 		  "id": "key3",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -423,7 +422,7 @@ const addKeys = `[{
 const updateExistingKey = `[{
 	"id": "key2",
 	"type": "JsonWebKey2020",
-	"purposes": ["verificationMethod"],
+	"purposes": ["assertionMethod"],
 	"publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/versions/0_1/docvalidator/didvalidator/testdata/doc.json
+++ b/pkg/versions/0_1/docvalidator/didvalidator/testdata/doc.json
@@ -3,7 +3,7 @@
     {
       "id": "master",
       "type": "EcdsaSecp256k1VerificationKey2019",
-      "purposes": ["verificationMethod", "authentication", "assertionMethod", "keyAgreement", "capabilityDelegation", "capabilityInvocation"],
+      "purposes": ["authentication", "assertionMethod", "keyAgreement", "capabilityDelegation", "capabilityInvocation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -14,7 +14,7 @@
     {
       "id": "dual-auth-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["authentication", "verificationMethod"],
+      "purposes": ["authentication"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -36,7 +36,7 @@
     {
       "id": "dual-assertion-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["assertionMethod", "verificationMethod"],
+      "purposes": ["assertionMethod"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -58,7 +58,7 @@
     {
       "id": "dual-agreement-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["keyAgreement", "verificationMethod"],
+      "purposes": ["keyAgreement"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -80,7 +80,7 @@
     {
       "id": "dual-invocation-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["capabilityInvocation", "verificationMethod"],
+      "purposes": ["capabilityInvocation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -102,7 +102,7 @@
     {
       "id": "dual-delegation-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["capabilityDelegation", "verificationMethod"],
+      "purposes": ["capabilityDelegation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -124,7 +124,6 @@
     {
       "id": "general-only",
       "type": "JsonWebKey2020",
-      "purposes": ["verificationMethod"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/pkg/versions/0_1/docvalidator/didvalidator/validator_test.go
+++ b/pkg/versions/0_1/docvalidator/didvalidator/validator_test.go
@@ -125,7 +125,6 @@ var (
 	"publicKey": [{
       	"id": "key-1",
       	"type": "JsonWebKey2020",
-      	"purposes": ["verificationMethod"],
 		"publicKeyJwk": {
 			"kty": "EC",
         	"crv": "P-256K",

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -1079,7 +1079,7 @@ const validDoc = `{
 	"publicKey": [{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["assertionMethod"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",
@@ -1093,7 +1093,7 @@ const recoveredDoc = `{
 	"publicKey": [{
 		  "id": "recovered",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["authentication"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -302,7 +302,7 @@ const validDoc = `{
 		{
 		  "id": "key1",
 		  "type": "JsonWebKey2020",
-		  "purposes": ["verificationMethod"],
+		  "purposes": ["authentication"],
 		  "publicKeyJwk": {
 			"kty": "EC",
 			"crv": "P-256K",

--- a/pkg/versions/0_1/operationparser/patchvalidator/addkeys_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/addkeys_test.go
@@ -41,7 +41,7 @@ const addPublicKeysPatch = `{
    "publicKeys": [{
       "id": "key1",
       "type": "JsonWebKey2020",
-      "purposes": ["verificationMethod"],
+      "purposes": ["assertionMethod"],
       "publicKeyJwk": {
          "kty": "EC",
          "crv": "P-256K",

--- a/pkg/versions/0_1/operationparser/patchvalidator/replace_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/replace_test.go
@@ -50,7 +50,7 @@ func TestValidateReplacePatch(t *testing.T) {
 		require.NotNil(t, p)
 
 		err = NewReplaceValidator().Validate(p)
-		require.Contains(t, err.Error(), "invalid number of public key properties")
+		require.Contains(t, err.Error(), "key 'type' is required for public key")
 	})
 	t.Run("error - services (missing endpoint)", func(t *testing.T) {
 		p, err := patch.NewReplacePatch(replaceDocInvalidServiceEndpoint)

--- a/pkg/versions/0_1/operationparser/patchvalidator/testdata/doc.json
+++ b/pkg/versions/0_1/operationparser/patchvalidator/testdata/doc.json
@@ -3,7 +3,7 @@
     {
       "id": "master",
       "type": "EcdsaSecp256k1VerificationKey2019",
-      "purposes": ["verificationMethod", "authentication", "assertionMethod", "keyAgreement", "capabilityDelegation", "capabilityInvocation"],
+      "purposes": ["authentication", "assertionMethod", "keyAgreement", "capabilityDelegation", "capabilityInvocation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -14,7 +14,7 @@
     {
       "id": "dual-auth-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["authentication", "verificationMethod"],
+      "purposes": ["authentication"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -36,7 +36,7 @@
     {
       "id": "dual-assertion-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["assertionMethod", "verificationMethod"],
+      "purposes": ["assertionMethod"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -58,7 +58,7 @@
     {
       "id": "dual-agreement-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["keyAgreement", "verificationMethod"],
+      "purposes": ["keyAgreement"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -80,7 +80,7 @@
     {
       "id": "dual-invocation-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["capabilityInvocation", "verificationMethod"],
+      "purposes": ["capabilityInvocation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -102,7 +102,7 @@
     {
       "id": "dual-delegation-gen",
       "type": "JsonWebKey2020",
-      "purposes": ["capabilityDelegation", "verificationMethod"],
+      "purposes": ["capabilityDelegation"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",
@@ -124,7 +124,6 @@
     {
       "id": "general-only",
       "type": "JsonWebKey2020",
-      "purposes": ["verificationMethod"],
       "publicKeyJwk": {
         "kty": "EC",
         "crv": "P-256K",


### PR DESCRIPTION
During transformation:
- use 'verificationMethod' tag instead of 'publicKey' tag for external document
- verificationMethod is implied for any key - it should not be passed in as "purpose"
- keys can no longer be embedded in purpose sections such as "authentication" etc.
- keys are always placed in "verficationMethod"
- keys are referenced in purpose sections if "purpose" has been specified
- keys in purposes sections are now referenced by "full" id and not as "fragment"

Closes #462

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>