### PR TITLE
chore: SIP-1: Core and Provisional Index Files

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -35,12 +35,12 @@ type Protocol struct {
 	MaxOperationSize uint `json:"maxOperationSize"`
 	// CompressionAlgorithm is file compression algorithm.
 	CompressionAlgorithm string `json:"compressionAlgorithm"`
-	// MaxAnchorFileSize is maximum allowed size (in bytes) of anchor file stored in CAS.
-	MaxAnchorFileSize uint `json:"maxAnchorFileSize"`
+	// MaxCoreIndexFileSize is maximum allowed size (in bytes) of core index file stored in CAS.
+	MaxCoreIndexFileSize uint `json:"maxAnchorFileSize"`
 	// MaxProofFileSize is maximum allowed size (in bytes) of proof files stored in CAS.
 	MaxProofFileSize uint `json:"maxProofFileSize"`
-	// MaxMapFileSize is maximum allowed size (in bytes) of map file stored in CAS.
-	MaxMapFileSize uint `json:"maxMapFileSize"`
+	// MaxProvisionalIndexFileSize is maximum allowed size (in bytes) of provisional index file stored in CAS.
+	MaxProvisionalIndexFileSize uint `json:"maxProvisionalIndexFileSize"`
 	// MaxChunkFileSize is maximum allowed size (in bytes) of chunk file stored in CAS.
 	MaxChunkFileSize uint `json:"maxChunkFileSize"`
 	// Patches contains the list of allowed patches.
@@ -84,13 +84,13 @@ type DocumentComposer interface {
 	ApplyPatches(doc document.Document, patches []patch.Patch) (document.Document, error)
 }
 
-// OperationHandler defines an interface for creating chunks, map and anchor files.
+// OperationHandler defines an interface for creating batch files.
 type OperationHandler interface {
-	// GetTxnOperations operations will create relevant files, store them in CAS and return anchor string.
+	// GetTxnOperations operations will create relevant batch files, store them in CAS and return anchor string.
 	PrepareTxnFiles(ops []*operation.QueuedOperation) (string, error)
 }
 
-// OperationProvider retrieves the anchored operations for  the given sidetree transaction.
+// OperationProvider retrieves the anchored operations for the given Sidetree transaction.
 type OperationProvider interface {
 	GetTxnOperations(sidetreeTxn *txn.SidetreeTxn) ([]*operation.AnchoredOperation, error)
 }

--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -97,7 +97,7 @@ func TestStart(t *testing.T) {
 	require.Equal(t, 2, len(cf.Deltas))
 }
 
-func getBatchFiles(cc cas.Client, anchor string) (*models.AnchorFile, *models.MapFile, *models.ChunkFile, error) { //nolint: interfacer
+func getBatchFiles(cc cas.Client, anchor string) (*models.CoreIndexFile, *models.ProvisionalIndexFile, *models.ChunkFile, error) { //nolint: interfacer
 	bytes, err := cc.Read(anchor)
 	if err != nil {
 		return nil, nil, nil, err
@@ -110,13 +110,13 @@ func getBatchFiles(cc cas.Client, anchor string) (*models.AnchorFile, *models.Ma
 		return nil, nil, nil, err
 	}
 
-	var af models.AnchorFile
+	var af models.CoreIndexFile
 	err = json.Unmarshal(content, &af)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	bytes, err = cc.Read(af.MapFileURI)
+	bytes, err = cc.Read(af.ProvisionalIndexFileURI)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -126,7 +126,7 @@ func getBatchFiles(cc cas.Client, anchor string) (*models.AnchorFile, *models.Ma
 		return nil, nil, nil, err
 	}
 
-	var mf models.MapFile
+	var mf models.ProvisionalIndexFile
 	err = json.Unmarshal(content, &mf)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -42,18 +42,18 @@ type MockProtocolClient struct {
 func NewMockProtocolClient() *MockProtocolClient {
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:          0,
-		MultihashAlgorithm:   sha2_256,
-		MaxOperationCount:    2,
-		MaxOperationSize:     MaxOperationByteSize,
-		CompressionAlgorithm: "GZIP",
-		MaxChunkFileSize:     MaxBatchFileSize,
-		MaxMapFileSize:       MaxBatchFileSize,
-		MaxAnchorFileSize:    MaxBatchFileSize,
-		MaxProofFileSize:     MaxBatchFileSize,
-		SignatureAlgorithms:  []string{"EdDSA", "ES256"},
-		KeyAlgorithms:        []string{"Ed25519", "P-256"},
-		Patches:              []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		GenesisTime:                 0,
+		MultihashAlgorithm:          sha2_256,
+		MaxOperationCount:           2,
+		MaxOperationSize:            MaxOperationByteSize,
+		CompressionAlgorithm:        "GZIP",
+		MaxChunkFileSize:            MaxBatchFileSize,
+		MaxProvisionalIndexFileSize: MaxBatchFileSize,
+		MaxCoreIndexFileSize:        MaxBatchFileSize,
+		MaxProofFileSize:            MaxBatchFileSize,
+		SignatureAlgorithms:         []string{"EdDSA", "ES256"},
+		KeyAlgorithms:               []string{"Ed25519", "P-256"},
+		Patches:                     []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	latestVersion := GetProtocolVersion(latest)

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1263,17 +1263,17 @@ func newMockProtocolClient() *mocks.MockProtocolClient {
 
 	//nolint:gomnd
 	latest := protocol.Protocol{
-		GenesisTime:          100,
-		MultihashAlgorithm:   sha2_512,
-		MaxOperationCount:    2,
-		MaxOperationSize:     mocks.MaxOperationByteSize,
-		CompressionAlgorithm: "GZIP",
-		MaxChunkFileSize:     mocks.MaxBatchFileSize,
-		MaxMapFileSize:       mocks.MaxBatchFileSize,
-		MaxAnchorFileSize:    mocks.MaxBatchFileSize,
-		SignatureAlgorithms:  []string{"EdDSA", "ES256"},
-		KeyAlgorithms:        []string{"Ed25519", "P-256"},
-		Patches:              []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		GenesisTime:                 100,
+		MultihashAlgorithm:          sha2_512,
+		MaxOperationCount:           2,
+		MaxOperationSize:            mocks.MaxOperationByteSize,
+		CompressionAlgorithm:        "GZIP",
+		MaxChunkFileSize:            mocks.MaxBatchFileSize,
+		MaxProvisionalIndexFileSize: mocks.MaxBatchFileSize,
+		MaxCoreIndexFileSize:        mocks.MaxBatchFileSize,
+		SignatureAlgorithms:         []string{"EdDSA", "ES256"},
+		KeyAlgorithms:               []string{"Ed25519", "P-256"},
+		Patches:                     []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	latestVersion := mocks.GetProtocolVersion(latest)

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -43,18 +43,18 @@ const (
 
 var (
 	p = protocol.Protocol{
-		GenesisTime:          0,
-		MultihashAlgorithm:   sha2_256,
-		MaxOperationCount:    2,
-		MaxOperationSize:     1024,
-		CompressionAlgorithm: "GZIP",
-		MaxChunkFileSize:     1024,
-		MaxMapFileSize:       1024,
-		MaxAnchorFileSize:    1024,
-		MaxProofFileSize:     1024,
-		SignatureAlgorithms:  []string{"EdDSA", "ES256"},
-		KeyAlgorithms:        []string{"Ed25519", "P-256"},
-		Patches:              []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		GenesisTime:                 0,
+		MultihashAlgorithm:          sha2_256,
+		MaxOperationCount:           2,
+		MaxOperationSize:            1024,
+		CompressionAlgorithm:        "GZIP",
+		MaxChunkFileSize:            1024,
+		MaxProvisionalIndexFileSize: 1024,
+		MaxCoreIndexFileSize:        1024,
+		MaxProofFileSize:            1024,
+		SignatureAlgorithms:         []string{"EdDSA", "ES256"},
+		KeyAlgorithms:               []string{"Ed25519", "P-256"},
+		Patches:                     []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser = operationparser.New(p)

--- a/pkg/versions/0_1/txnprovider/models/anchor.go
+++ b/pkg/versions/0_1/txnprovider/models/anchor.go
@@ -9,24 +9,20 @@ package models
 import (
 	"encoding/json"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
-// AnchorFile defines the schema of an anchor file.
-type AnchorFile struct {
+// CoreIndexFile defines the schema of an core index file.
+type CoreIndexFile struct {
 
-	// MapFileURI is map file URI
-	MapFileURI string `json:"mapFileUri,omitempty"`
+	// ProvisionalIndexFileURI is provisional index file URI
+	ProvisionalIndexFileURI string `json:"provisionalIndexFileUri,omitempty"`
 
 	// CoreProofFileURI is core proof file URI
 	CoreProofFileURI string `json:"coreProofFileUri,omitempty"`
 
-	// ProvisionalProofFileURI is provisional proof file URI
-	ProvisionalProofFileURI string `json:"provisionalProofFileUri,omitempty"`
-
-	// Operations contain proving data for create, recover and deactivate operations.
-	Operations Operations `json:"operations"`
+	// CoreOperations contain proving data for create, recover and deactivate operations.
+	Operations CoreOperations `json:"operations"`
 }
 
 // CreateOperation contains create operation data.
@@ -35,61 +31,41 @@ type CreateOperation struct {
 	SuffixData *model.SuffixDataModel `json:"suffixData"`
 }
 
-// Operations contains operation proving data.
-type Operations struct {
+// CoreOperations contains operation proving data.
+type CoreOperations struct {
 	Create     []CreateOperation `json:"create,omitempty"`
-	Update     []SignedOperation `json:"update,omitempty"`
 	Recover    []SignedOperation `json:"recover,omitempty"`
 	Deactivate []SignedOperation `json:"deactivate,omitempty"`
 }
 
-// CreateAnchorFile will create anchor file from provided operations.
-// returns anchor file model.
-func CreateAnchorFile(coreProofURI, provisionalProofURI, mapURI string, ops []*model.Operation) *AnchorFile {
-	return &AnchorFile{
+// CreateCoreIndexFile will create core index file from provided operations.
+// returns core index file model.
+func CreateCoreIndexFile(coreProofURI, mapURI string, ops *SortedOperations) *CoreIndexFile {
+	return &CoreIndexFile{
 		CoreProofFileURI:        coreProofURI,
-		ProvisionalProofFileURI: provisionalProofURI,
-		MapFileURI:              mapURI,
-		Operations: Operations{
-			Create:     getCreateOperations(ops),
-			Recover:    getSignedOperations(operation.TypeRecover, ops),
-			Deactivate: getSignedOperations(operation.TypeDeactivate, ops),
+		ProvisionalIndexFileURI: mapURI,
+		Operations: CoreOperations{
+			Create:     assembleCreateOperations(ops.Create),
+			Recover:    getSignedOperations(ops.Recover),
+			Deactivate: getSignedOperations(ops.Deactivate),
 		},
 	}
 }
 
-func getCreateOperations(ops []*model.Operation) []CreateOperation {
+func assembleCreateOperations(createOps []*model.Operation) []CreateOperation {
 	var result []CreateOperation
-	for _, op := range ops {
-		if op.Type == operation.TypeCreate {
-			create := CreateOperation{SuffixData: op.SuffixData}
-
-			result = append(result, create)
-		}
+	for _, op := range createOps {
+		create := CreateOperation{SuffixData: op.SuffixData}
+		result = append(result, create)
 	}
 
 	return result
 }
 
-// ParseAnchorFile will parse anchor model from content.
-func ParseAnchorFile(content []byte) (*AnchorFile, error) {
-	af, err := getAnchorFile(content)
-	if err != nil {
-		return nil, err
-	}
-
-	return af, nil
-}
-
-// getAnchorFile creates new anchor file struct from bytes.
-var getAnchorFile = func(bytes []byte) (*AnchorFile, error) {
-	return unmarshalAnchorFile(bytes)
-}
-
-// unmarshalAnchorFile creates new anchor file struct from bytes.
-func unmarshalAnchorFile(bytes []byte) (*AnchorFile, error) {
-	file := &AnchorFile{}
-	err := json.Unmarshal(bytes, file)
+// ParseCoreIndexFile will parse anchor model from content.
+func ParseCoreIndexFile(content []byte) (*CoreIndexFile, error) {
+	file := &CoreIndexFile{}
+	err := json.Unmarshal(content, file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/versions/0_1/txnprovider/models/anchor_test.go
+++ b/pkg/versions/0_1/txnprovider/models/anchor_test.go
@@ -25,12 +25,11 @@ func TestCreateAnchorFile(t *testing.T) {
 
 	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-	af := CreateAnchorFile("coreURI", "provisionalURI", "mapURI", ops)
-	require.NotNil(t, af)
-	require.Equal(t, createOpsNum, len(af.Operations.Create))
-	require.Equal(t, 0, len(af.Operations.Update))
-	require.Equal(t, deactivateOpsNum, len(af.Operations.Deactivate))
-	require.Equal(t, recoverOpsNum, len(af.Operations.Recover))
+	cif := CreateCoreIndexFile("coreURI", "mapURI", ops)
+	require.NotNil(t, cif)
+	require.Equal(t, createOpsNum, len(cif.Operations.Create))
+	require.Equal(t, deactivateOpsNum, len(cif.Operations.Deactivate))
+	require.Equal(t, recoverOpsNum, len(cif.Operations.Recover))
 }
 
 func TestParseAnchorFile(t *testing.T) {
@@ -41,28 +40,27 @@ func TestParseAnchorFile(t *testing.T) {
 
 	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-	model := CreateAnchorFile("coreURI", "provisionalURI", "mapURI", ops)
+	model := CreateCoreIndexFile("coreURI", "mapURI", ops)
 
 	bytes, err := json.Marshal(model)
 	require.NoError(t, err)
 
-	parsed, err := ParseAnchorFile(bytes)
+	parsed, err := ParseCoreIndexFile(bytes)
 	require.NoError(t, err)
 
 	require.Equal(t, createOpsNum, len(parsed.Operations.Create))
-	require.Equal(t, 0, len(parsed.Operations.Update))
 	require.Equal(t, deactivateOpsNum, len(parsed.Operations.Deactivate))
 	require.Equal(t, recoverOpsNum, len(parsed.Operations.Recover))
 }
 
-func getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum int) []*model.Operation {
-	var ops []*model.Operation
-	ops = append(ops, generateOperations(createOpsNum, operation.TypeCreate)...)
-	ops = append(ops, generateOperations(recoverOpsNum, operation.TypeRecover)...)
-	ops = append(ops, generateOperations(deactivateOpsNum, operation.TypeDeactivate)...)
-	ops = append(ops, generateOperations(updateOpsNum, operation.TypeUpdate)...)
+func getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum int) *SortedOperations {
+	result := &SortedOperations{}
+	result.Create = append(result.Create, generateOperations(createOpsNum, operation.TypeCreate)...)
+	result.Recover = append(result.Recover, generateOperations(recoverOpsNum, operation.TypeRecover)...)
+	result.Deactivate = append(result.Deactivate, generateOperations(deactivateOpsNum, operation.TypeDeactivate)...)
+	result.Update = append(result.Update, generateOperations(updateOpsNum, operation.TypeUpdate)...)
 
-	return ops
+	return result
 }
 
 func generateOperations(numOfOperations int, opType operation.Type) (ops []*model.Operation) {

--- a/pkg/versions/0_1/txnprovider/models/chunk.go
+++ b/pkg/versions/0_1/txnprovider/models/chunk.go
@@ -9,7 +9,6 @@ package models
 import (
 	"encoding/json"
 
-	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -21,49 +20,32 @@ type ChunkFile struct {
 
 // CreateChunkFile will combine all operation deltas into chunk file.
 // returns chunk file model.
-func CreateChunkFile(ops []*model.Operation) *ChunkFile {
+func CreateChunkFile(ops *SortedOperations) *ChunkFile {
 	var deltas []*model.DeltaModel
 
-	deltas = append(deltas, getDeltas(operation.TypeCreate, ops)...)
-	deltas = append(deltas, getDeltas(operation.TypeRecover, ops)...)
-	deltas = append(deltas, getDeltas(operation.TypeUpdate, ops)...)
+	deltas = append(deltas, getDeltas(ops.Create)...)
+	deltas = append(deltas, getDeltas(ops.Recover)...)
+	deltas = append(deltas, getDeltas(ops.Update)...)
 
 	return &ChunkFile{Deltas: deltas}
 }
 
 // ParseChunkFile will parse chunk file model from content.
 func ParseChunkFile(content []byte) (*ChunkFile, error) {
-	cf, err := getChunkFile(content)
-	if err != nil {
-		return nil, err
-	}
-
-	return cf, nil
-}
-
-func getDeltas(filter operation.Type, ops []*model.Operation) []*model.DeltaModel {
-	var deltas []*model.DeltaModel
-	for _, op := range ops {
-		if op.Type == filter {
-			deltas = append(deltas, op.Delta)
-		}
-	}
-
-	return deltas
-}
-
-// get chunk file struct from bytes.
-var getChunkFile = func(bytes []byte) (*ChunkFile, error) {
-	return unmarshalChunkFile(bytes)
-}
-
-// unmarshal chunk file bytes into chunk file model.
-func unmarshalChunkFile(bytes []byte) (*ChunkFile, error) {
 	file := &ChunkFile{}
-	err := json.Unmarshal(bytes, file)
+	err := json.Unmarshal(content, file)
 	if err != nil {
 		return nil, err
 	}
 
 	return file, nil
+}
+
+func getDeltas(ops []*model.Operation) []*model.DeltaModel {
+	var deltas []*model.DeltaModel
+	for _, op := range ops {
+		deltas = append(deltas, op.Delta)
+	}
+
+	return deltas
 }

--- a/pkg/versions/0_1/txnprovider/models/common.go
+++ b/pkg/versions/0_1/txnprovider/models/common.go
@@ -7,9 +7,21 @@ SPDX-License-Identifier: Apache-2.0
 package models
 
 import (
-	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
+
+// SortedOperations stores operations per type.
+type SortedOperations struct {
+	Create     []*model.Operation
+	Update     []*model.Operation
+	Recover    []*model.Operation
+	Deactivate []*model.Operation
+}
+
+// Size returns the length of all operations(combined).
+func (o *SortedOperations) Size() int {
+	return len(o.Create) + len(o.Recover) + len(o.Deactivate) + len(o.Update)
+}
 
 // SignedOperation contains operation proving data.
 type SignedOperation struct {
@@ -20,18 +32,15 @@ type SignedOperation struct {
 	SignedData string `json:"signedData"`
 }
 
-// TODO: Remove type check when SIP-1 fully completed.
-func getSignedOperations(filter operation.Type, ops []*model.Operation) []SignedOperation {
+func getSignedOperations(ops []*model.Operation) []SignedOperation {
 	var result []SignedOperation
 	for _, op := range ops {
-		if op.Type == filter {
-			upd := SignedOperation{
-				DidSuffix:  op.UniqueSuffix,
-				SignedData: op.SignedData,
-			}
-
-			result = append(result, upd)
+		upd := SignedOperation{
+			DidSuffix:  op.UniqueSuffix,
+			SignedData: op.SignedData,
 		}
+
+		result = append(result, upd)
 	}
 
 	return result

--- a/pkg/versions/0_1/txnprovider/models/map_test.go
+++ b/pkg/versions/0_1/txnprovider/models/map_test.go
@@ -11,44 +11,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 )
 
 func TestHandler_CreateMapFile(t *testing.T) {
-	const createOpsNum = 2
 	const updateOpsNum = 2
-	const deactivateOpsNum = 2
-	const recoverOpsNum = 2
 
-	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+	ops := generateOperations(updateOpsNum, operation.TypeUpdate)
 
 	chunks := []string{"chunk_uri"}
-	batch := CreateMapFile(chunks, ops)
+	batch := CreateProvisionalIndexFile(chunks, "provisionalURI", ops)
 	require.NotNil(t, batch)
 	require.Equal(t, updateOpsNum, len(batch.Operations.Update))
-	require.Equal(t, 0, len(batch.Operations.Create))
-	require.Equal(t, 0, len(batch.Operations.Deactivate))
-	require.Equal(t, 0, len(batch.Operations.Recover))
 }
 
 func TestHandler_ParseMapFile(t *testing.T) {
-	const createOpsNum = 2
-	const updateOpsNum = 2
-	const deactivateOpsNum = 2
-	const recoverOpsNum = 2
+	const updateOpsNum = 5
 
-	ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
+	ops := generateOperations(updateOpsNum, operation.TypeUpdate)
 
 	chunks := []string{"chunk_uri"}
-	model := CreateMapFile(chunks, ops)
+	model := CreateProvisionalIndexFile(chunks, "provisionalURI", ops)
 
 	bytes, err := json.Marshal(model)
 	require.NoError(t, err)
 
-	parsed, err := ParseMapFile(bytes)
+	parsed, err := ParseProvisionalIndexFile(bytes)
 	require.NoError(t, err)
 
-	require.Equal(t, 0, len(parsed.Operations.Create))
 	require.Equal(t, updateOpsNum, len(parsed.Operations.Update))
-	require.Equal(t, 0, len(parsed.Operations.Deactivate))
-	require.Equal(t, 0, len(parsed.Operations.Recover))
 }


### PR DESCRIPTION
Included:
- organize operations by type for batch file creation and processing
- collect batch files into one struct for assembling operations (too many files as params)
- rename Anchor and Map Files to Core Index and Provisional Index Files
- move Provisional Proof URI to Provisional Index File

Closes #468

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>