### PR TITLE
chore: remove references to kid MUST be present in protected headers

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -36,7 +36,7 @@ type Protocol struct {
 	// CompressionAlgorithm is file compression algorithm.
 	CompressionAlgorithm string `json:"compressionAlgorithm"`
 	// MaxCoreIndexFileSize is maximum allowed size (in bytes) of core index file stored in CAS.
-	MaxCoreIndexFileSize uint `json:"maxAnchorFileSize"`
+	MaxCoreIndexFileSize uint `json:"maxCoreIndexFileSize"`
 	// MaxProofFileSize is maximum allowed size (in bytes) of proof files stored in CAS.
 	MaxProofFileSize uint `json:"maxProofFileSize"`
 	// MaxProvisionalIndexFileSize is maximum allowed size (in bytes) of provisional index file stored in CAS.

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -121,17 +121,9 @@ func (p *Parser) validateProtectedHeaders(headers jws.Headers, allowedAlgorithms
 		return errors.New("missing protected headers")
 	}
 
-	// kid MUST be present in the protected header.
+	// kid MAY be present in the protected header.
 	// alg MUST be present in the protected header, its value MUST NOT be none.
 	// no additional members may be present in the protected header.
-
-	// TODO: There is discrepancy between spec "kid MUST be present in the protected header" (issue-365)
-	// and reference implementation ('kid' is not present; only one 'alg' header expected)
-	// so disable this check for now
-	// _, ok := headers.KeyID()
-	// if !ok {
-	// return errors.New("kid must be present in the protected header")
-	// }
 
 	alg, ok := headers.Algorithm()
 	if !ok {

--- a/pkg/versions/0_1/operationparser/recover_test.go
+++ b/pkg/versions/0_1/operationparser/recover_test.go
@@ -325,15 +325,6 @@ func TestValidateProtectedHeader(t *testing.T) {
 		require.Contains(t, err.Error(), "missing protected headers")
 	})
 
-	//t.Run("err - kid must be present in the protected header", func(t *testing.T) {
-	//	protected := make(jws.Headers)
-	//	protected[algKey] = "alg-1"
-	//
-	//	err := validateProtectedHeaders(protected, algs)
-	//	require.Error(t, err)
-	//	require.Contains(t, err.Error(), "kid must be present in the protected header")
-	//})
-
 	t.Run("err - algorithm must be present in the protected header", func(t *testing.T) {
 		protected := make(jws.Headers)
 		protected[kidKey] = "kid-1"


### PR DESCRIPTION
Spec has been updated to "kid MAY be present in the protected headers". Remove commented out code.

Also, included fix for JSON tag: 'maxCoreIndexFileSize'

Closes #365

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>