### PR TITLE
chore: add validation of CAS file URI in batch files

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -41,6 +41,8 @@ type Protocol struct {
 	MaxDeltaSize uint `json:"maxDeltaSize"`
 	// MaxProofSize is maximum size of operation's proof property.
 	MaxProofSize uint `json:"maxProofSize"`
+	// MaxCasUriLength is maximum length of CAS URI in batch files.
+	MaxCasURILength uint `json:"maxCasUriLength"`
 	// CompressionAlgorithm is file compression algorithm.
 	CompressionAlgorithm string `json:"compressionAlgorithm"`
 	// MaxCoreIndexFileSize is maximum allowed size (in bytes) of core index file stored in CAS.

--- a/pkg/mocks/cas.go
+++ b/pkg/mocks/cas.go
@@ -8,10 +8,10 @@ package mocks
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"sync"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/encoder"
 	"github.com/trustbloc/sidetree-core-go/pkg/hashing"
 )
 
@@ -41,7 +41,7 @@ func (m *MockCasClient) Write(content []byte) (string, error) {
 		return "", err
 	}
 
-	key := base64.URLEncoding.EncodeToString(hash)
+	key := encoder.EncodeToString(hash)
 
 	m.Lock()
 	defer m.Unlock()
@@ -68,7 +68,7 @@ func (m *MockCasClient) Read(address string) ([]byte, error) {
 	}
 
 	// decode address to verify hashes
-	decoded, err := base64.URLEncoding.DecodeString(address)
+	decoded, err := encoder.DecodeString(address)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -145,6 +145,7 @@ func GetDefaultProtocolParameters() protocol.Protocol {
 		MaxOperationSize:            MaxOperationByteSize,
 		MaxDeltaSize:                MaxDeltaByteSize,
 		MaxProofSize:                MaxProofByteSize,
+		MaxCasURILength:             100,
 		CompressionAlgorithm:        "GZIP",
 		MaxChunkFileSize:            MaxBatchFileSize,
 		MaxProvisionalIndexFileSize: MaxBatchFileSize,

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1267,6 +1267,7 @@ func newMockProtocolClient() *mocks.MockProtocolClient {
 		MaxOperationSize:            mocks.MaxOperationByteSize,
 		MaxDeltaSize:                mocks.MaxDeltaByteSize,
 		MaxProofSize:                700, // has to be increased from 500 since we now use sha2_512
+		MaxCasURILength:             100,
 		CompressionAlgorithm:        "GZIP",
 		MaxChunkFileSize:            mocks.MaxBatchFileSize,
 		MaxProvisionalIndexFileSize: mocks.MaxBatchFileSize,

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -49,6 +49,7 @@ var (
 		MaxOperationSize:            2000,
 		MaxProofSize:                500,
 		MaxDeltaSize:                1000,
+		MaxCasURILength:             100,
 		CompressionAlgorithm:        "GZIP",
 		MaxChunkFileSize:            1024,
 		MaxProvisionalIndexFileSize: 1024,


### PR DESCRIPTION
Included: 
- new protocol parameter maxCasUriLength
- added validation of CAS file URIs in batch files

Closes #477

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>