### PR TITLE
chore: Rename SignedOperation to OperationReference

### DIFF
--- a/pkg/versions/0_1/txnprovider/models/common.go
+++ b/pkg/versions/0_1/txnprovider/models/common.go
@@ -23,8 +23,8 @@ func (o *SortedOperations) Size() int {
 	return len(o.Create) + len(o.Recover) + len(o.Deactivate) + len(o.Update)
 }
 
-// SignedOperation contains minimum proving data.
-type SignedOperation struct {
+// OperationReference contains minimum proving data.
+type OperationReference struct {
 	// DidSuffix is the suffix of the DID
 	DidSuffix string `json:"didSuffix"`
 
@@ -32,10 +32,10 @@ type SignedOperation struct {
 	RevealValue string `json:"revealValue"`
 }
 
-func getSignedOperations(ops []*model.Operation) []SignedOperation {
-	var result []SignedOperation
+func getOperationReferences(ops []*model.Operation) []OperationReference {
+	var result []OperationReference
 	for _, op := range ops {
-		upd := SignedOperation{
+		upd := OperationReference{
 			DidSuffix:   op.UniqueSuffix,
 			RevealValue: op.RevealValue,
 		}

--- a/pkg/versions/0_1/txnprovider/models/coreindex.go
+++ b/pkg/versions/0_1/txnprovider/models/coreindex.go
@@ -33,9 +33,9 @@ type CreateOperation struct {
 
 // CoreOperations contains operation proving data.
 type CoreOperations struct {
-	Create     []CreateOperation `json:"create,omitempty"`
-	Recover    []SignedOperation `json:"recover,omitempty"`
-	Deactivate []SignedOperation `json:"deactivate,omitempty"`
+	Create     []CreateOperation    `json:"create,omitempty"`
+	Recover    []OperationReference `json:"recover,omitempty"`
+	Deactivate []OperationReference `json:"deactivate,omitempty"`
 }
 
 // CreateCoreIndexFile will create core index file from provided operations.
@@ -46,8 +46,8 @@ func CreateCoreIndexFile(coreProofURI, mapURI string, ops *SortedOperations) *Co
 		ProvisionalIndexFileURI: mapURI,
 		Operations: CoreOperations{
 			Create:     assembleCreateOperations(ops.Create),
-			Recover:    getSignedOperations(ops.Recover),
-			Deactivate: getSignedOperations(ops.Deactivate),
+			Recover:    getOperationReferences(ops.Recover),
+			Deactivate: getOperationReferences(ops.Deactivate),
 		},
 	}
 }

--- a/pkg/versions/0_1/txnprovider/models/provisionalindex.go
+++ b/pkg/versions/0_1/txnprovider/models/provisionalindex.go
@@ -25,9 +25,9 @@ type ProvisionalIndexFile struct {
 	Operations ProvisionalOperations `json:"operations,omitempty"`
 }
 
-// ProvisionalOperations contains operation proving data for provisional (update) operations.
+// ProvisionalOperations contains minimal operation proving data for provisional (update) operations.
 type ProvisionalOperations struct {
-	Update []SignedOperation `json:"update,omitempty"`
+	Update []OperationReference `json:"update,omitempty"`
 }
 
 // Chunk holds chunk file URI.
@@ -42,7 +42,7 @@ func CreateProvisionalIndexFile(chunkURIs []string, provisionalProofURI string, 
 		Chunks:                  getChunks(chunkURIs),
 		ProvisionalProofFileURI: provisionalProofURI,
 		Operations: ProvisionalOperations{
-			Update: getSignedOperations(updateOps),
+			Update: getOperationReferences(updateOps),
 		},
 	}
 }

--- a/pkg/versions/0_1/txnprovider/provider.go
+++ b/pkg/versions/0_1/txnprovider/provider.go
@@ -342,14 +342,14 @@ func (h *OperationProvider) validateCoreIndexFile(cif *models.CoreIndexFile) err
 	}
 
 	for i, op := range cif.Operations.Recover {
-		err := validateSignedOperation(op)
+		err := validateOperationReference(op)
 		if err != nil {
 			return fmt.Errorf("failed to validate signed operation for recover[%d]: %s", i, err.Error())
 		}
 	}
 
 	for i, op := range cif.Operations.Deactivate {
-		err := validateSignedOperation(op)
+		err := validateOperationReference(op)
 		if err != nil {
 			return fmt.Errorf("failed to validate signed operation for deactivate[%d]: %s", i, err.Error())
 		}
@@ -358,7 +358,7 @@ func (h *OperationProvider) validateCoreIndexFile(cif *models.CoreIndexFile) err
 	return nil
 }
 
-func validateSignedOperation(op models.SignedOperation) error {
+func validateOperationReference(op models.OperationReference) error {
 	if op.DidSuffix == "" {
 		return errors.New("missing did suffix")
 	}
@@ -475,7 +475,7 @@ func (h *OperationProvider) validateProvisionalIndexFile(pif *models.Provisional
 	}
 
 	for i, op := range pif.Operations.Update {
-		err := validateSignedOperation(op)
+		err := validateOperationReference(op)
 		if err != nil {
 			return fmt.Errorf("failed to validate signed operation for update[%d]: %s", i, err.Error())
 		}

--- a/pkg/versions/0_1/txnprovider/provider_test.go
+++ b/pkg/versions/0_1/txnprovider/provider_test.go
@@ -816,7 +816,7 @@ func TestHandler_GetBatchFiles(t *testing.T) {
 		Chunks:                  []models.Chunk{{ChunkFileURI: chunkURI}},
 		ProvisionalProofFileURI: ppfURI,
 		Operations: models.ProvisionalOperations{
-			Update: []models.SignedOperation{
+			Update: []models.OperationReference{
 				{
 					DidSuffix:   updateOp.UniqueSuffix,
 					RevealValue: updateOp.RevealValue,
@@ -841,7 +841,7 @@ func TestHandler_GetBatchFiles(t *testing.T) {
 		ProvisionalIndexFileURI: pifURI,
 		CoreProofFileURI:        cpfURI,
 		Operations: models.CoreOperations{
-			Recover: []models.SignedOperation{
+			Recover: []models.OperationReference{
 				{
 					DidSuffix:   recoverOp.UniqueSuffix,
 					RevealValue: recoverOp.RevealValue,
@@ -896,7 +896,7 @@ func TestHandler_GetBatchFiles(t *testing.T) {
 			Chunks:                  []models.Chunk{{ChunkFileURI: chunkURI}},
 			ProvisionalProofFileURI: invalidContentURI,
 			Operations: models.ProvisionalOperations{
-				Update: []models.SignedOperation{
+				Update: []models.OperationReference{
 					{
 						DidSuffix:   updateOp.UniqueSuffix,
 						RevealValue: updateOp.RevealValue,
@@ -941,7 +941,7 @@ func TestHandler_GetBatchFiles(t *testing.T) {
 		pif2 := &models.ProvisionalIndexFile{
 			ProvisionalProofFileURI: "",
 			Operations: models.ProvisionalOperations{
-				Update: []models.SignedOperation{
+				Update: []models.OperationReference{
 					{
 						DidSuffix:   updateOp.UniqueSuffix,
 						RevealValue: updateOp.RevealValue,
@@ -987,7 +987,7 @@ func TestHandler_GetBatchFiles(t *testing.T) {
 		cif := &models.CoreIndexFile{
 			CoreProofFileURI: cpfURI,
 			Operations: models.CoreOperations{
-				Recover: []models.SignedOperation{
+				Recover: []models.OperationReference{
 					{
 						DidSuffix:   recoverOp.UniqueSuffix,
 						RevealValue: recoverOp.RevealValue,
@@ -1048,7 +1048,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 			ProvisionalIndexFileURI: "hash",
 			Operations: models.CoreOperations{
 				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
-				Deactivate: []models.SignedOperation{
+				Deactivate: []models.OperationReference{
 					{DidSuffix: deactivateOp.UniqueSuffix, RevealValue: deactivateOp.RevealValue},
 				},
 			},
@@ -1057,7 +1057,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		pif := &models.ProvisionalIndexFile{
 			Chunks: []models.Chunk{},
 			Operations: models.ProvisionalOperations{
-				Update: []models.SignedOperation{{DidSuffix: updateOp.UniqueSuffix, RevealValue: updateOp.RevealValue}},
+				Update: []models.OperationReference{{DidSuffix: updateOp.UniqueSuffix, RevealValue: updateOp.RevealValue}},
 			},
 		}
 
@@ -1107,7 +1107,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 			ProvisionalIndexFileURI: "hash",
 			Operations: models.CoreOperations{
 				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
-				Deactivate: []models.SignedOperation{
+				Deactivate: []models.OperationReference{
 					{DidSuffix: deactivateOp.UniqueSuffix, RevealValue: deactivateOp.RevealValue},
 					{DidSuffix: deactivateOp.UniqueSuffix, RevealValue: deactivateOp.RevealValue},
 				},
@@ -1117,7 +1117,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		pif := &models.ProvisionalIndexFile{
 			Chunks: []models.Chunk{},
 			Operations: models.ProvisionalOperations{
-				Update: []models.SignedOperation{
+				Update: []models.OperationReference{
 					{DidSuffix: updateOp.UniqueSuffix, RevealValue: updateOp.RevealValue},
 					{DidSuffix: updateOp.UniqueSuffix, RevealValue: updateOp.RevealValue},
 				},
@@ -1227,13 +1227,13 @@ func generateDefaultBatchFiles() (*batchFiles, error) {
 		CoreProofFileURI:        "coreProofURI",
 		Operations: models.CoreOperations{
 			Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
-			Recover: []models.SignedOperation{
+			Recover: []models.OperationReference{
 				{
 					DidSuffix:   recoverOp.UniqueSuffix,
 					RevealValue: recoverOp.RevealValue,
 				},
 			},
-			Deactivate: []models.SignedOperation{
+			Deactivate: []models.OperationReference{
 				{
 					DidSuffix:   deactivateOp.UniqueSuffix,
 					RevealValue: deactivateOp.RevealValue,
@@ -1246,7 +1246,7 @@ func generateDefaultBatchFiles() (*batchFiles, error) {
 		Chunks:                  []models.Chunk{{ChunkFileURI: "chunkURI"}},
 		ProvisionalProofFileURI: "provisionalProofURI",
 		Operations: models.ProvisionalOperations{
-			Update: []models.SignedOperation{
+			Update: []models.OperationReference{
 				{
 					DidSuffix:   updateOp.UniqueSuffix,
 					RevealValue: updateOp.RevealValue,


### PR DESCRIPTION
Rename SignedOperation to OperationReference (to align naming with reference app)

Closes #489

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>