### PR TITLE
chore: return an error if there are duplicate suffixes in core index

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -261,7 +261,7 @@ func (s *OperationProcessor) applyFirstValidOperation(ops []*operation.AnchoredO
 		}
 
 		if currCommitment == nextCommitment {
-			logger.Infof("[%s] Skipped bad operation {UniqueSuffix: %s, Type: %s, TransactionTime: %d, TransactionNumber: %d}. Reason: operation commitment equals next operation commitment", s.name, op.UniqueSuffix, op.Type, op.TransactionTime, op.TransactionNumber)
+			logger.Infof("[%s] Skipped bad operation {UniqueSuffix: %s, Type: %s, TransactionTime: %d, TransactionNumber: %d}. Reason: operation commitment(key) equals next operation commitment(key)", s.name, op.UniqueSuffix, op.Type, op.TransactionTime, op.TransactionNumber)
 
 			continue
 		}
@@ -270,7 +270,7 @@ func (s *OperationProcessor) applyFirstValidOperation(ops []*operation.AnchoredO
 			// for recovery and update operations check if next commitment has been used already; if so skip to next operation
 			_, processed := processedCommitments[nextCommitment]
 			if processed {
-				logger.Infof("[%s] Skipped bad operation {UniqueSuffix: %s, Type: %s, TransactionTime: %d, TransactionNumber: %d}. Reason: next operation commitment has already been used", s.name, op.UniqueSuffix, op.Type, op.TransactionTime, op.TransactionNumber)
+				logger.Infof("[%s] Skipped bad operation {UniqueSuffix: %s, Type: %s, TransactionTime: %d, TransactionNumber: %d}. Reason: next operation commitment(key) has already been used", s.name, op.UniqueSuffix, op.Type, op.TransactionTime, op.TransactionNumber)
 
 				continue
 			}

--- a/pkg/versions/0_1/txnprovider/provider.go
+++ b/pkg/versions/0_1/txnprovider/provider.go
@@ -589,6 +589,11 @@ func (h *OperationProvider) parseCoreIndexOperations(cif *models.CoreIndexFile, 
 		deactivateOps = append(deactivateOps, deactivate)
 	}
 
+	err := checkForDuplicates(suffixes)
+	if err != nil {
+		return nil, fmt.Errorf("check for duplicate suffixes in core index files: %s", err.Error())
+	}
+
 	return &coreOperations{
 		Create:     createOps,
 		Recover:    recoverOps,


### PR DESCRIPTION
Transaction Processor:
- return an error if there are duplicate suffixes in core index file
- clarify log for operation commitment equals next operation commitment

Closes #493

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>
