### PR TITLE
chore: Remove operations tag from core/provisional index if there are…

### DIFF
--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -93,7 +93,7 @@ func TestStart(t *testing.T) {
 	require.Nil(t, err)
 
 	require.Equal(t, 2, len(cif.Operations.Create))
-	require.Equal(t, 0, len(pif.Operations.Update))
+	require.Nil(t, pif.Operations)
 	require.Equal(t, 2, len(cf.Deltas))
 }
 
@@ -181,7 +181,7 @@ func TestBatchTimer(t *testing.T) {
 	require.Equal(t, 0, len(cif.Operations.Recover))
 	require.Equal(t, 0, len(cif.Operations.Deactivate))
 
-	require.Equal(t, 0, len(pif.Operations.Update))
+	require.Nil(t, pif.Operations)
 
 	require.Equal(t, 1, len(cf.Deltas))
 }
@@ -220,7 +220,7 @@ func TestDiscardDuplicateSuffixInBatchFile(t *testing.T) {
 	require.Equal(t, 0, len(cif.Operations.Recover))
 	require.Equal(t, 0, len(cif.Operations.Deactivate))
 
-	require.Equal(t, 0, len(pif.Operations.Update))
+	require.Nil(t, pif.Operations)
 
 	require.Equal(t, 1, len(cf.Deltas))
 }

--- a/pkg/versions/0_1/txnprovider/handler_test.go
+++ b/pkg/versions/0_1/txnprovider/handler_test.go
@@ -190,7 +190,7 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 		err = json.Unmarshal(content, &pif)
 		require.NoError(t, err)
 		require.NotNil(t, pif)
-		require.Equal(t, 0, len(pif.Operations.Update))
+		require.Nil(t, pif.Operations)
 
 		bytes, err = handler.cas.Read(pif.Chunks[0].ChunkFileURI)
 		require.NoError(t, err)

--- a/pkg/versions/0_1/txnprovider/models/coreindex.go
+++ b/pkg/versions/0_1/txnprovider/models/coreindex.go
@@ -22,7 +22,7 @@ type CoreIndexFile struct {
 	CoreProofFileURI string `json:"coreProofFileUri,omitempty"`
 
 	// CoreOperations contain proving data for create, recover and deactivate operations.
-	Operations CoreOperations `json:"operations"`
+	Operations *CoreOperations `json:"operations,omitempty"`
 }
 
 // CreateOperation contains create operation data.
@@ -40,15 +40,21 @@ type CoreOperations struct {
 
 // CreateCoreIndexFile will create core index file from provided operations.
 // returns core index file model.
-func CreateCoreIndexFile(coreProofURI, mapURI string, ops *SortedOperations) *CoreIndexFile {
+func CreateCoreIndexFile(coreProofURI, provisionalIndexURI string, ops *SortedOperations) *CoreIndexFile {
+	var coreOps *CoreOperations
+
+	if len(ops.Create)+len(ops.Recover)+len(ops.Deactivate) > 0 {
+		coreOps = &CoreOperations{}
+
+		coreOps.Create = assembleCreateOperations(ops.Create)
+		coreOps.Recover = getOperationReferences(ops.Recover)
+		coreOps.Deactivate = getOperationReferences(ops.Deactivate)
+	}
+
 	return &CoreIndexFile{
 		CoreProofFileURI:        coreProofURI,
-		ProvisionalIndexFileURI: mapURI,
-		Operations: CoreOperations{
-			Create:     assembleCreateOperations(ops.Create),
-			Recover:    getOperationReferences(ops.Recover),
-			Deactivate: getOperationReferences(ops.Deactivate),
-		},
+		ProvisionalIndexFileURI: provisionalIndexURI,
+		Operations:              coreOps,
 	}
 }
 

--- a/pkg/versions/0_1/txnprovider/models/coreproof.go
+++ b/pkg/versions/0_1/txnprovider/models/coreproof.go
@@ -21,7 +21,7 @@ import (
 type CoreProofFile struct {
 
 	// Operations contain proving data for recover and deactivate operations.
-	Operations CoreProofOperations `json:"operations"`
+	Operations CoreProofOperations `json:"operations,omitempty"`
 }
 
 // CoreProofOperations contains proving data for any recover and deactivate operations to be included in a batch.

--- a/pkg/versions/0_1/txnprovider/models/provisionalindex.go
+++ b/pkg/versions/0_1/txnprovider/models/provisionalindex.go
@@ -22,7 +22,7 @@ type ProvisionalIndexFile struct {
 	Chunks []Chunk `json:"chunks"`
 
 	// Operations will contain provisional (update) operations
-	Operations ProvisionalOperations `json:"operations,omitempty"`
+	Operations *ProvisionalOperations `json:"operations,omitempty"`
 }
 
 // ProvisionalOperations contains minimal operation proving data for provisional (update) operations.
@@ -38,12 +38,17 @@ type Chunk struct {
 // CreateProvisionalIndexFile will create provisional index file model from operations and chunk file URI.
 // returns chunk file model.
 func CreateProvisionalIndexFile(chunkURIs []string, provisionalProofURI string, updateOps []*model.Operation) *ProvisionalIndexFile {
+	var provisionalOps *ProvisionalOperations
+	if len(updateOps) > 0 {
+		provisionalOps = &ProvisionalOperations{}
+
+		provisionalOps.Update = getOperationReferences(updateOps)
+	}
+
 	return &ProvisionalIndexFile{
 		Chunks:                  getChunks(chunkURIs),
 		ProvisionalProofFileURI: provisionalProofURI,
-		Operations: ProvisionalOperations{
-			Update: getOperationReferences(updateOps),
-		},
+		Operations:              provisionalOps,
 	}
 }
 

--- a/pkg/versions/0_1/txnprovider/models/provisionalindex_test.go
+++ b/pkg/versions/0_1/txnprovider/models/provisionalindex_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/canonicalizer"
 )
 
 func TestHandler_CreateMapFile(t *testing.T) {
@@ -43,4 +44,19 @@ func TestHandler_ParseMapFile(t *testing.T) {
 	require.Equal(t, updateOpsNum, len(parsed.Operations.Update))
 
 	require.Equal(t, parsed.Operations.Update[0].RevealValue, revealValue)
+}
+
+func TestMarshalProvisionalIndexFile(t *testing.T) {
+	t.Run("success - provisional index with no operations ", func(t *testing.T) {
+		model := CreateProvisionalIndexFile([]string{"chunkURI"}, "", nil)
+		bytes, err := canonicalizer.MarshalCanonical(model)
+		require.NoError(t, err)
+		require.Equal(t, `{"chunks":[{"chunkFileUri":"chunkURI"}]}`, string(bytes))
+	})
+	t.Run("success - provisional index with operations", func(t *testing.T) {
+		model := CreateProvisionalIndexFile([]string{"chunkURI"}, "", generateOperations(1, operation.TypeUpdate))
+		bytes, err := canonicalizer.MarshalCanonical(model)
+		require.NoError(t, err)
+		require.Equal(t, `{"chunks":[{"chunkFileUri":"chunkURI"}],"operations":{"update":[{"didSuffix":"update-1","revealValue":"reveal-value"}]}}`, string(bytes))
+	})
 }


### PR DESCRIPTION
… no relevant operations

Remove operations tag in core and provisional index files should be omitted from stored batch files if there are no relevant operations.
- core index if there are no create/deactive/recover operations
- provisional index if there are no update operations

Note: Even though spec is not enforcing "no tag" in this case reference application is enforcing it.

Closes #495

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>