### PR TITLE
chore: Rename CreateOperation to CreateReference (core index)

### DIFF
--- a/pkg/versions/0_1/txnprovider/models/coreindex.go
+++ b/pkg/versions/0_1/txnprovider/models/coreindex.go
@@ -25,15 +25,15 @@ type CoreIndexFile struct {
 	Operations *CoreOperations `json:"operations,omitempty"`
 }
 
-// CreateOperation contains create operation data.
-type CreateOperation struct {
+// CreateReference contains create operation reference.
+type CreateReference struct {
 	// SuffixData object
 	SuffixData *model.SuffixDataModel `json:"suffixData"`
 }
 
-// CoreOperations contains operation proving data.
+// CoreOperations contains operation references.
 type CoreOperations struct {
-	Create     []CreateOperation    `json:"create,omitempty"`
+	Create     []CreateReference    `json:"create,omitempty"`
 	Recover    []OperationReference `json:"recover,omitempty"`
 	Deactivate []OperationReference `json:"deactivate,omitempty"`
 }
@@ -46,7 +46,7 @@ func CreateCoreIndexFile(coreProofURI, provisionalIndexURI string, ops *SortedOp
 	if len(ops.Create)+len(ops.Recover)+len(ops.Deactivate) > 0 {
 		coreOps = &CoreOperations{}
 
-		coreOps.Create = assembleCreateOperations(ops.Create)
+		coreOps.Create = assembleCreateReferences(ops.Create)
 		coreOps.Recover = getOperationReferences(ops.Recover)
 		coreOps.Deactivate = getOperationReferences(ops.Deactivate)
 	}
@@ -58,10 +58,10 @@ func CreateCoreIndexFile(coreProofURI, provisionalIndexURI string, ops *SortedOp
 	}
 }
 
-func assembleCreateOperations(createOps []*model.Operation) []CreateOperation {
-	var result []CreateOperation
+func assembleCreateReferences(createOps []*model.Operation) []CreateReference {
+	var result []CreateReference
 	for _, op := range createOps {
-		create := CreateOperation{SuffixData: op.SuffixData}
+		create := CreateReference{SuffixData: op.SuffixData}
 		result = append(result, create)
 	}
 

--- a/pkg/versions/0_1/txnprovider/provider_test.go
+++ b/pkg/versions/0_1/txnprovider/provider_test.go
@@ -1128,7 +1128,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		cif := &models.CoreIndexFile{
 			ProvisionalIndexFileURI: "hash",
 			Operations: &models.CoreOperations{
-				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
+				Create: []models.CreateReference{{SuffixData: createOp.SuffixData}},
 				Deactivate: []models.OperationReference{
 					{DidSuffix: deactivateOp.UniqueSuffix, RevealValue: deactivateOp.RevealValue},
 				},
@@ -1187,7 +1187,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		cif := &models.CoreIndexFile{
 			ProvisionalIndexFileURI: "hash",
 			Operations: &models.CoreOperations{
-				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
+				Create: []models.CreateReference{{SuffixData: createOp.SuffixData}},
 				Deactivate: []models.OperationReference{
 					{DidSuffix: "test-suffix", RevealValue: deactivateOp.RevealValue},
 				},
@@ -1240,7 +1240,7 @@ func TestHandler_assembleBatchOperations(t *testing.T) {
 		cif := &models.CoreIndexFile{
 			ProvisionalIndexFileURI: "hash",
 			Operations: &models.CoreOperations{
-				Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
+				Create: []models.CreateReference{{SuffixData: createOp.SuffixData}},
 				Deactivate: []models.OperationReference{
 					{DidSuffix: deactivateOp.UniqueSuffix, RevealValue: deactivateOp.RevealValue},
 					{DidSuffix: deactivateOp.UniqueSuffix, RevealValue: deactivateOp.RevealValue},
@@ -1359,7 +1359,7 @@ func generateDefaultBatchFiles() (*batchFiles, error) {
 		ProvisionalIndexFileURI: "provisionalIndexURI",
 		CoreProofFileURI:        "coreProofURI",
 		Operations: &models.CoreOperations{
-			Create: []models.CreateOperation{{SuffixData: createOp.SuffixData}},
+			Create: []models.CreateReference{{SuffixData: createOp.SuffixData}},
 			Recover: []models.OperationReference{
 				{
 					DidSuffix:   recoverOp.UniqueSuffix,


### PR DESCRIPTION
Rename CreateOperation to CreateReference (to align naming with reference app)

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>

Closes #498