### PR TITLE
chore: Add checks for re-using commitments (client, operation parser)

### DIFF
--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -465,13 +465,25 @@ func generateOperationsAtTime(numOfOperations int, protocolGenesisTime uint64) (
 }
 
 func generateOperation(num int) (*operation.QueuedOperation, error) {
-	jwk := &jws.JWK{
+	updateJwk := &jws.JWK{
 		Crv: "crv",
 		Kty: "kty",
 		X:   "x",
 	}
 
-	c, err := commitment.Calculate(jwk, sha2_256)
+	recoverJWK := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+		Y:   "y",
+	}
+
+	updateCommitment, err := commitment.Calculate(updateJwk, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
+	recoverComitment, err := commitment.Calculate(recoverJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}
@@ -479,8 +491,8 @@ func generateOperation(num int) (*operation.QueuedOperation, error) {
 	doc := fmt.Sprintf(`{"test":%d}`, num)
 	info := &client.CreateRequestInfo{
 		OpaqueDocument:     doc,
-		RecoveryCommitment: c,
-		UpdateCommitment:   c,
+		RecoveryCommitment: recoverComitment,
+		UpdateCommitment:   updateCommitment,
 		MultihashCode:      sha2_256,
 	}
 

--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -189,8 +189,15 @@ func getSuffixData() *model.SuffixDataModel {
 	}
 }
 
-var testJWK = &jws.JWK{
+var recoverJWK = &jws.JWK{
 	Kty: "kty",
 	Crv: "P-256",
 	X:   "x",
+}
+
+var updateJWK = &jws.JWK{
+	Kty: "kty",
+	Crv: "crv",
+	X:   "x",
+	Y:   "y",
 }

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -139,12 +139,12 @@ func TestUpdateHandler_Update(t *testing.T) {
 }
 
 func getCreateRequestInfo() (*client.CreateRequestInfo, error) {
-	recoveryCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	recoveryCommitment, err := commitment.Calculate(recoverJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
-	updateCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func getUpdateRequestInfo(uniqueSuffix string) *client.UpdateRequestInfo {
 		panic(err)
 	}
 
-	updateCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
 	if err != nil {
 		panic(err)
 	}
@@ -198,7 +198,7 @@ func getDeactivateRequestInfo(uniqueSuffix string) *client.DeactivateRequestInfo
 
 	return &client.DeactivateRequestInfo{
 		DidSuffix:   uniqueSuffix,
-		RecoveryKey: testJWK,
+		RecoveryKey: recoverJWK,
 		Signer:      ecsigner.New(privateKey, "ES256", ""),
 	}
 }
@@ -214,12 +214,12 @@ func getRecoverRequestInfo(uniqueSuffix string) *client.RecoverRequestInfo {
 		panic(err)
 	}
 
-	recoveryCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	recoveryCommitment, err := commitment.Calculate(recoverJWK, sha2_256)
 	if err != nil {
 		panic(err)
 	}
 
-	updateCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/versions/0_1/client/create.go
+++ b/pkg/versions/0_1/client/create.go
@@ -108,5 +108,9 @@ func validateCreateRequest(info *CreateRequestInfo) error {
 		return errors.New("next update commitment is not computed with the specified hash algorithm")
 	}
 
+	if info.RecoveryCommitment == info.UpdateCommitment {
+		return errors.New("recovery and update commitments cannot be equal, re-using public keys is not allowed")
+	}
+
 	return nil
 }

--- a/pkg/versions/0_1/client/recover_test.go
+++ b/pkg/versions/0_1/client/recover_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
@@ -94,6 +95,21 @@ func TestNewRecoverRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "invalid character ','")
 	})
+
+	t.Run("error - re-using public keys for commitment is not allowed", func(t *testing.T) {
+		info := getRecoverRequestInfo()
+
+		currentCommitment, err := commitment.Calculate(info.RecoveryKey, info.MultihashCode)
+		require.NoError(t, err)
+
+		info.RecoveryCommitment = currentCommitment
+
+		request, err := NewRecoverRequest(info)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "re-using public keys for commitment is not allowed")
+	})
+
 	t.Run("success - opaque document", func(t *testing.T) {
 		info := getRecoverRequestInfo()
 

--- a/pkg/versions/0_1/client/update.go
+++ b/pkg/versions/0_1/client/update.go
@@ -61,6 +61,11 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 		UpdateKey: info.UpdateKey,
 	}
 
+	err = validateCommitment(info.UpdateKey, info.MultihashCode, info.UpdateCommitment)
+	if err != nil {
+		return nil, err
+	}
+
 	jws, err := signutil.SignModel(signedDataModel, info.Signer)
 	if err != nil {
 		return nil, err

--- a/pkg/versions/0_1/operationapplier/operationapplier.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier.go
@@ -78,7 +78,7 @@ func (s *Applier) applyCreateOperation(anchoredOp *operation.AnchoredOperation, 
 
 	op, err := s.OperationParser.ParseCreateOperation(anchoredOp.OperationBuffer, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse create operation in anchor mode: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse create operation in batch mode: %s", err.Error())
 	}
 
 	// from this point any error should advance recovery commitment
@@ -128,7 +128,7 @@ func (s *Applier) applyUpdateOperation(anchoredOp *operation.AnchoredOperation, 
 
 	op, err := s.OperationParser.ParseUpdateOperation(anchoredOp.OperationBuffer, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse update operation in anchor mode: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse update operation in batch mode: %s", err.Error())
 	}
 
 	signedDataModel, err := s.ParseSignedDataForUpdate(op.SignedData)
@@ -177,7 +177,7 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperati
 
 	op, err := s.OperationParser.ParseDeactivateOperation(anchoredOp.OperationBuffer, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse deactive operation in anchor mode: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse deactive operation in batch mode: %s", err.Error())
 	}
 
 	signedDataModel, err := s.ParseSignedDataForDeactivate(op.SignedData)
@@ -215,7 +215,7 @@ func (s *Applier) applyRecoverOperation(anchoredOp *operation.AnchoredOperation,
 
 	op, err := s.OperationParser.ParseRecoverOperation(anchoredOp.OperationBuffer, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse recover operation in anchor mode: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse recover operation in batch mode: %s", err.Error())
 	}
 
 	signedDataModel, err := s.ParseSignedDataForRecover(op.SignedData)

--- a/pkg/versions/0_1/operationparser/commitment_test.go
+++ b/pkg/versions/0_1/operationparser/commitment_test.go
@@ -181,11 +181,16 @@ func generateRecoverRequest(recoveryKey *ecdsa.PrivateKey, commitment string, p 
 		return nil, err
 	}
 
+	_, updateCommitment, err := generateKeyAndCommitment(p)
+	if err != nil {
+		return nil, err
+	}
+
 	info := &client.RecoverRequestInfo{
 		DidSuffix:          "recover-suffix",
 		OpaqueDocument:     `{"test":"value"}`,
 		RecoveryCommitment: commitment,
-		UpdateCommitment:   commitment, // not evaluated in operation getting commitment/reveal value
+		UpdateCommitment:   updateCommitment, // not evaluated in operation getting commitment/reveal value
 		RecoveryKey:        jwk,
 		MultihashCode:      p.MultihashAlgorithm,
 		Signer:             ecsigner.New(recoveryKey, "ES256", ""),

--- a/pkg/versions/0_1/operationparser/create.go
+++ b/pkg/versions/0_1/operationparser/create.go
@@ -40,7 +40,11 @@ func (p *Parser) ParseCreateOperation(request []byte, batch bool) (*model.Operat
 		// verify actual delta hash matches expected delta hash
 		err = hashing.IsValidModelMultihash(schema.Delta, schema.SuffixData.DeltaHash)
 		if err != nil {
-			return nil, fmt.Errorf("parse create operation: delta doesn't match suffix data delta hash: %s", err.Error())
+			return nil, fmt.Errorf("delta doesn't match suffix data delta hash: %s", err.Error())
+		}
+
+		if schema.Delta.UpdateCommitment == schema.SuffixData.RecoveryCommitment {
+			return nil, errors.New("recovery and update commitments cannot be equal, re-using public keys is not allowed")
 		}
 	}
 

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -94,7 +94,7 @@ func TestParseCreateOperation(t *testing.T) {
 		require.Contains(t, err.Error(), "missing delta")
 	})
 
-	t.Run("missing delta is ok in anchor mode", func(t *testing.T) {
+	t.Run("missing delta is ok in batch mode", func(t *testing.T) {
 		create, err := getCreateRequest()
 		require.NoError(t, err)
 		create.Delta = nil
@@ -136,6 +136,21 @@ func TestParseCreateOperation(t *testing.T) {
 		op, err := parser.ParseCreateOperation(request, false)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "delta doesn't match suffix data delta hash")
+		require.Nil(t, op)
+	})
+
+	t.Run("error - update commitment equals recovery commitment", func(t *testing.T) {
+		create, err := getCreateRequest()
+		require.NoError(t, err)
+
+		create.SuffixData.RecoveryCommitment = create.Delta.UpdateCommitment
+
+		request, err := json.Marshal(create)
+		require.NoError(t, err)
+
+		op, err := parser.ParseCreateOperation(request, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "recovery and update commitments cannot be equal, re-using public keys is not allowed")
 		require.Nil(t, op)
 	})
 }

--- a/pkg/versions/0_1/operationparser/operation.go
+++ b/pkg/versions/0_1/operationparser/operation.go
@@ -10,11 +10,15 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/trustbloc/edge-core/pkg/log"
+
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
+
+var logger = log.New("sidetree-core-parser")
 
 // Parser is an operation parser.
 type Parser struct {
@@ -69,6 +73,8 @@ func (p *Parser) ParseOperation(namespace string, operationBuffer []byte, batch 
 	}
 
 	if parseErr != nil {
+		logger.Warnf("parse '%s' operation for batch[%t]: %s", schema.Operation, batch, parseErr.Error())
+
 		return nil, parseErr
 	}
 

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -33,6 +33,11 @@ func (p *Parser) ParseUpdateOperation(request []byte, batch bool) (*model.Operat
 		if err != nil {
 			return nil, err
 		}
+
+		err = validateCommitment(signedData.UpdateKey, p.MultihashAlgorithm, schema.Delta.UpdateCommitment)
+		if err != nil {
+			return nil, fmt.Errorf("calculate current commitment: %s", err.Error())
+		}
 	}
 
 	revealValue, err := p.getRevealValueMultihash(signedData.UpdateKey)

--- a/pkg/versions/0_1/txnprovider/models/coreindex.go
+++ b/pkg/versions/0_1/txnprovider/models/coreindex.go
@@ -68,7 +68,7 @@ func assembleCreateReferences(createOps []*model.Operation) []CreateReference {
 	return result
 }
 
-// ParseCoreIndexFile will parse anchor model from content.
+// ParseCoreIndexFile will parse core index file from content.
 func ParseCoreIndexFile(content []byte) (*CoreIndexFile, error) {
 	file := &CoreIndexFile{}
 	err := json.Unmarshal(content, file)


### PR DESCRIPTION
Add checks for re-using commitments to client and operation parser

Closes #502

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>