### PR TITLE
chore: Remove "kid must be present in the protected headers" for client

### DIFF
--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -42,8 +42,6 @@ const (
 
 	dummyUniqueSuffix = "dummy"
 
-	updateKeyID = "update-key"
-
 	defaultBlockNumber = 0
 )
 
@@ -829,7 +827,7 @@ func TestOpsWithTxnGreaterThan(t *testing.T) {
 }
 
 func getUpdateOperation(privateKey *ecdsa.PrivateKey, uniqueSuffix string, blockNum uint64) (*model.Operation, *ecdsa.PrivateKey, error) {
-	s := ecsigner.New(privateKey, "ES256", updateKeyID)
+	s := ecsigner.New(privateKey, "ES256", "")
 
 	return getUpdateOperationWithSigner(s, privateKey, uniqueSuffix, blockNum)
 }

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -185,7 +185,7 @@ func getUpdateRequestInfo(uniqueSuffix string) *client.UpdateRequestInfo {
 		UpdateKey:        pubKey,
 		UpdateCommitment: updateCommitment,
 		MultihashCode:    sha2_256,
-		Signer:           ecsigner.New(privateKey, "ES256", "key-1"),
+		Signer:           ecsigner.New(privateKey, "ES256", ""),
 	}
 }
 

--- a/pkg/util/ecsigner/signer.go
+++ b/pkg/util/ecsigner/signer.go
@@ -33,8 +33,14 @@ func New(privKey *ecdsa.PrivateKey, alg, kid string) *Signer {
 // Headers provides required JWS protected headers. It provides information about signing key and algorithm.
 func (signer *Signer) Headers() jws.Headers {
 	headers := make(jws.Headers)
-	headers[jws.HeaderAlgorithm] = signer.alg
-	headers[jws.HeaderKeyID] = signer.kid
+
+	if signer.alg != "" {
+		headers[jws.HeaderAlgorithm] = signer.alg
+	}
+
+	if signer.kid != "" {
+		headers[jws.HeaderKeyID] = signer.kid
+	}
 
 	return headers
 }

--- a/pkg/util/ecsigner/signer_test.go
+++ b/pkg/util/ecsigner/signer_test.go
@@ -81,14 +81,29 @@ func TestHeaders(t *testing.T) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	signer := New(privateKey, "ES256", "key-1")
+	t.Run("success - kid, alg provided", func(t *testing.T) {
+		signer := New(privateKey, "ES256", "key-1")
 
-	// verify headers
-	kid, ok := signer.Headers().KeyID()
-	require.Equal(t, true, ok)
-	require.Equal(t, "key-1", kid)
+		// verify headers
+		kid, ok := signer.Headers().KeyID()
+		require.Equal(t, true, ok)
+		require.Equal(t, "key-1", kid)
 
-	alg, ok := signer.Headers().Algorithm()
-	require.Equal(t, true, ok)
-	require.Equal(t, "ES256", alg)
+		alg, ok := signer.Headers().Algorithm()
+		require.Equal(t, true, ok)
+		require.Equal(t, "ES256", alg)
+	})
+
+	t.Run("success - kid, alg not provided", func(t *testing.T) {
+		signer := New(privateKey, "", "")
+
+		// verify headers
+		kid, ok := signer.Headers().KeyID()
+		require.Equal(t, false, ok)
+		require.Empty(t, kid)
+
+		alg, ok := signer.Headers().Algorithm()
+		require.Equal(t, false, ok)
+		require.Empty(t, alg)
+	})
 }

--- a/pkg/util/edsigner/signer.go
+++ b/pkg/util/edsigner/signer.go
@@ -28,8 +28,14 @@ func New(privKey ed25519.PrivateKey, alg, kid string) *Signer {
 // Headers provides required JWS protected headers. It provides information about signing key and algorithm.
 func (signer *Signer) Headers() jws.Headers {
 	headers := make(jws.Headers)
-	headers[jws.HeaderAlgorithm] = signer.alg
-	headers[jws.HeaderKeyID] = signer.kid
+
+	if signer.alg != "" {
+		headers[jws.HeaderAlgorithm] = signer.alg
+	}
+
+	if signer.kid != "" {
+		headers[jws.HeaderKeyID] = signer.kid
+	}
 
 	return headers
 }

--- a/pkg/util/edsigner/signer_test.go
+++ b/pkg/util/edsigner/signer_test.go
@@ -40,17 +40,35 @@ func TestSign(t *testing.T) {
 }
 
 func TestHeaders(t *testing.T) {
-	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
+	t.Run("success - kid, alg provided", func(t *testing.T) {
+		_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
 
-	signer := New(privateKey, "EdDSA", "key-1")
+		signer := New(privateKey, "EdDSA", "key-1")
 
-	// verify headers
-	kid, ok := signer.Headers().KeyID()
-	require.Equal(t, true, ok)
-	require.Equal(t, "key-1", kid)
+		// verify headers
+		kid, ok := signer.Headers().KeyID()
+		require.Equal(t, true, ok)
+		require.Equal(t, "key-1", kid)
 
-	alg, ok := signer.Headers().Algorithm()
-	require.Equal(t, true, ok)
-	require.Equal(t, "EdDSA", alg)
+		alg, ok := signer.Headers().Algorithm()
+		require.Equal(t, true, ok)
+		require.Equal(t, "EdDSA", alg)
+	})
+
+	t.Run("success - kid, alg not provided", func(t *testing.T) {
+		_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		signer := New(privateKey, "", "")
+
+		// verify headers
+		kid, ok := signer.Headers().KeyID()
+		require.Equal(t, false, ok)
+		require.Empty(t, kid)
+
+		alg, ok := signer.Headers().Algorithm()
+		require.Equal(t, false, ok)
+		require.Empty(t, alg)
+	})
 }

--- a/pkg/versions/0_1/client/deactivate_test.go
+++ b/pkg/versions/0_1/client/deactivate_test.go
@@ -74,12 +74,10 @@ func TestValidateSigner(t *testing.T) {
 		require.Contains(t, err.Error(), "missing signer")
 	})
 
-	t.Run("err - kid must be present in the protected header", func(t *testing.T) {
-		signer := &MockSigner{MockHeaders: make(jws.Headers)}
-
-		err := validateSigner(signer)
+	t.Run("error - missing protected headers", func(t *testing.T) {
+		err := validateSigner(&MockSigner{})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "kid must be present in the protected header")
+		require.Contains(t, err.Error(), "missing protected headers")
 	})
 
 	t.Run("err - algorithm must be present in the protected header", func(t *testing.T) {
@@ -118,7 +116,7 @@ func TestValidateSigner(t *testing.T) {
 
 		err := validateSigner(signer)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "protected headers can only contain kid and alg")
+		require.Contains(t, err.Error(), "header 'invalid' is not allowed in the protected headers")
 	})
 }
 
@@ -130,19 +128,15 @@ type MockSigner struct {
 
 // New creates new mock signer (default to recovery signer).
 func NewMockSigner(err error) *MockSigner {
-	return &MockSigner{Err: err}
+	headers := make(jws.Headers)
+	headers[jws.HeaderAlgorithm] = "alg"
+	headers[jws.HeaderKeyID] = "kid"
+
+	return &MockSigner{Err: err, MockHeaders: headers}
 }
 
 // Headers provides required JWS protected headers. It provides information about signing key and algorithm.
 func (ms *MockSigner) Headers() jws.Headers {
-	if ms.MockHeaders == nil {
-		headers := make(jws.Headers)
-		headers[jws.HeaderAlgorithm] = "alg"
-		headers[jws.HeaderKeyID] = "kid"
-
-		return headers
-	}
-
 	return ms.MockHeaders
 }
 

--- a/pkg/versions/0_1/client/update_test.go
+++ b/pkg/versions/0_1/client/update_test.go
@@ -80,7 +80,7 @@ func TestNewUpdateRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "missing update key")
 	})
-	t.Run("kid must be present in the protected header", func(t *testing.T) {
+	t.Run("algorithm must be present in the protected header", func(t *testing.T) {
 		signer = NewMockSigner(nil)
 		signer.MockHeaders = make(jws.Headers)
 
@@ -95,7 +95,7 @@ func TestNewUpdateRequest(t *testing.T) {
 		request, err := NewUpdateRequest(info)
 		require.Error(t, err)
 		require.Empty(t, request)
-		require.Contains(t, err.Error(), "kid must be present in the protected header")
+		require.Contains(t, err.Error(), "algorithm must be present in the protected header")
 	})
 	t.Run("signing error", func(t *testing.T) {
 		info := &UpdateRequestInfo{

--- a/pkg/versions/0_1/operationparser/commitment_test.go
+++ b/pkg/versions/0_1/operationparser/commitment_test.go
@@ -237,7 +237,7 @@ func generateUpdateRequest(updateKey *ecdsa.PrivateKey, commitment string, p pro
 
 	info := &client.UpdateRequestInfo{
 		DidSuffix:        "update-suffix",
-		Signer:           ecsigner.New(updateKey, "ES256", "key-1"),
+		Signer:           ecsigner.New(updateKey, "ES256", ""),
 		UpdateCommitment: commitment,
 		UpdateKey:        jwk,
 		Patches:          []patch.Patch{testPatch},

--- a/pkg/versions/0_1/txnprovider/handler_test.go
+++ b/pkg/versions/0_1/txnprovider/handler_test.go
@@ -491,7 +491,7 @@ func generateUpdateOperation(num int) ([]byte, error) {
 
 	info := &client.UpdateRequestInfo{
 		DidSuffix:        fmt.Sprintf("update-%d", num),
-		Signer:           ecsigner.New(privateKey, "ES256", "key-1"),
+		Signer:           ecsigner.New(privateKey, "ES256", ""),
 		UpdateCommitment: updateCommitment,
 		UpdateKey:        testJWK,
 		Patches:          []patch.Patch{testPatch},


### PR DESCRIPTION
Remove "kid must be present in the protected headers" rule in the client
Also, if empty don't add kid, alg to the headers of utility signers.

Closes #503

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>