### PR TITLE
chore: Add support for service endpoint object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/multiformats/go-multihash v0.0.14
-	github.com/onsi/ginkgo v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/square/go-jose/v3 v3.0.0-20191119004800-96c717272387
 	github.com/stretchr/testify v1.4.0

--- a/pkg/document/service.go
+++ b/pkg/document/service.go
@@ -28,8 +28,8 @@ func (s Service) Type() string {
 }
 
 // ServiceEndpoint is service endpoint.
-func (s Service) ServiceEndpoint() string {
-	return stringEntry(s[ServiceEndpointProperty])
+func (s Service) ServiceEndpoint() interface{} {
+	return s[ServiceEndpointProperty]
 }
 
 // JSONLdObject returns map that represents JSON LD Object.

--- a/pkg/versions/0_1/doctransformer/didtransformer/testdata/doc.json
+++ b/pkg/versions/0_1/doctransformer/didtransformer/testdata/doc.json
@@ -85,6 +85,15 @@
       "routingKeys": "routingKeysValue",
       "recipientKeys": "recipientKeysValue",
       "serviceEndpoint": "https://example.com/hub/"
+    },
+    {
+      "id": "hub-object",
+      "type": "IdentityHub",
+      "serviceEndpoint": {
+        "@context": "https://schema.identity.foundation/hub",
+        "type": "UserHubEndpoint",
+        "instances": ["did:example:456", "did:example:789"]
+      }
     }
   ]
 }

--- a/pkg/versions/0_1/doctransformer/didtransformer/transformer_test.go
+++ b/pkg/versions/0_1/doctransformer/didtransformer/transformer_test.go
@@ -81,11 +81,23 @@ func TestTransformDocument(t *testing.T) {
 
 		// validate services
 		service := didDoc.Services()[0]
-		require.Contains(t, service.ID(), testID)
-		require.NotEmpty(t, service.ServiceEndpoint())
+		require.Equal(t, service.ID(), testID+"#hub")
+		require.Equal(t, "https://example.com/hub/", service.ServiceEndpoint().(string))
 		require.Equal(t, "recipientKeysValue", service["recipientKeys"])
 		require.Equal(t, "routingKeysValue", service["routingKeys"])
 		require.Equal(t, "IdentityHub", service.Type())
+
+		service = didDoc.Services()[1]
+		require.Equal(t, service.ID(), testID+"#hub-object")
+		require.NotEmpty(t, service.ServiceEndpoint())
+		require.Empty(t, service["recipientKeys"])
+		require.Equal(t, "IdentityHub", service.Type())
+
+		serviceEndpointEntry := service.ServiceEndpoint()
+		serviceEndpoint := serviceEndpointEntry.(map[string]interface{})
+		require.Equal(t, "https://schema.identity.foundation/hub", serviceEndpoint["@context"])
+		require.Equal(t, "UserHubEndpoint", serviceEndpoint["type"])
+		require.Equal(t, []interface{}{"did:example:456", "did:example:789"}, serviceEndpoint["instances"])
 
 		// validate public keys
 		pk := didDoc.VerificationMethods()[0]

--- a/pkg/versions/0_1/operationparser/patchvalidator/document.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/document.go
@@ -30,8 +30,7 @@ const (
 	// public keys, services id length.
 	maxIDLength = 50
 
-	maxServiceTypeLength     = 30
-	maxServiceEndpointLength = 100
+	maxServiceTypeLength = 30
 )
 
 var allowedPurposes = map[document.KeyPurpose]bool{
@@ -196,17 +195,31 @@ func validateServiceType(serviceType string) error {
 	return nil
 }
 
-func validateServiceEndpoint(serviceEndpoint string) error {
-	if serviceEndpoint == "" {
+func validateServiceEndpoint(serviceEndpoint interface{}) error {
+	if serviceEndpoint == nil {
 		return errors.New("service endpoint is missing")
 	}
 
-	if len(serviceEndpoint) > maxServiceEndpointLength {
-		return fmt.Errorf("service endpoint exceeds maximum length: %d", maxServiceEndpointLength)
+	uri, ok := serviceEndpoint.(string)
+	if ok {
+		return validateURI(uri)
 	}
 
-	if _, err := url.ParseRequestURI(serviceEndpoint); err != nil {
-		return fmt.Errorf("service endpoint is not valid URI: %s", err.Error())
+	_, ok = serviceEndpoint.([]interface{})
+	if ok {
+		return errors.New("service endpoint cannot be an array of objects")
+	}
+
+	return nil
+}
+
+func validateURI(uri string) error {
+	if uri == "" {
+		return errors.New("service endpoint URI is empty")
+	}
+
+	if _, err := url.ParseRequestURI(uri); err != nil {
+		return fmt.Errorf("service endpoint '%s' is not a valid URI: %s", uri, err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Add support for service endpoint as either URI string or  "JSON object with properties that describe the Service Endpoint further." Also, remove check for service endpoint URI length (no longer in spec)

Closes #508

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>