### PR TITLE
chore: move canonicalId to did document metadata

### DIFF
--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -117,7 +117,7 @@ func TestDocumentHandler_ResolveDocument_DID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
-	require.Equal(t, result.MethodMetadata[document.CanonicalIDProperty], docID)
+	require.Equal(t, result.DocumentMetadata[document.CanonicalIDProperty], docID)
 	require.Equal(t, result.Document[keyID], aliasID)
 
 	// scenario: invalid namespace

--- a/pkg/document/resolution.go
+++ b/pkg/document/resolution.go
@@ -8,13 +8,14 @@ package document
 
 // ResolutionResult describes resolution result.
 type ResolutionResult struct {
-	Context        string         `json:"@context"`
-	Document       Document       `json:"didDocument"`
-	MethodMetadata MethodMetadata `json:"methodMetadata"`
+	Context          string   `json:"@context"`
+	Document         Document `json:"didDocument"`
+	MethodMetadata   Metadata `json:"methodMetadata"`
+	DocumentMetadata Metadata `json:"didDocumentMetadata,omitempty"`
 }
 
-// MethodMetadata contains document metadata.
-type MethodMetadata map[string]interface{}
+// Metadata can contains various metadata such as document metadata and method metadata..
+type Metadata map[string]interface{}
 
 const (
 	// UpdateCommitmentProperty is update commitment key.
@@ -27,5 +28,5 @@ const (
 	PublishedProperty = "published"
 
 	// CanonicalIDProperty is canonical ID key.
-	CanonicalIDProperty = "canonicalID"
+	CanonicalIDProperty = "canonicalId"
 )

--- a/pkg/mocks/transformer.go
+++ b/pkg/mocks/transformer.go
@@ -29,7 +29,7 @@ func (m *MockDocumentTransformer) TransformDocument(internal *protocol.Resolutio
 
 	internal.Doc[document.IDProperty] = info[document.IDProperty]
 
-	metadata := make(document.MethodMetadata)
+	metadata := make(document.Metadata)
 	metadata[document.PublishedProperty] = info[document.PublishedProperty]
 	metadata[document.RecoveryCommitmentProperty] = internal.RecoveryCommitment
 	metadata[document.UpdateCommitmentProperty] = internal.UpdateCommitment

--- a/pkg/versions/0_1/doctransformer/didtransformer/transformer_test.go
+++ b/pkg/versions/0_1/doctransformer/didtransformer/transformer_test.go
@@ -69,7 +69,7 @@ func TestTransformDocument(t *testing.T) {
 		require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
 		require.Equal(t, "recovery", result.MethodMetadata[document.RecoveryCommitmentProperty])
 		require.Equal(t, "update", result.MethodMetadata[document.UpdateCommitmentProperty])
-		require.Empty(t, result.MethodMetadata[document.CanonicalIDProperty])
+		require.Empty(t, result.DocumentMetadata)
 
 		jsonTransformed, err := json.Marshal(result.Document)
 		require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestTransformDocument(t *testing.T) {
 		require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
 		require.Equal(t, "recovery", result.MethodMetadata[document.RecoveryCommitmentProperty])
 		require.Equal(t, "update", result.MethodMetadata[document.UpdateCommitmentProperty])
-		require.Equal(t, "canonical", result.MethodMetadata[document.CanonicalIDProperty])
+		require.Equal(t, "canonical", result.DocumentMetadata[document.CanonicalIDProperty])
 	})
 
 	t.Run("error - internal document is missing", func(t *testing.T) {

--- a/pkg/versions/0_1/doctransformer/doctransformer/transformer.go
+++ b/pkg/versions/0_1/doctransformer/doctransformer/transformer.go
@@ -45,18 +45,26 @@ func (v *Transformer) TransformDocument(rm *protocol.ResolutionModel, info proto
 
 	rm.Doc[document.IDProperty] = id
 
-	metadata := make(document.MethodMetadata)
-	metadata[document.PublishedProperty] = published
-	metadata[document.RecoveryCommitmentProperty] = rm.RecoveryCommitment
-	metadata[document.UpdateCommitmentProperty] = rm.UpdateCommitment
+	methodMetadata := make(document.Metadata)
+	methodMetadata[document.PublishedProperty] = published
+	methodMetadata[document.RecoveryCommitmentProperty] = rm.RecoveryCommitment
+	methodMetadata[document.UpdateCommitmentProperty] = rm.UpdateCommitment
+
+	result := &document.ResolutionResult{
+		Document:       rm.Doc,
+		MethodMetadata: methodMetadata,
+	}
+
+	docMetadata := make(document.Metadata)
 
 	canonicalID, ok := info[document.CanonicalIDProperty]
 	if ok {
-		metadata[document.CanonicalIDProperty] = canonicalID
+		docMetadata[document.CanonicalIDProperty] = canonicalID
 	}
 
-	return &document.ResolutionResult{
-		Document:       rm.Doc,
-		MethodMetadata: metadata,
-	}, nil
+	if len(docMetadata) > 0 {
+		result.DocumentMetadata = docMetadata
+	}
+
+	return result, nil
 }

--- a/pkg/versions/0_1/doctransformer/doctransformer/transformer_test.go
+++ b/pkg/versions/0_1/doctransformer/doctransformer/transformer_test.go
@@ -38,7 +38,7 @@ func TestTransformDocument(t *testing.T) {
 		require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
 		require.Equal(t, "recovery", result.MethodMetadata[document.RecoveryCommitmentProperty])
 		require.Equal(t, "update", result.MethodMetadata[document.UpdateCommitmentProperty])
-		require.Empty(t, result.MethodMetadata[document.CanonicalIDProperty])
+		require.Empty(t, result.DocumentMetadata)
 	})
 
 	t.Run("success - with canonical ID", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestTransformDocument(t *testing.T) {
 		require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
 		require.Equal(t, "recovery", result.MethodMetadata[document.RecoveryCommitmentProperty])
 		require.Equal(t, "update", result.MethodMetadata[document.UpdateCommitmentProperty])
-		require.Equal(t, "canonical", result.MethodMetadata[document.CanonicalIDProperty])
+		require.Equal(t, "canonical", result.DocumentMetadata[document.CanonicalIDProperty])
 	})
 
 	t.Run("error - internal document is missing", func(t *testing.T) {


### PR DESCRIPTION
Created new did document metadata section in the resolution result and set canonicalId there

Closes #514

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>