### PR TITLE
chore: add-services patch should not allow duplicate service ids

### DIFF
--- a/pkg/versions/0_1/operationparser/patchvalidator/document.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/document.go
@@ -76,7 +76,7 @@ var allowedKeyTypes = map[string]existenceMap{
 
 // validatePublicKeys validates public keys.
 func validatePublicKeys(pubKeys []document.PublicKey) error {
-	ids := make(map[string]string)
+	ids := make(map[string]bool)
 
 	for _, pubKey := range pubKeys {
 		if err := validatePublicKeyProperties(pubKey); err != nil {
@@ -91,7 +91,7 @@ func validatePublicKeys(pubKeys []document.PublicKey) error {
 		if _, ok := ids[kid]; ok {
 			return fmt.Errorf("duplicate public key id: %s", kid)
 		}
-		ids[kid] = kid
+		ids[kid] = true
 
 		if err := validateKeyPurposes(pubKey); err != nil {
 			return err
@@ -144,10 +144,17 @@ func validateID(id string) error {
 
 // validateServices validates services.
 func validateServices(services []document.Service) error {
+	ids := make(map[string]bool)
 	for _, service := range services {
 		if err := validateService(service); err != nil {
 			return err
 		}
+
+		if _, ok := ids[service.ID()]; ok {
+			return fmt.Errorf("duplicate service id: %s", service.ID())
+		}
+
+		ids[service.ID()] = true
 	}
 
 	return nil

--- a/pkg/versions/0_1/operationparser/patchvalidator/document_test.go
+++ b/pkg/versions/0_1/operationparser/patchvalidator/document_test.go
@@ -114,7 +114,15 @@ func TestValidateServices(t *testing.T) {
 		require.NoError(t, err)
 
 		err = validateServices(doc.Services())
-		require.Nil(t, err)
+		require.NoError(t, err)
+	})
+	t.Run("error - duplicate service id", func(t *testing.T) {
+		doc, err := document.DidDocumentFromBytes([]byte(serviceDocWithDuplicateServices))
+		require.NoError(t, err)
+
+		err = validateServices(doc.Services())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate service id: sid-123_ABC")
 	})
 	t.Run("success - service can have allowed optional property", func(t *testing.T) {
 		doc, err := document.DidDocumentFromBytes([]byte(serviceDocOptionalProperty))
@@ -495,6 +503,19 @@ const duplicateID = `{
 
 const serviceDoc = `{
 	"service": [{
+		"id": "sid-123_ABC",
+		"type": "VerifiableCredentialService",
+		"serviceEndpoint": "https://example.com/vc/"
+	}]
+}`
+
+const serviceDocWithDuplicateServices = `{
+	"service": [{
+		"id": "sid-123_ABC",
+		"type": "VerifiableCredentialService",
+		"serviceEndpoint": "https://example.com/vc/"
+	},
+	{
 		"id": "sid-123_ABC",
 		"type": "VerifiableCredentialService",
 		"serviceEndpoint": "https://example.com/vc/"


### PR DESCRIPTION
Add validation for duplicate service id to "add-services" patch

Closes #518

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>