### PR TITLE
feat: Add max operation hash length protocol parameter

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -37,6 +37,8 @@ type Protocol struct {
 	// MaxOperationSize is maximum operation size in bytes (used to reject operations before parsing them)
 	// It has to be greater than max delta size (big) + max proof size (medium) + other small values (operation type, suffix-data)
 	MaxOperationSize uint `json:"maxOperationSize"`
+	// MaxOperationHashLength is maximum operation hash length
+	MaxOperationHashLength uint `json:"maxOperationHashLength"`
 	// MaxDeltaSize is maximum size of operation's delta property.
 	MaxDeltaSize uint `json:"maxDeltaSize"`
 	// MaxProofSize is maximum size of operation's proof property.

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -143,6 +143,7 @@ func GetDefaultProtocolParameters() protocol.Protocol {
 		MultihashAlgorithm:          sha2_256,
 		MaxOperationCount:           2,
 		MaxOperationSize:            MaxOperationByteSize,
+		MaxOperationHashLength:      100,
 		MaxDeltaSize:                MaxDeltaByteSize,
 		MaxProofSize:                MaxProofByteSize,
 		MaxCasURILength:             100,

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1265,6 +1265,7 @@ func newMockProtocolClient() *mocks.MockProtocolClient {
 		MultihashAlgorithm:          sha2_512,
 		MaxOperationCount:           2,
 		MaxOperationSize:            mocks.MaxOperationByteSize,
+		MaxOperationHashLength:      100,
 		MaxDeltaSize:                mocks.MaxDeltaByteSize,
 		MaxProofSize:                700, // has to be increased from 500 since we now use sha2_512
 		MaxCasURILength:             100,

--- a/pkg/versions/0_1/operationapplier/operationapplier_test.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier_test.go
@@ -47,6 +47,7 @@ var (
 		MultihashAlgorithm:          sha2_256,
 		MaxOperationCount:           2,
 		MaxOperationSize:            2000,
+		MaxOperationHashLength:      100,
 		MaxProofSize:                500,
 		MaxDeltaSize:                1000,
 		MaxCasURILength:             100,

--- a/pkg/versions/0_1/operationparser/deactivate.go
+++ b/pkg/versions/0_1/operationparser/deactivate.go
@@ -85,7 +85,7 @@ func (p *Parser) ParseSignedDataForDeactivate(compactJWS string) (*model.Deactiv
 	}
 
 	if err := p.validateSigningKey(signedData.RecoveryKey, p.KeyAlgorithms); err != nil {
-		return nil, fmt.Errorf("signed data for deactivate: %s", err.Error())
+		return nil, fmt.Errorf("validate signed data for deactivate: %s", err.Error())
 	}
 
 	return signedData, nil

--- a/pkg/versions/0_1/operationparser/deactivate_test.go
+++ b/pkg/versions/0_1/operationparser/deactivate_test.go
@@ -124,7 +124,7 @@ func TestParseDeactivateOperation(t *testing.T) {
 
 		op, err := parser.ParseDeactivateOperation(request, false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "signed data for deactivate: key algorithm 'crv' is not in the allowed list [other]")
+		require.Contains(t, err.Error(), "validate signed data for deactivate: key algorithm 'crv' is not in the allowed list [other]")
 		require.Nil(t, op)
 	})
 }

--- a/pkg/versions/0_1/operationparser/operation_test.go
+++ b/pkg/versions/0_1/operationparser/operation_test.go
@@ -19,19 +19,21 @@ const (
 	namespace = "did:sidetree"
 
 	maxOperationSize = 2000
+	maxHashLength    = 100
 	maxDeltaSize     = 1000
 	maxProofSize     = 500
 )
 
 func TestGetOperation(t *testing.T) {
 	p := protocol.Protocol{
-		MaxOperationSize:    maxOperationSize,
-		MaxDeltaSize:        maxDeltaSize,
-		MaxProofSize:        maxProofSize,
-		MultihashAlgorithm:  sha2_256,
-		SignatureAlgorithms: []string{"alg"},
-		KeyAlgorithms:       []string{"crv"},
-		Patches:             []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MaxOperationSize:       maxOperationSize,
+		MaxOperationHashLength: maxHashLength,
+		MaxDeltaSize:           maxDeltaSize,
+		MaxProofSize:           maxProofSize,
+		MultihashAlgorithm:     sha2_256,
+		SignatureAlgorithms:    []string{"alg"},
+		KeyAlgorithms:          []string{"crv"},
+		Patches:                []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -97,13 +97,12 @@ func (p *Parser) validateSignedDataForRecovery(signedData *model.RecoverSignedDa
 		return err
 	}
 
-	code := uint64(p.MultihashAlgorithm)
-	if !hashing.IsComputedUsingMultihashAlgorithm(signedData.RecoveryCommitment, code) {
-		return fmt.Errorf("next recovery commitment hash is not computed with the required hash algorithm: %d", code)
+	if err := p.validateMultihash(signedData.RecoveryCommitment, "recovery commitment"); err != nil {
+		return err
 	}
 
-	if !hashing.IsComputedUsingMultihashAlgorithm(signedData.DeltaHash, code) {
-		return fmt.Errorf("patch data hash is not computed with the required hash algorithm: %d", code)
+	if err := p.validateMultihash(signedData.DeltaHash, "delta hash"); err != nil {
+		return err
 	}
 
 	return validateCommitment(signedData.RecoveryKey, p.MultihashAlgorithm, signedData.RecoveryCommitment)

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
-	"github.com/trustbloc/sidetree-core-go/pkg/hashing"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -83,7 +82,7 @@ func (p *Parser) ParseSignedDataForUpdate(compactJWS string) (*model.UpdateSigne
 	}
 
 	if err := p.validateSignedDataForUpdate(schema); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate signed data for update: %s", err.Error())
 	}
 
 	return schema, nil
@@ -103,13 +102,8 @@ func (p *Parser) validateUpdateRequest(update *model.UpdateRequest) error {
 
 func (p *Parser) validateSignedDataForUpdate(signedData *model.UpdateSignedDataModel) error {
 	if err := p.validateSigningKey(signedData.UpdateKey, p.KeyAlgorithms); err != nil {
-		return fmt.Errorf("signed data for update: %s", err.Error())
+		return err
 	}
 
-	code := uint64(p.MultihashAlgorithm)
-	if !hashing.IsComputedUsingMultihashAlgorithm(signedData.DeltaHash, code) {
-		return fmt.Errorf("delta hash is not computed with the required multihash algorithm: %d", code)
-	}
-
-	return nil
+	return p.validateMultihash(signedData.DeltaHash, "delta hash")
 }

--- a/pkg/versions/0_1/operationparser/update_test.go
+++ b/pkg/versions/0_1/operationparser/update_test.go
@@ -24,12 +24,13 @@ import (
 
 func TestParseUpdateOperation(t *testing.T) {
 	p := protocol.Protocol{
-		MaxDeltaSize:        maxDeltaSize,
-		MaxProofSize:        maxProofSize,
-		MultihashAlgorithm:  sha2_256,
-		SignatureAlgorithms: []string{"alg"},
-		KeyAlgorithms:       []string{"crv"},
-		Patches:             []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MaxOperationHashLength: maxHashLength,
+		MaxDeltaSize:           maxDeltaSize,
+		MaxProofSize:           maxProofSize,
+		MultihashAlgorithm:     sha2_256,
+		SignatureAlgorithms:    []string{"alg"},
+		KeyAlgorithms:          []string{"crv"},
+		Patches:                []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
 	}
 
 	parser := New(p)
@@ -81,7 +82,7 @@ func TestParseUpdateOperation(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, schema)
 		require.Contains(t, err.Error(),
-			"next update commitment hash is not computed with the required supported hash algorithm")
+			"update commitment is not computed with the required hash algorithm: 18")
 	})
 	t.Run("invalid signed data", func(t *testing.T) {
 		delta, err := getUpdateDelta()
@@ -140,10 +141,11 @@ func TestParseUpdateOperation(t *testing.T) {
 
 func TestParseSignedDataForUpdate(t *testing.T) {
 	p := protocol.Protocol{
-		MaxProofSize:        maxProofSize,
-		MultihashAlgorithm:  sha2_256,
-		SignatureAlgorithms: []string{"alg"},
-		KeyAlgorithms:       []string{"crv"},
+		MaxOperationHashLength: maxHashLength,
+		MaxProofSize:           maxProofSize,
+		MultihashAlgorithm:     sha2_256,
+		SignatureAlgorithms:    []string{"alg"},
+		KeyAlgorithms:          []string{"crv"},
 	}
 
 	parser := New(p)
@@ -176,7 +178,7 @@ func TestParseSignedDataForUpdate(t *testing.T) {
 		schema, err := parser.ParseSignedDataForUpdate(compactJWS)
 		require.Error(t, err)
 		require.Nil(t, schema)
-		require.Contains(t, err.Error(), "delta hash is not computed with the required multihash algorithm: 18")
+		require.Contains(t, err.Error(), "delta hash is not computed with the required hash algorithm: 18")
 	})
 	t.Run("payload not JSON object", func(t *testing.T) {
 		compactJWS, err := signutil.SignPayload([]byte("test"), NewMockSigner())
@@ -205,7 +207,7 @@ func TestValidateUpdateDelta(t *testing.T) {
 		err = parser.ValidateDelta(delta)
 		require.Error(t, err)
 		require.Contains(t, err.Error(),
-			"next update commitment hash is not computed with the required supported hash algorithm")
+			"update commitment is not computed with the required hash algorithm")
 	})
 }
 


### PR DESCRIPTION
Add MAX_OPERATION_HASH_LENGTH parameter to protocol and validate the following values against it:
- did suffix and reveal value in core index file (reference operation is generated by batch writer/values to be checked in observer)
- deltaHash, recoveryCommitment (suffix data) - input
- updateCommitment(delta) - input
- deltaHash, recoveryCommitment - JWS (recovery) - input

Closes #517

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>