### PR TITLE
feat: add reveal value to update, recover and deactivate requests

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -10,7 +10,6 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
-	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 )
 
@@ -72,7 +71,7 @@ type TxnProcessor interface {
 type OperationParser interface {
 	Parse(namespace string, operation []byte) (*operation.Operation, error)
 	ParseDID(namespace, shortOrLongFormDID string) (string, []byte, error)
-	GetRevealValue(operation []byte) (*jws.JWK, error)
+	GetRevealValue(operation []byte) (string, error)
 	GetCommitment(operation []byte) (string, error)
 }
 

--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -478,12 +478,12 @@ func generateOperation(num int) (*operation.QueuedOperation, error) {
 		Y:   "y",
 	}
 
-	updateCommitment, err := commitment.Calculate(updateJwk, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateJwk, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
-	recoverComitment, err := commitment.Calculate(recoverJWK, sha2_256)
+	recoverComitment, err := commitment.GetCommitment(recoverJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commitment/hash_test.go
+++ b/pkg/commitment/hash_test.go
@@ -19,7 +19,7 @@ const (
 	sha2_256 uint = 18 // multihash code
 )
 
-func TestCalculate(t *testing.T) {
+func TestGetCommitment(t *testing.T) {
 	jwk := &jws.JWK{
 		Crv: "crv",
 		Kty: "kty",
@@ -28,20 +28,20 @@ func TestCalculate(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		commitment, err := Calculate(jwk, sha2_256)
+		commitment, err := GetCommitment(jwk, sha2_256)
 		require.NoError(t, err)
 		require.NotEmpty(t, commitment)
 	})
 
 	t.Run(" error - multihash not supported", func(t *testing.T) {
-		commitment, err := Calculate(jwk, 55)
+		commitment, err := GetCommitment(jwk, 55)
 		require.Error(t, err)
 		require.Empty(t, commitment)
 		require.Contains(t, err.Error(), "algorithm not supported, unable to compute hash")
 	})
 
 	t.Run("error - canonicalization failed", func(t *testing.T) {
-		commitment, err := Calculate(nil, sha2_256)
+		commitment, err := GetCommitment(nil, sha2_256)
 		require.Error(t, err)
 		require.Empty(t, commitment)
 		require.Contains(t, err.Error(), "Expected '{' but got 'n'")
@@ -60,5 +60,55 @@ func TestCalculate(t *testing.T) {
 
 		expected := `{"crv":"secp256k1","kty":"EC","x":"5s3-bKjD1Eu_3NJu8pk7qIdOPl1GBzU_V8aR3xiacoM","y":"v0-Q5H3vcfAfQ4zsebJQvMrIg3pcsaJzRvuIYZ3_UOY"}`
 		require.Equal(t, string(canonicalized), expected)
+	})
+}
+
+func TestGetRevealValue(t *testing.T) {
+	jwk := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+		Y:   "y",
+	}
+
+	t.Run("success", func(t *testing.T) {
+		rv, err := GetRevealValue(jwk, sha2_256)
+		require.NoError(t, err)
+		require.NotEmpty(t, rv)
+	})
+
+	t.Run("error - wrong multihash code", func(t *testing.T) {
+		rv, err := GetRevealValue(jwk, 55)
+		require.Error(t, err)
+		require.Empty(t, rv)
+		require.Contains(t, err.Error(), "failed to get reveal value: algorithm not supported, unable to compute hash")
+	})
+}
+
+func TestGetCommitmentFromRevealValue(t *testing.T) {
+	jwk := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+		Y:   "y",
+	}
+
+	t.Run("success", func(t *testing.T) {
+		rv, err := GetRevealValue(jwk, sha2_256)
+		require.NoError(t, err)
+
+		cFromRv, err := GetCommitmentFromRevealValue(rv)
+		require.NoError(t, err)
+
+		c, err := GetCommitment(jwk, sha2_256)
+		require.NoError(t, err)
+		require.Equal(t, c, cFromRv)
+	})
+
+	t.Run("error - reveal value is not a multihash", func(t *testing.T) {
+		cFromRv, err := GetCommitmentFromRevealValue("reveal")
+		require.Error(t, err)
+		require.Empty(t, cFromRv)
+		require.Contains(t, err.Error(), "failed to get commitment from reveal value")
 	})
 }

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -499,7 +499,7 @@ func getSuffixData(delta *model.DeltaModel) (*model.SuffixDataModel, error) {
 		X:   "x",
 	}
 
-	c, err := commitment.Calculate(jwk, sha2_256)
+	c, err := commitment.GetCommitment(jwk, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hashing/hash.go
+++ b/pkg/hashing/hash.go
@@ -68,17 +68,22 @@ func IsComputedUsingMultihashAlgorithm(encodedMultihash string, code uint64) boo
 
 // GetMultihashCode returns multihash code from encoded multihash.
 func GetMultihashCode(encodedMultihash string) (uint64, error) {
-	multihashBytes, err := encoder.DecodeString(encodedMultihash)
+	mh, err := GetMultihash(encodedMultihash)
 	if err != nil {
-		return 0, err
-	}
-
-	mh, err := multihash.Decode(multihashBytes)
-	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get decoded multihash: %s", err.Error())
 	}
 
 	return mh.Code, nil
+}
+
+// GetMultihash returns decoded multihash from encoded multihash.
+func GetMultihash(encodedMultihash string) (*multihash.DecodedMultihash, error) {
+	multihashBytes, err := encoder.DecodeString(encodedMultihash)
+	if err != nil {
+		return nil, err
+	}
+
+	return multihash.Decode(multihashBytes)
 }
 
 // IsValidModelMultihash compares model with provided model multihash.

--- a/pkg/mocks/operationparser.gen.go
+++ b/pkg/mocks/operationparser.gen.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 )
 
 type OperationParser struct {
@@ -23,17 +22,17 @@ type OperationParser struct {
 		result1 string
 		result2 error
 	}
-	GetRevealValueStub        func([]byte) (*jws.JWK, error)
+	GetRevealValueStub        func([]byte) (string, error)
 	getRevealValueMutex       sync.RWMutex
 	getRevealValueArgsForCall []struct {
 		arg1 []byte
 	}
 	getRevealValueReturns struct {
-		result1 *jws.JWK
+		result1 string
 		result2 error
 	}
 	getRevealValueReturnsOnCall map[int]struct {
-		result1 *jws.JWK
+		result1 string
 		result2 error
 	}
 	ParseStub        func(string, []byte) (*operation.Operation, error)
@@ -138,7 +137,7 @@ func (fake *OperationParser) GetCommitmentReturnsOnCall(i int, result1 string, r
 	}{result1, result2}
 }
 
-func (fake *OperationParser) GetRevealValue(arg1 []byte) (*jws.JWK, error) {
+func (fake *OperationParser) GetRevealValue(arg1 []byte) (string, error) {
 	var arg1Copy []byte
 	if arg1 != nil {
 		arg1Copy = make([]byte, len(arg1))
@@ -167,7 +166,7 @@ func (fake *OperationParser) GetRevealValueCallCount() int {
 	return len(fake.getRevealValueArgsForCall)
 }
 
-func (fake *OperationParser) GetRevealValueCalls(stub func([]byte) (*jws.JWK, error)) {
+func (fake *OperationParser) GetRevealValueCalls(stub func([]byte) (string, error)) {
 	fake.getRevealValueMutex.Lock()
 	defer fake.getRevealValueMutex.Unlock()
 	fake.GetRevealValueStub = stub
@@ -180,28 +179,28 @@ func (fake *OperationParser) GetRevealValueArgsForCall(i int) []byte {
 	return argsForCall.arg1
 }
 
-func (fake *OperationParser) GetRevealValueReturns(result1 *jws.JWK, result2 error) {
+func (fake *OperationParser) GetRevealValueReturns(result1 string, result2 error) {
 	fake.getRevealValueMutex.Lock()
 	defer fake.getRevealValueMutex.Unlock()
 	fake.GetRevealValueStub = nil
 	fake.getRevealValueReturns = struct {
-		result1 *jws.JWK
+		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *OperationParser) GetRevealValueReturnsOnCall(i int, result1 *jws.JWK, result2 error) {
+func (fake *OperationParser) GetRevealValueReturnsOnCall(i int, result1 string, result2 error) {
 	fake.getRevealValueMutex.Lock()
 	defer fake.getRevealValueMutex.Unlock()
 	fake.GetRevealValueStub = nil
 	if fake.getRevealValueReturnsOnCall == nil {
 		fake.getRevealValueReturnsOnCall = make(map[int]struct {
-			result1 *jws.JWK
+			result1 string
 			result2 error
 		})
 	}
 	fake.getRevealValueReturnsOnCall[i] = struct {
-		result1 *jws.JWK
+		result1 string
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/restapi/diddochandler/updatehandler_test.go
+++ b/pkg/restapi/diddochandler/updatehandler_test.go
@@ -117,7 +117,7 @@ func getDelta() (*model.DeltaModel, error) {
 		return nil, err
 	}
 
-	updateCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(testJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func getDelta() (*model.DeltaModel, error) {
 }
 
 func getSuffixData() (*model.SuffixDataModel, error) {
-	recoveryCommitment, err := commitment.Calculate(testJWK, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(testJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/restapi/dochandler/updatehandler_test.go
+++ b/pkg/restapi/dochandler/updatehandler_test.go
@@ -139,12 +139,12 @@ func TestUpdateHandler_Update(t *testing.T) {
 }
 
 func getCreateRequestInfo() (*client.CreateRequestInfo, error) {
-	recoveryCommitment, err := commitment.Calculate(recoverJWK, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(recoverJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
-	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateJWK, sha2_256)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,12 @@ func getUpdateRequestInfo(uniqueSuffix string) *client.UpdateRequestInfo {
 		panic(err)
 	}
 
-	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
+	rv, err := commitment.GetRevealValue(pubKey, sha2_256)
+	if err != nil {
+		panic(err)
+	}
+
+	updateCommitment, err := commitment.GetCommitment(updateJWK, sha2_256)
 	if err != nil {
 		panic(err)
 	}
@@ -186,6 +191,7 @@ func getUpdateRequestInfo(uniqueSuffix string) *client.UpdateRequestInfo {
 		UpdateCommitment: updateCommitment,
 		MultihashCode:    sha2_256,
 		Signer:           ecsigner.New(privateKey, "ES256", ""),
+		RevealValue:      rv,
 	}
 }
 
@@ -196,10 +202,21 @@ func getDeactivateRequestInfo(uniqueSuffix string) *client.DeactivateRequestInfo
 		panic(err)
 	}
 
+	jwk, err := pubkey.GetPublicKeyJWK(&privateKey.PublicKey)
+	if err != nil {
+		panic(err)
+	}
+
+	rv, err := commitment.GetRevealValue(jwk, sha2_256)
+	if err != nil {
+		panic(err)
+	}
+
 	return &client.DeactivateRequestInfo{
 		DidSuffix:   uniqueSuffix,
-		RecoveryKey: recoverJWK,
+		RecoveryKey: jwk,
 		Signer:      ecsigner.New(privateKey, "ES256", ""),
+		RevealValue: rv,
 	}
 }
 
@@ -214,12 +231,17 @@ func getRecoverRequestInfo(uniqueSuffix string) *client.RecoverRequestInfo {
 		panic(err)
 	}
 
-	recoveryCommitment, err := commitment.Calculate(recoverJWK, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(recoverJWK, sha2_256)
 	if err != nil {
 		panic(err)
 	}
 
-	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateJWK, sha2_256)
+	if err != nil {
+		panic(err)
+	}
+
+	rv, err := commitment.GetRevealValue(recoveryKey, sha2_256)
 	if err != nil {
 		panic(err)
 	}
@@ -232,6 +254,7 @@ func getRecoverRequestInfo(uniqueSuffix string) *client.RecoverRequestInfo {
 		UpdateCommitment:   updateCommitment,
 		MultihashCode:      sha2_256,
 		Signer:             ecsigner.New(privateKey, "ES256", ""),
+		RevealValue:        rv,
 	}
 }
 

--- a/pkg/versions/0_1/client/create_test.go
+++ b/pkg/versions/0_1/client/create_test.go
@@ -41,10 +41,10 @@ func TestNewCreateRequest(t *testing.T) {
 	updateJWK, err := pubkey.GetPublicKeyJWK(&updatePrivateKey.PublicKey)
 	require.NoError(t, err)
 
-	recoveryCommitment, err := commitment.Calculate(recoverJWK, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(recoverJWK, sha2_256)
 	require.NoError(t, err)
 
-	updateCommitment, err := commitment.Calculate(updateJWK, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateJWK, sha2_256)
 	require.NoError(t, err)
 
 	t.Run("missing opaque document or patches", func(t *testing.T) {

--- a/pkg/versions/0_1/client/deactivate.go
+++ b/pkg/versions/0_1/client/deactivate.go
@@ -38,6 +38,9 @@ type DeactivateRequestInfo struct {
 	// Signer that will be used for signing specific subset of request data
 	// Signer for recover operation must be recovery key
 	Signer Signer
+
+	// RevealValue is reveal value
+	RevealValue string
 }
 
 // NewDeactivateRequest is utility function to create payload for 'deactivate' request.
@@ -57,9 +60,10 @@ func NewDeactivateRequest(info *DeactivateRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.DeactivateRequest{
-		Operation:  operation.TypeDeactivate,
-		DidSuffix:  info.DidSuffix,
-		SignedData: jws,
+		Operation:   operation.TypeDeactivate,
+		DidSuffix:   info.DidSuffix,
+		RevealValue: info.RevealValue,
+		SignedData:  jws,
 	}
 
 	return canonicalizer.MarshalCanonical(schema)
@@ -68,6 +72,10 @@ func NewDeactivateRequest(info *DeactivateRequestInfo) ([]byte, error) {
 func validateDeactivateRequest(info *DeactivateRequestInfo) error {
 	if info.DidSuffix == "" {
 		return errors.New("missing did unique suffix")
+	}
+
+	if info.RevealValue == "" {
+		return errors.New("missing reveal value")
 	}
 
 	return validateSigner(info.Signer)

--- a/pkg/versions/0_1/client/recover.go
+++ b/pkg/versions/0_1/client/recover.go
@@ -48,6 +48,9 @@ type RecoverRequestInfo struct {
 	// Signer will be used for signing specific subset of request data
 	// Signer for recover operation must be recovery key
 	Signer Signer
+
+	// RevealValue is reveal value
+	RevealValue string
 }
 
 // NewRecoverRequest is utility function to create payload for 'recovery' request.
@@ -89,10 +92,11 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.RecoverRequest{
-		Operation:  operation.TypeRecover,
-		DidSuffix:  info.DidSuffix,
-		Delta:      delta,
-		SignedData: jws,
+		Operation:   operation.TypeRecover,
+		DidSuffix:   info.DidSuffix,
+		RevealValue: info.RevealValue,
+		Delta:       delta,
+		SignedData:  jws,
 	}
 
 	return canonicalizer.MarshalCanonical(schema)
@@ -101,6 +105,10 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 func validateRecoverRequest(info *RecoverRequestInfo) error {
 	if info.DidSuffix == "" {
 		return errors.New("missing did unique suffix")
+	}
+
+	if info.RevealValue == "" {
+		return errors.New("missing reveal value")
 	}
 
 	if info.OpaqueDocument == "" && len(info.Patches) == 0 {
@@ -127,7 +135,7 @@ func validateRecoveryKey(key *jws.JWK) error {
 }
 
 func validateCommitment(jwk *jws.JWK, multihashCode uint, nextCommitment string) error {
-	currentCommitment, err := commitment.Calculate(jwk, multihashCode)
+	currentCommitment, err := commitment.GetCommitment(jwk, multihashCode)
 	if err != nil {
 		return fmt.Errorf("calculate current commitment: %s", err.Error())
 	}

--- a/pkg/versions/0_1/client/recover_test.go
+++ b/pkg/versions/0_1/client/recover_test.go
@@ -32,6 +32,15 @@ func TestNewRecoverRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "missing did unique suffix")
 	})
+	t.Run("missing reveal value", func(t *testing.T) {
+		info := getRecoverRequestInfo()
+		info.RevealValue = ""
+
+		request, err := NewRecoverRequest(info)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing reveal value")
+	})
 	t.Run("missing opaque document", func(t *testing.T) {
 		info := getRecoverRequestInfo()
 		info.OpaqueDocument = ""
@@ -99,7 +108,7 @@ func TestNewRecoverRequest(t *testing.T) {
 	t.Run("error - re-using public keys for commitment is not allowed", func(t *testing.T) {
 		info := getRecoverRequestInfo()
 
-		currentCommitment, err := commitment.Calculate(info.RecoveryKey, info.MultihashCode)
+		currentCommitment, err := commitment.GetCommitment(info.RecoveryKey, info.MultihashCode)
 		require.NoError(t, err)
 
 		info.RecoveryCommitment = currentCommitment
@@ -164,5 +173,6 @@ func getRecoverRequestInfo() *RecoverRequestInfo {
 		RecoveryKey:    jwk,
 		MultihashCode:  sha2_256,
 		Signer:         ecsigner.New(privKey, "ES256", ""),
+		RevealValue:    "reveal",
 	}
 }

--- a/pkg/versions/0_1/client/update.go
+++ b/pkg/versions/0_1/client/update.go
@@ -38,6 +38,9 @@ type UpdateRequestInfo struct {
 
 	// Signer that will be used for signing request specific subset of data
 	Signer Signer
+
+	// RevealValue is reveal value
+	RevealValue string
 }
 
 // NewUpdateRequest is utility function to create payload for 'update' request.
@@ -72,10 +75,11 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 	}
 
 	schema := &model.UpdateRequest{
-		Operation:  operation.TypeUpdate,
-		DidSuffix:  info.DidSuffix,
-		Delta:      delta,
-		SignedData: jws,
+		Operation:   operation.TypeUpdate,
+		DidSuffix:   info.DidSuffix,
+		RevealValue: info.RevealValue,
+		Delta:       delta,
+		SignedData:  jws,
 	}
 
 	return canonicalizer.MarshalCanonical(schema)
@@ -84,6 +88,10 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 func validateUpdateRequest(info *UpdateRequestInfo) error {
 	if info.DidSuffix == "" {
 		return errors.New("missing did unique suffix")
+	}
+
+	if info.RevealValue == "" {
+		return errors.New("missing reveal value")
 	}
 
 	if len(info.Patches) == 0 {

--- a/pkg/versions/0_1/client/update_test.go
+++ b/pkg/versions/0_1/client/update_test.go
@@ -43,8 +43,16 @@ func TestNewUpdateRequest(t *testing.T) {
 		require.Empty(t, request)
 		require.Contains(t, err.Error(), "missing did unique suffix")
 	})
-	t.Run("missing json patch", func(t *testing.T) {
+	t.Run("missing reveal value", func(t *testing.T) {
 		info := &UpdateRequestInfo{DidSuffix: didSuffix}
+
+		request, err := NewUpdateRequest(info)
+		require.Error(t, err)
+		require.Empty(t, request)
+		require.Contains(t, err.Error(), "missing reveal value")
+	})
+	t.Run("missing json patch", func(t *testing.T) {
+		info := &UpdateRequestInfo{DidSuffix: didSuffix, RevealValue: "reveal"}
 
 		request, err := NewUpdateRequest(info)
 		require.Error(t, err)
@@ -53,10 +61,11 @@ func TestNewUpdateRequest(t *testing.T) {
 	})
 	t.Run("multihash not supported", func(t *testing.T) {
 		info := &UpdateRequestInfo{
-			DidSuffix: didSuffix,
-			Patches:   patches,
-			UpdateKey: updateJWK,
-			Signer:    signer,
+			DidSuffix:   didSuffix,
+			Patches:     patches,
+			UpdateKey:   updateJWK,
+			Signer:      signer,
+			RevealValue: "reveal",
 		}
 
 		request, err := NewUpdateRequest(info)
@@ -73,6 +82,7 @@ func TestNewUpdateRequest(t *testing.T) {
 			Patches:       patches,
 			MultihashCode: sha2_256,
 			Signer:        signer,
+			RevealValue:   "reveal",
 		}
 
 		request, err := NewUpdateRequest(info)
@@ -90,6 +100,7 @@ func TestNewUpdateRequest(t *testing.T) {
 			MultihashCode: sha2_256,
 			UpdateKey:     updateJWK,
 			Signer:        signer,
+			RevealValue:   "reveal",
 		}
 
 		request, err := NewUpdateRequest(info)
@@ -104,6 +115,7 @@ func TestNewUpdateRequest(t *testing.T) {
 			MultihashCode: sha2_256,
 			UpdateKey:     updateJWK,
 			Signer:        NewMockSigner(errors.New(signerErr)),
+			RevealValue:   "reveal",
 		}
 
 		request, err := NewUpdateRequest(info)
@@ -117,7 +129,7 @@ func TestNewUpdateRequest(t *testing.T) {
 
 		signer := ecsigner.New(privateKey, "ES256", "key-1")
 
-		currentCommitment, err := commitment.Calculate(updateJWK, sha2_256)
+		currentCommitment, err := commitment.GetCommitment(updateJWK, sha2_256)
 		require.NoError(t, err)
 
 		info := &UpdateRequestInfo{
@@ -127,6 +139,7 @@ func TestNewUpdateRequest(t *testing.T) {
 			UpdateKey:        updateJWK,
 			UpdateCommitment: currentCommitment,
 			Signer:           signer,
+			RevealValue:      "reveal",
 		}
 
 		request, err := NewUpdateRequest(info)
@@ -146,6 +159,7 @@ func TestNewUpdateRequest(t *testing.T) {
 			MultihashCode: sha2_256,
 			UpdateKey:     updateJWK,
 			Signer:        signer,
+			RevealValue:   "reveal",
 		}
 
 		request, err := NewUpdateRequest(info)

--- a/pkg/versions/0_1/model/request.go
+++ b/pkg/versions/0_1/model/request.go
@@ -55,6 +55,9 @@ type UpdateRequest struct {
 	// DidSuffix is the suffix of the DID
 	DidSuffix string `json:"didSuffix"`
 
+	// RevealValue is the reveal value
+	RevealValue string `json:"revealValue"`
+
 	// SignedData is compact JWS - signature information
 	SignedData string `json:"signedData"`
 
@@ -71,6 +74,9 @@ type DeactivateRequest struct {
 	// DidSuffix of the DID
 	// Required: true
 	DidSuffix string `json:"didSuffix"`
+
+	// RevealValue is the reveal value
+	RevealValue string `json:"revealValue"`
 
 	// Compact JWS - signature information
 	SignedData string `json:"signedData"`
@@ -105,6 +111,9 @@ type DeactivateSignedDataModel struct {
 	// Required: true
 	DidSuffix string `json:"didSuffix"`
 
+	// RevealValue is the reveal value
+	RevealValue string `json:"revealValue"`
+
 	// RecoveryKey is the current recovery key
 	RecoveryKey *jws.JWK `json:"recoveryKey"`
 }
@@ -118,6 +127,9 @@ type RecoverRequest struct {
 	// DidSuffix is the suffix of the DID
 	// Required: true
 	DidSuffix string `json:"didSuffix"`
+
+	// RevealValue is the reveal value
+	RevealValue string `json:"revealValue"`
 
 	// Compact JWS - signature information
 	SignedData string `json:"signedData"`

--- a/pkg/versions/0_1/model/util.go
+++ b/pkg/versions/0_1/model/util.go
@@ -26,25 +26,28 @@ func GetAnchoredOperation(op *Operation) (*operation.AnchoredOperation, error) {
 
 	case operation.TypeUpdate:
 		request = UpdateRequest{
-			Operation:  op.Type,
-			DidSuffix:  op.UniqueSuffix,
-			Delta:      op.Delta,
-			SignedData: op.SignedData,
+			Operation:   op.Type,
+			DidSuffix:   op.UniqueSuffix,
+			Delta:       op.Delta,
+			SignedData:  op.SignedData,
+			RevealValue: op.RevealValue,
 		}
 
 	case operation.TypeDeactivate:
 		request = DeactivateRequest{
-			Operation:  op.Type,
-			DidSuffix:  op.UniqueSuffix,
-			SignedData: op.SignedData,
+			Operation:   op.Type,
+			DidSuffix:   op.UniqueSuffix,
+			SignedData:  op.SignedData,
+			RevealValue: op.RevealValue,
 		}
 
 	case operation.TypeRecover:
 		request = RecoverRequest{
-			Operation:  op.Type,
-			DidSuffix:  op.UniqueSuffix,
-			Delta:      op.Delta,
-			SignedData: op.SignedData,
+			Operation:   op.Type,
+			DidSuffix:   op.UniqueSuffix,
+			Delta:       op.Delta,
+			SignedData:  op.SignedData,
+			RevealValue: op.RevealValue,
 		}
 
 	default:

--- a/pkg/versions/0_1/operationparser/commitment.go
+++ b/pkg/versions/0_1/operationparser/commitment.go
@@ -4,44 +4,21 @@ import (
 	"fmt"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
-	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 )
 
 // GetRevealValue returns this operation reveal value.
-func (p *Parser) GetRevealValue(opBytes []byte) (*jws.JWK, error) {
+func (p *Parser) GetRevealValue(opBytes []byte) (string, error) {
 	// namespace is irrelevant in this case
 	op, err := p.ParseOperation("", opBytes, false)
 	if err != nil {
-		return nil, fmt.Errorf("get reveal value - parse operation error: %s", err.Error())
+		return "", fmt.Errorf("get reveal value - parse operation error: %s", err.Error())
 	}
 
-	switch op.Type { //nolint:exhaustive
-	case operation.TypeUpdate:
-		signedDataModel, innerErr := p.ParseSignedDataForUpdate(op.SignedData)
-		if innerErr != nil {
-			return nil, fmt.Errorf("failed to parse signed data model for update: %s", innerErr.Error())
-		}
-
-		return signedDataModel.UpdateKey, nil
-
-	case operation.TypeDeactivate:
-		signedDataModel, innerErr := p.ParseSignedDataForDeactivate(op.SignedData)
-		if innerErr != nil {
-			return nil, fmt.Errorf("failed to parse signed data model for deactivate: %s", innerErr.Error())
-		}
-
-		return signedDataModel.RecoveryKey, nil
-
-	case operation.TypeRecover:
-		signedDataModel, innerErr := p.ParseSignedDataForRecover(op.SignedData)
-		if innerErr != nil {
-			return nil, fmt.Errorf("failed to parse signed data model for recover: %s", innerErr.Error())
-		}
-
-		return signedDataModel.RecoveryKey, nil
+	if op.Type == operation.TypeCreate {
+		return "", fmt.Errorf("operation type '%s' not supported for getting operation reveal value", op.Type)
 	}
 
-	return nil, fmt.Errorf("operation type '%s' not supported for getting operation reveal value", op.Type)
+	return op.RevealValue, nil
 }
 
 // GetCommitment returns next operation commitment.

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -352,7 +352,7 @@ func getSuffixData() (*model.SuffixDataModel, error) {
 		X:   "x",
 	}
 
-	recoveryCommitment, err := commitment.Calculate(jwk, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(jwk, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/versions/0_1/operationparser/deactivate.go
+++ b/pkg/versions/0_1/operationparser/deactivate.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/hashing"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -31,9 +32,9 @@ func (p *Parser) ParseDeactivateOperation(request []byte, batch bool) (*model.Op
 		return nil, errors.New("signed did suffix mismatch for deactivate")
 	}
 
-	revealValue, err := p.getRevealValueMultihash(signedData.RecoveryKey)
+	err = hashing.IsValidModelMultihash(signedData.RecoveryKey, schema.RevealValue)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get reveal value multihash for deactivate: %s", err.Error())
+		return nil, fmt.Errorf("canonicalized recovery public key hash doesn't match reveal value: %s", err.Error())
 	}
 
 	return &model.Operation{
@@ -41,7 +42,7 @@ func (p *Parser) ParseDeactivateOperation(request []byte, batch bool) (*model.Op
 		OperationBuffer: request,
 		UniqueSuffix:    schema.DidSuffix,
 		SignedData:      schema.SignedData,
-		RevealValue:     revealValue,
+		RevealValue:     schema.RevealValue,
 	}, nil
 }
 

--- a/pkg/versions/0_1/operationparser/operation_test.go
+++ b/pkg/versions/0_1/operationparser/operation_test.go
@@ -83,16 +83,18 @@ func TestGetOperation(t *testing.T) {
 
 		op, err := New(invalid).Parse(namespace, operation)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "operation size[698] exceeds maximum operation size[20]")
+		require.Contains(t, err.Error(), "operation size[761] exceeds maximum operation size[20]")
 		require.Nil(t, op)
 	})
 	t.Run("operation parsing error", func(t *testing.T) {
 		// set-up invalid hash algorithm in protocol configuration
 		invalid := protocol.Protocol{
-			SignatureAlgorithms: []string{"not-used"},
-			MaxOperationSize:    maxOperationSize,
-			MaxDeltaSize:        maxDeltaSize,
-			MaxProofSize:        maxProofSize,
+			SignatureAlgorithms:    []string{"not-used"},
+			MaxOperationSize:       maxOperationSize,
+			MaxDeltaSize:           maxDeltaSize,
+			MaxProofSize:           maxProofSize,
+			MaxOperationHashLength: maxHashLength,
+			MultihashAlgorithm:     18,
 		}
 
 		operation, err := getRecoverRequestBytes()

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/hashing"
 	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
@@ -39,9 +40,9 @@ func (p *Parser) ParseUpdateOperation(request []byte, batch bool) (*model.Operat
 		}
 	}
 
-	revealValue, err := p.getRevealValueMultihash(signedData.UpdateKey)
+	err = hashing.IsValidModelMultihash(signedData.UpdateKey, schema.RevealValue)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get reveal value multihash for update: %s", err.Error())
+		return nil, fmt.Errorf("canonicalized update public key hash doesn't match reveal value: %s", err.Error())
 	}
 
 	return &model.Operation{
@@ -50,7 +51,7 @@ func (p *Parser) ParseUpdateOperation(request []byte, batch bool) (*model.Operat
 		UniqueSuffix:    schema.DidSuffix,
 		Delta:           schema.Delta,
 		SignedData:      schema.SignedData,
-		RevealValue:     revealValue,
+		RevealValue:     schema.RevealValue,
 	}, nil
 }
 

--- a/pkg/versions/0_1/txnprovider/provider_test.go
+++ b/pkg/versions/0_1/txnprovider/provider_test.go
@@ -130,7 +130,7 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 
 		require.Error(t, err)
 		require.Nil(t, txnOps)
-		require.Contains(t, err.Error(), "failed to validate signed data for update[0]: proof size[264] exceeds maximum proof size[10]")
+		require.Contains(t, err.Error(), "failed to validate signed data for update[0]: proof size[376] exceeds maximum proof size[10]")
 	})
 
 	t.Run("error - delta exceeds maximum delta size in chunk file", func(t *testing.T) {


### PR DESCRIPTION
- add reveal value to update, recover and deactivate requests
- propagate this value to batch files
- use passed in reveal value (instead of JWK in signed data) for constructing operation hash map

There will be follow-up PR to validate reveal #525 value once we support multiple hashing algorithms in protocol #522 

Closes #521

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>