### PR TITLE
chore: Reject create operation at API layer when applying patches results in an empty document

### DIFF
--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -125,6 +125,11 @@ func (r *DocumentHandler) getCreateResult(op *operation.Operation, pv protocol.V
 		return nil, err
 	}
 
+	// if returned document is empty (e.g. applying patches failed) we can reject this request at API level
+	if len(rm.Doc.JSONLdObject()) == 0 {
+		return nil, errors.New("applying delta resulted in an empty document (most likely due to an invalid patch)")
+	}
+
 	return rm, nil
 }
 


### PR DESCRIPTION
Reject create operation at API layer when applying patches fails (e.g. resulting document is empty)

Currently, at the API layer, when user submits a create operation we accept delta that may result in an error during applying patches. The DID will be created with the commit reveal value but it won't be able to apply delta and the resulting document will be empty. We have an opportunity to gate this "half failed" operation at the API layer. This requires the API to behave differently from observer, but provides a better user experience. So basically we would fail for every create that results in an empty document. 

Closes #527

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>