### PR TITLE
feat: Align with core did spec

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -81,6 +81,7 @@ type ResolutionModel struct {
 	LastOperationProtocolGenesisTime uint64
 	UpdateCommitment                 string
 	RecoveryCommitment               string
+	Deactivated                      bool
 }
 
 // OperationApplier applies the given operation to the document.

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -223,10 +223,8 @@ func (r *DocumentHandler) resolveRequestWithID(namespace, uniquePortion string, 
 
 	ti := getTransformationInfo(namespace+docutil.NamespaceDelimiter+uniquePortion, true)
 
-	if r.namespace != namespace {
-		// we got here using alias; suggest using namespace
-		ti[document.CanonicalIDProperty] = r.namespace + docutil.NamespaceDelimiter + uniquePortion
-	}
+	// we should always set canonical id if document has been published
+	ti[document.CanonicalIDProperty] = r.namespace + docutil.NamespaceDelimiter + uniquePortion
 
 	return pv.DocumentTransformer().TransformDocument(internalResult, ti)
 }
@@ -256,7 +254,12 @@ func (r *DocumentHandler) resolveRequestWithInitialState(uniqueSuffix, longFormD
 		return nil, fmt.Errorf("%s: validate initial document: %s", badRequest, err.Error())
 	}
 
-	externalResult, err := pv.DocumentTransformer().TransformDocument(rm, getTransformationInfo(longFormDID, false))
+	ti := getTransformationInfo(longFormDID, false)
+
+	// we should always set equivalent id for long form resolution
+	ti[document.EquivalentIDProperty] = []string{r.namespace + docutil.NamespaceDelimiter + op.UniqueSuffix}
+
+	externalResult, err := pv.DocumentTransformer().TransformDocument(rm, ti)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform create with initial state to external document: %s", err.Error())
 	}

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -134,14 +134,20 @@ func TestDocumentHandler_ResolveDocument_DID(t *testing.T) {
 	result, err = dochandler.ResolveDocument(docID)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
+
+	methodMetadataEntry, ok := result.DocumentMetadata[document.MethodProperty]
+	require.True(t, ok)
+	methodMetadata, ok := methodMetadataEntry.(document.Metadata)
+	require.True(t, ok)
+
+	require.Equal(t, true, methodMetadata[document.PublishedProperty])
 
 	// scenario: resolve document with alias namespace (success)
 	aliasID := alias + ":" + uniqueSuffix
 	result, err = dochandler.ResolveDocument(aliasID)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, true, result.MethodMetadata[document.PublishedProperty])
+	require.Equal(t, true, methodMetadata[document.PublishedProperty])
 	require.Equal(t, result.DocumentMetadata[document.CanonicalIDProperty], docID)
 	require.Equal(t, result.Document[keyID], aliasID)
 
@@ -179,7 +185,14 @@ func TestDocumentHandler_ResolveDocument_InitialValue(t *testing.T) {
 		result, err := dochandler.ResolveDocument(docID + longFormPart)
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		require.Equal(t, false, result.MethodMetadata[document.PublishedProperty])
+
+		methodMetadataEntry, ok := result.DocumentMetadata[document.MethodProperty]
+		require.True(t, ok)
+
+		methodMetadata, ok := methodMetadataEntry.(document.Metadata)
+		require.True(t, ok)
+
+		require.Equal(t, false, methodMetadata[document.PublishedProperty])
 	})
 
 	t.Run("error - invalid initial state format (not encoded JCS)", func(t *testing.T) {

--- a/pkg/document/resolution.go
+++ b/pkg/document/resolution.go
@@ -10,7 +10,6 @@ package document
 type ResolutionResult struct {
 	Context          string   `json:"@context"`
 	Document         Document `json:"didDocument"`
-	MethodMetadata   Metadata `json:"methodMetadata"`
 	DocumentMetadata Metadata `json:"didDocumentMetadata,omitempty"`
 }
 
@@ -27,6 +26,15 @@ const (
 	// PublishedProperty is published key.
 	PublishedProperty = "published"
 
+	// DeactivatedProperty is deactivated flag key.
+	DeactivatedProperty = "deactivated"
+
 	// CanonicalIDProperty is canonical ID key.
 	CanonicalIDProperty = "canonicalId"
+
+	// EquivalentIDProperty is equivalent ID array.
+	EquivalentIDProperty = "equivalentId"
+
+	// MethodProperty is used for method metadata within did document metadata.
+	MethodProperty = "method"
 )

--- a/pkg/mocks/transformer.go
+++ b/pkg/mocks/transformer.go
@@ -34,8 +34,11 @@ func (m *MockDocumentTransformer) TransformDocument(internal *protocol.Resolutio
 	metadata[document.RecoveryCommitmentProperty] = internal.RecoveryCommitment
 	metadata[document.UpdateCommitmentProperty] = internal.UpdateCommitment
 
+	docMetadata := make(document.Metadata)
+	docMetadata[document.MethodProperty] = metadata
+
 	return &document.ResolutionResult{
-		Document:       internal.Doc,
-		MethodMetadata: metadata,
+		Document:         internal.Doc,
+		DocumentMetadata: docMetadata,
 	}, nil
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -71,8 +71,9 @@ func (s *OperationProcessor) Resolve(uniqueSuffix string) (*protocol.ResolutionM
 		logger.Debugf("[%s] Applying %d full operations for unique suffix [%s]", s.name, len(fullOps), uniqueSuffix)
 
 		rm = s.applyOperations(fullOps, rm, getRecoveryCommitment)
-		if rm.Doc == nil {
-			return nil, errors.New("document was deactivated")
+		if rm.Deactivated {
+			// document was deactivated, stop processing
+			return rm, nil
 		}
 	}
 

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -424,9 +424,10 @@ func TestDeactivate(t *testing.T) {
 
 		p := New("test", store, pc)
 		doc, err := p.Resolve(uniqueSuffix)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "document was deactivated")
-		require.Nil(t, doc)
+		require.NoError(t, err)
+		require.Equal(t, doc.Deactivated, true)
+		require.Empty(t, doc.UpdateCommitment)
+		require.Empty(t, doc.RecoveryCommitment)
 	})
 }
 

--- a/pkg/versions/0_1/doctransformer/metadata.go
+++ b/pkg/versions/0_1/doctransformer/metadata.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package doctransformer
+
+import (
+	"errors"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+)
+
+// CreateDocumentMetadata will create document metadata.
+func CreateDocumentMetadata(rm *protocol.ResolutionModel, info protocol.TransformationInfo) (document.Metadata, error) {
+	if rm == nil || rm.Doc == nil {
+		return nil, errors.New("resolution model is required for creating document metadata")
+	}
+
+	if info == nil {
+		return nil, errors.New("transformation info is required for creating document metadata")
+	}
+
+	published, ok := info[document.PublishedProperty]
+	if !ok {
+		return nil, errors.New("published is required for creating document metadata")
+	}
+
+	methodMetadata := make(document.Metadata)
+	methodMetadata[document.PublishedProperty] = published
+
+	if rm.RecoveryCommitment != "" {
+		methodMetadata[document.RecoveryCommitmentProperty] = rm.RecoveryCommitment
+	}
+
+	if rm.UpdateCommitment != "" {
+		methodMetadata[document.UpdateCommitmentProperty] = rm.UpdateCommitment
+	}
+
+	docMetadata := make(document.Metadata)
+	docMetadata[document.MethodProperty] = methodMetadata
+
+	// TODO: (issue-535) It is still not 100% confirmed that 'deactivated' flage will be in document metadata
+	if rm.Deactivated {
+		docMetadata[document.DeactivatedProperty] = rm.Deactivated
+	}
+
+	canonicalID, ok := info[document.CanonicalIDProperty]
+	if ok {
+		docMetadata[document.CanonicalIDProperty] = canonicalID
+	}
+
+	equivalentID, ok := info[document.EquivalentIDProperty]
+	if ok {
+		docMetadata[document.EquivalentIDProperty] = equivalentID
+	}
+
+	return docMetadata, nil
+}

--- a/pkg/versions/0_1/doctransformer/metadata_test.go
+++ b/pkg/versions/0_1/doctransformer/metadata_test.go
@@ -15,28 +15,27 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 )
 
-func TestNewTransformer(t *testing.T) {
-	require.NotNil(t, New())
-}
-
-func TestTransformDocument(t *testing.T) {
+func TestPopulateDocumentMetadata(t *testing.T) {
 	doc, err := document.FromBytes(validDoc)
 	require.NoError(t, err)
 
-	transformer := New()
-
 	internal := &protocol.ResolutionModel{Doc: doc, RecoveryCommitment: "recovery", UpdateCommitment: "update"}
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("success - all info present", func(t *testing.T) {
 		info := make(protocol.TransformationInfo)
 		info[document.IDProperty] = "did:abc:123"
 		info[document.PublishedProperty] = true
+		info[document.CanonicalIDProperty] = "canonical"
+		info[document.EquivalentIDProperty] = []string{"equivalent"}
 
-		result, err := transformer.TransformDocument(internal, info)
+		documentMetadata, err := CreateDocumentMetadata(internal, info)
 		require.NoError(t, err)
-		require.Equal(t, "did:abc:123", result.Document[document.IDProperty])
 
-		methodMetadataEntry, ok := result.DocumentMetadata[document.MethodProperty]
+		require.Empty(t, documentMetadata[document.DeactivatedProperty])
+		require.Equal(t, "canonical", documentMetadata[document.CanonicalIDProperty])
+		require.NotEmpty(t, documentMetadata[document.EquivalentIDProperty])
+
+		methodMetadataEntry, ok := documentMetadata[document.MethodProperty]
 		require.True(t, ok)
 		methodMetadata, ok := methodMetadataEntry.(document.Metadata)
 		require.True(t, ok)
@@ -46,28 +45,29 @@ func TestTransformDocument(t *testing.T) {
 		require.Equal(t, "update", methodMetadata[document.UpdateCommitmentProperty])
 	})
 
-	t.Run("success - with canonical, equivalent ID", func(t *testing.T) {
+	t.Run("success - deactivated, commitments empty", func(t *testing.T) {
+		internal2 := &protocol.ResolutionModel{Doc: doc, Deactivated: true}
+
 		info := make(protocol.TransformationInfo)
 		info[document.IDProperty] = "did:abc:123"
 		info[document.PublishedProperty] = true
 		info[document.CanonicalIDProperty] = "canonical"
-		info[document.EquivalentIDProperty] = []string{"equivalent"}
 
-		result, err := transformer.TransformDocument(internal, info)
+		documentMetadata, err := CreateDocumentMetadata(internal2, info)
 		require.NoError(t, err)
-		require.Equal(t, "did:abc:123", result.Document[document.IDProperty])
 
-		methodMetadataEntry, ok := result.DocumentMetadata[document.MethodProperty]
+		require.Equal(t, true, documentMetadata[document.DeactivatedProperty])
+		require.Equal(t, "canonical", documentMetadata[document.CanonicalIDProperty])
+		require.Empty(t, documentMetadata[document.EquivalentIDProperty])
+
+		methodMetadataEntry, ok := documentMetadata[document.MethodProperty]
 		require.True(t, ok)
 		methodMetadata, ok := methodMetadataEntry.(document.Metadata)
 		require.True(t, ok)
 
 		require.Equal(t, true, methodMetadata[document.PublishedProperty])
-		require.Equal(t, "recovery", methodMetadata[document.RecoveryCommitmentProperty])
-		require.Equal(t, "update", methodMetadata[document.UpdateCommitmentProperty])
-
-		require.Equal(t, "canonical", result.DocumentMetadata[document.CanonicalIDProperty])
-		require.NotEmpty(t, result.DocumentMetadata[document.EquivalentIDProperty])
+		require.Empty(t, methodMetadata[document.RecoveryCommitmentProperty])
+		require.Empty(t, methodMetadata[document.UpdateCommitmentProperty])
 	})
 
 	t.Run("error - internal document is missing", func(t *testing.T) {
@@ -75,27 +75,26 @@ func TestTransformDocument(t *testing.T) {
 		info[document.IDProperty] = "doc:abc:xyz"
 		info[document.PublishedProperty] = true
 
-		result, err := transformer.TransformDocument(nil, info)
+		result, err := CreateDocumentMetadata(nil, info)
 		require.Error(t, err)
 		require.Nil(t, result)
 		require.Contains(t, err.Error(), "resolution model is required for creating document metadata")
 	})
 
 	t.Run("error - transformation info is missing", func(t *testing.T) {
-		result, err := transformer.TransformDocument(internal, nil)
+		result, err := CreateDocumentMetadata(internal, nil)
 		require.Error(t, err)
 		require.Nil(t, result)
 		require.Contains(t, err.Error(), "transformation info is required for creating document metadata")
 	})
 
-	t.Run("error - transformation info is missing id", func(t *testing.T) {
+	t.Run("error - transformation info is missing published", func(t *testing.T) {
 		info := make(protocol.TransformationInfo)
-		info[document.PublishedProperty] = true
 
-		result, err := transformer.TransformDocument(internal, info)
+		result, err := CreateDocumentMetadata(internal, info)
 		require.Error(t, err)
 		require.Nil(t, result)
-		require.Contains(t, err.Error(), "id is required for document transformation")
+		require.Contains(t, err.Error(), "published is required for creating document metadata")
 	})
 }
 

--- a/pkg/versions/0_1/operationapplier/operationapplier.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier.go
@@ -205,12 +205,13 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperati
 	}
 
 	return &protocol.ResolutionModel{
-		Doc:                              nil,
+		Doc:                              make(document.Document),
 		LastOperationTransactionTime:     anchoredOp.TransactionTime,
 		LastOperationTransactionNumber:   anchoredOp.TransactionTime,
 		LastOperationProtocolGenesisTime: anchoredOp.ProtocolGenesisTime,
 		UpdateCommitment:                 "",
 		RecoveryCommitment:               "",
+		Deactivated:                      true,
 	}, nil
 }
 


### PR DESCRIPTION
Included:
- align resolution object with did core spec (method metadata moved to document metadata)
- add 'deactivated' flag to document metadata
- add 'equivalentId' for long form resolution
- return 'canonicalId' for all published documents

Created #535 for follow-up regarding questions posted to Sidetree slack regarding deactivate and controller.

Closes #534

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>