### PR TITLE
Return operation references upon creating batch files 

### DIFF
--- a/pkg/api/operation/models.go
+++ b/pkg/api/operation/models.go
@@ -22,6 +22,16 @@ type Operation struct {
 	OperationBuffer []byte
 }
 
+// Reference holds minimum information about did operation (suffix and type).
+type Reference struct {
+
+	// UniqueSuffix defines document unique suffix.
+	UniqueSuffix string
+
+	// Type defines operation type.
+	Type Type
+}
+
 // AnchoredOperation defines an anchored operation (stored in document operation store).
 type AnchoredOperation struct {
 

--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -97,7 +97,7 @@ type DocumentComposer interface {
 // OperationHandler defines an interface for creating batch files.
 type OperationHandler interface {
 	// GetTxnOperations operations will create relevant batch files, store them in CAS and return anchor string.
-	PrepareTxnFiles(ops []*operation.QueuedOperation) (string, error)
+	PrepareTxnFiles(ops []*operation.QueuedOperation) (string, []*operation.Reference, error)
 }
 
 // OperationProvider retrieves the anchored operations for the given Sidetree transaction.

--- a/pkg/batch/writer.go
+++ b/pkg/batch/writer.go
@@ -76,7 +76,7 @@ type Context interface {
 // BlockchainClient defines an interface to access the underlying blockchain.
 type BlockchainClient interface {
 	// WriteAnchor writes the anchor string as a transaction to blockchain
-	WriteAnchor(anchor string, protocolGenesisTime uint64) error
+	WriteAnchor(anchor string, ops []*operation.Reference, protocolGenesisTime uint64) error
 	// Read ledger transaction
 	Read(sinceTransactionNumber int) (bool, *txn.SidetreeTxn)
 }
@@ -283,7 +283,7 @@ func (r *Writer) process(ops []*operation.QueuedOperation, protocolGenesisTime u
 		return err
 	}
 
-	anchorString, err := p.OperationHandler().PrepareTxnFiles(ops)
+	anchorString, dids, err := p.OperationHandler().PrepareTxnFiles(ops)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func (r *Writer) process(ops []*operation.QueuedOperation, protocolGenesisTime u
 	logger.Infof("[%s] writing anchor string: %s", r.namespace, anchorString)
 
 	// Create Sidetree transaction in blockchain (write anchor string)
-	return r.context.Blockchain().WriteAnchor(anchorString, protocolGenesisTime)
+	return r.context.Blockchain().WriteAnchor(anchorString, dids, protocolGenesisTime)
 }
 
 func (r *Writer) handleTimer(timer <-chan time.Time, pending bool) <-chan time.Time {

--- a/pkg/mocks/blockchain.go
+++ b/pkg/mocks/blockchain.go
@@ -9,6 +9,7 @@ package mocks
 import (
 	"sync"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 )
 
@@ -26,7 +27,7 @@ func NewMockBlockchainClient(err error) *MockBlockchainClient {
 }
 
 // WriteAnchor writes the anchor string as a transaction to blockchain.
-func (m *MockBlockchainClient) WriteAnchor(anchor string, _ uint64) error {
+func (m *MockBlockchainClient) WriteAnchor(anchor string, _ []*operation.Reference, _ uint64) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/pkg/mocks/operationhandler.gen.go
+++ b/pkg/mocks/operationhandler.gen.go
@@ -9,24 +9,26 @@ import (
 )
 
 type OperationHandler struct {
-	PrepareTxnFilesStub        func([]*operation.QueuedOperation) (string, error)
+	PrepareTxnFilesStub        func([]*operation.QueuedOperation) (string, []*operation.Reference, error)
 	prepareTxnFilesMutex       sync.RWMutex
 	prepareTxnFilesArgsForCall []struct {
 		arg1 []*operation.QueuedOperation
 	}
 	prepareTxnFilesReturns struct {
 		result1 string
-		result2 error
+		result2 []*operation.Reference
+		result3 error
 	}
 	prepareTxnFilesReturnsOnCall map[int]struct {
 		result1 string
-		result2 error
+		result2 []*operation.Reference
+		result3 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OperationHandler) PrepareTxnFiles(arg1 []*operation.QueuedOperation) (string, error) {
+func (fake *OperationHandler) PrepareTxnFiles(arg1 []*operation.QueuedOperation) (string, []*operation.Reference, error) {
 	var arg1Copy []*operation.QueuedOperation
 	if arg1 != nil {
 		arg1Copy = make([]*operation.QueuedOperation, len(arg1))
@@ -43,10 +45,10 @@ func (fake *OperationHandler) PrepareTxnFiles(arg1 []*operation.QueuedOperation)
 		return fake.PrepareTxnFilesStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
 	fakeReturns := fake.prepareTxnFilesReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *OperationHandler) PrepareTxnFilesCallCount() int {
@@ -55,7 +57,7 @@ func (fake *OperationHandler) PrepareTxnFilesCallCount() int {
 	return len(fake.prepareTxnFilesArgsForCall)
 }
 
-func (fake *OperationHandler) PrepareTxnFilesCalls(stub func([]*operation.QueuedOperation) (string, error)) {
+func (fake *OperationHandler) PrepareTxnFilesCalls(stub func([]*operation.QueuedOperation) (string, []*operation.Reference, error)) {
 	fake.prepareTxnFilesMutex.Lock()
 	defer fake.prepareTxnFilesMutex.Unlock()
 	fake.PrepareTxnFilesStub = stub
@@ -68,30 +70,33 @@ func (fake *OperationHandler) PrepareTxnFilesArgsForCall(i int) []*operation.Que
 	return argsForCall.arg1
 }
 
-func (fake *OperationHandler) PrepareTxnFilesReturns(result1 string, result2 error) {
+func (fake *OperationHandler) PrepareTxnFilesReturns(result1 string, result2 []*operation.Reference, result3 error) {
 	fake.prepareTxnFilesMutex.Lock()
 	defer fake.prepareTxnFilesMutex.Unlock()
 	fake.PrepareTxnFilesStub = nil
 	fake.prepareTxnFilesReturns = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
+		result2 []*operation.Reference
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *OperationHandler) PrepareTxnFilesReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *OperationHandler) PrepareTxnFilesReturnsOnCall(i int, result1 string, result2 []*operation.Reference, result3 error) {
 	fake.prepareTxnFilesMutex.Lock()
 	defer fake.prepareTxnFilesMutex.Unlock()
 	fake.PrepareTxnFilesStub = nil
 	if fake.prepareTxnFilesReturnsOnCall == nil {
 		fake.prepareTxnFilesReturnsOnCall = make(map[int]struct {
 			result1 string
-			result2 error
+			result2 []*operation.Reference
+			result3 error
 		})
 	}
 	fake.prepareTxnFilesReturnsOnCall[i] = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
+		result2 []*operation.Reference
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *OperationHandler) Invocations() map[string][][]interface{} {

--- a/pkg/versions/0_1/txnprovider/handler_test.go
+++ b/pkg/versions/0_1/txnprovider/handler_test.go
@@ -68,9 +68,10 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			compression,
 			operationparser.New(protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), createOpsNum+updateOpsNum+deactivateOpsNum+recoverOpsNum)
 
 		anchorData, err := ParseAnchorData(anchorString)
 		require.NoError(t, err)
@@ -156,9 +157,10 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			compression,
 			operationparser.New(protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), createOpsNum)
 
 		anchorData, err := ParseAnchorData(anchorString)
 		require.NoError(t, err)
@@ -213,9 +215,10 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			compression,
 			operationparser.New(protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(nil)
+		anchorString, refs, err := handler.PrepareTxnFiles(nil)
 		require.Error(t, err)
 		require.Empty(t, anchorString)
+		require.Empty(t, refs)
 		require.Contains(t, err.Error(), "prepare txn operations called without operations, should not happen")
 	})
 
@@ -232,9 +235,10 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			Namespace:       defaultNS,
 		}
 
-		anchorString, err := handler.PrepareTxnFiles([]*operation.QueuedOperation{op})
+		anchorString, refs, err := handler.PrepareTxnFiles([]*operation.QueuedOperation{op})
 		require.Error(t, err)
 		require.Empty(t, anchorString)
+		require.Empty(t, refs)
 		require.Contains(t, err.Error(), "parse operation: operation type [] not supported")
 	})
 
@@ -247,7 +251,7 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			compression,
 			operationparser.New(protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, _, err := handler.PrepareTxnFiles(ops)
 		require.Error(t, err)
 		require.Empty(t, anchorString)
 		require.Contains(t, err.Error(), "failed to store chunk file: CAS error")
@@ -262,9 +266,10 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			compression,
 			operationparser.New(protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.Error(t, err)
 		require.Empty(t, anchorString)
+		require.Empty(t, refs)
 		require.Contains(t, err.Error(), "failed to store core proof file: CAS error")
 	})
 }

--- a/pkg/versions/0_1/txnprovider/provider_test.go
+++ b/pkg/versions/0_1/txnprovider/provider_test.go
@@ -62,9 +62,10 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 
 		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), createOpsNum+updateOpsNum+deactivateOpsNum+recoverOpsNum)
 
 		provider := NewOperationProvider(pc.Protocol, parser, cas, cp)
 
@@ -85,9 +86,10 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 
 		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), createOpsNum+updateOpsNum+deactivateOpsNum+recoverOpsNum)
 
 		smallDeltaProofSize := mocks.GetDefaultProtocolParameters()
 		smallDeltaProofSize.MaxDeltaSize = 50
@@ -113,7 +115,7 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
 		// anchor string has 9 operations "9.coreIndexURI"
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, _, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
 
@@ -159,7 +161,7 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 
 		ops := getTestOperations(createOpsNum, updateOpsNum, deactivateOpsNum, recoverOpsNum)
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, _, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
 
@@ -204,9 +206,11 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		cas := mocks.NewMockCasClient(nil)
 		handler := NewOperationHandler(pc.Protocol, cas, cp, operationparser.New(pc.Protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), deactivateOpsNum)
+		require.Equal(t, refs[0].Type, operation.TypeDeactivate)
 
 		p := mocks.NewMockProtocolClient().Protocol
 		provider := NewOperationProvider(p, operationparser.New(p), cas, cp)
@@ -231,9 +235,11 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		cas := mocks.NewMockCasClient(nil)
 		handler := NewOperationHandler(pc.Protocol, cas, cp, operationparser.New(pc.Protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), updateOpsNum)
+		require.Equal(t, refs[0].Type, operation.TypeUpdate)
 
 		p := mocks.NewMockProtocolClient().Protocol
 		provider := NewOperationProvider(p, operationparser.New(p), cas, cp)
@@ -258,9 +264,11 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		cas := mocks.NewMockCasClient(nil)
 		handler := NewOperationHandler(pc.Protocol, cas, cp, operationparser.New(pc.Protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), createOpsNum)
+		require.Equal(t, refs[0].Type, operation.TypeCreate)
 
 		p := mocks.NewMockProtocolClient().Protocol
 		provider := NewOperationProvider(p, operationparser.New(p), cas, cp)
@@ -285,9 +293,11 @@ func TestHandler_GetTxnOperations(t *testing.T) {
 		cas := mocks.NewMockCasClient(nil)
 		handler := NewOperationHandler(pc.Protocol, cas, cp, operationparser.New(pc.Protocol))
 
-		anchorString, err := handler.PrepareTxnFiles(ops)
+		anchorString, refs, err := handler.PrepareTxnFiles(ops)
 		require.NoError(t, err)
 		require.NotEmpty(t, anchorString)
+		require.Equal(t, len(refs), recoverOpsNum)
+		require.Equal(t, refs[0].Type, operation.TypeRecover)
 
 		p := mocks.NewMockProtocolClient().Protocol
 		provider := NewOperationProvider(p, operationparser.New(p), cas, cp)


### PR DESCRIPTION
When creating Sidetree transaction  it can be beneficial to know minimum information about did operations that are referenced in Sidetree batch files:
- return operation references upon creating batch files
- pass operation references when writing transaction 

Closes #539

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>