### PR TITLE
chore: rename blockchain client to anchor writer

### DIFF
--- a/pkg/api/operation/models.go
+++ b/pkg/api/operation/models.go
@@ -44,7 +44,7 @@ type AnchoredOperation struct {
 	// OperationBuffer is the original operation request
 	OperationBuffer []byte `json:"operationBuffer"`
 
-	// TransactionTime is the logical blockchain time (block number) that this operation was anchored on the blockchain.
+	// TransactionTime is the logical anchoring time (block number in case of blockchain) for this operation in the anchoring system (blockchain).
 	TransactionTime uint64 `json:"transactionTime"`
 
 	// TransactionNumber is the transaction number of the transaction this operation was batched within.

--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -26,7 +26,7 @@ import (
 
 // Protocol defines protocol parameters.
 type Protocol struct {
-	// GenesisTime is inclusive starting logical blockchain time that this protocol applies to.
+	// GenesisTime is inclusive starting logical anchoring time that this protocol applies to.
 	// (e.g. block number in a blockchain)
 	GenesisTime uint64 `json:"genesisTime"`
 	// MultihashAlgorithms are supported multihash algorithm codes

--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -157,7 +157,7 @@ func getTransformationInfo(id string, published bool) protocol.TransformationInf
 // 2. Long Form DID format:
 // did:METHOD:<did-suffix>:Base64url(JCS({suffix-data-object, delta-object}))
 //
-// Standard resolution is performed if the DID is found to be registered on the blockchain.
+// Standard resolution is performed if the DID is found to be registered on the anchoring system.
 // If the DID Document cannot be found, the <suffix-data-object> and <delta-object> are used
 // to generate and return resolved DID Document. In this case the supplied delta and suffix objects
 // are subject to the same validation as during processing create operation.

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -369,10 +369,10 @@ func TestProcessOperation_ParseOperationError(t *testing.T) {
 
 // BatchContext implements batch writer context.
 type BatchContext struct {
-	ProtocolClient   *mocks.MockProtocolClient
-	CasClient        *mocks.MockCasClient
-	BlockchainClient *mocks.MockBlockchainClient
-	OpQueue          cutter.OperationQueue
+	ProtocolClient *mocks.MockProtocolClient
+	CasClient      *mocks.MockCasClient
+	AnchorWriter   *mocks.MockAnchorWriter
+	OpQueue        cutter.OperationQueue
 }
 
 // Protocol returns the ProtocolClient.
@@ -380,9 +380,9 @@ func (m *BatchContext) Protocol() protocol.Client {
 	return m.ProtocolClient
 }
 
-// Blockchain returns the block chain client.
-func (m *BatchContext) Blockchain() batch.BlockchainClient {
-	return m.BlockchainClient
+// Anchor returns the block chain client.
+func (m *BatchContext) Anchor() batch.AnchorWriter {
+	return m.AnchorWriter
 }
 
 // CAS returns the CAS client.
@@ -405,10 +405,10 @@ func getDocumentHandlerWithProtocolClient(store processor.OperationStoreClient, 
 	processor := processor.New("test", store, protocol)
 
 	ctx := &BatchContext{
-		ProtocolClient:   protocol,
-		CasClient:        mocks.NewMockCasClient(nil),
-		BlockchainClient: mocks.NewMockBlockchainClient(nil),
-		OpQueue:          &opqueue.MemQueue{},
+		ProtocolClient: protocol,
+		CasClient:      mocks.NewMockCasClient(nil),
+		AnchorWriter:   mocks.NewMockAnchorWriter(nil),
+		OpQueue:        &opqueue.MemQueue{},
 	}
 	writer, err := batch.New("test", ctx)
 	if err != nil {

--- a/pkg/mocks/blockchain.go
+++ b/pkg/mocks/blockchain.go
@@ -13,21 +13,21 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 )
 
-// MockBlockchainClient mocks blockchain client for testing purposes.
-type MockBlockchainClient struct {
+// MockAnchorWriter mocks anchor writer for testing purposes.
+type MockAnchorWriter struct {
 	sync.RWMutex
 	namespace string
 	anchors   []string
 	err       error
 }
 
-// NewMockBlockchainClient creates mock client.
-func NewMockBlockchainClient(err error) *MockBlockchainClient {
-	return &MockBlockchainClient{err: err, namespace: DefaultNS}
+// NewMockAnchorWriter creates mock anchor writer.
+func NewMockAnchorWriter(err error) *MockAnchorWriter {
+	return &MockAnchorWriter{err: err, namespace: DefaultNS}
 }
 
-// WriteAnchor writes the anchor string as a transaction to blockchain.
-func (m *MockBlockchainClient) WriteAnchor(anchor string, _ []*operation.Reference, _ uint64) error {
+// WriteAnchor writes the anchor string as a transaction to anchoring system.
+func (m *MockAnchorWriter) WriteAnchor(anchor string, _ []*operation.Reference, _ uint64) error {
 	if m.err != nil {
 		return m.err
 	}
@@ -41,7 +41,7 @@ func (m *MockBlockchainClient) WriteAnchor(anchor string, _ []*operation.Referen
 }
 
 // Read reads transactions since transaction number.
-func (m *MockBlockchainClient) Read(sinceTransactionNumber int) (bool, *txn.SidetreeTxn) {
+func (m *MockAnchorWriter) Read(sinceTransactionNumber int) (bool, *txn.SidetreeTxn) {
 	m.RLock()
 	defer m.RUnlock()
 	moreTransactions := false
@@ -66,7 +66,7 @@ func (m *MockBlockchainClient) Read(sinceTransactionNumber int) (bool, *txn.Side
 }
 
 // GetAnchors returns anchors.
-func (m *MockBlockchainClient) GetAnchors() []string {
+func (m *MockAnchorWriter) GetAnchors() []string {
 	m.RLock()
 	defer m.RUnlock()
 

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -69,7 +69,7 @@ func (m *MockProtocolClient) Current() (protocol.Version, error) {
 	return m.CurrentVersion, nil
 }
 
-// Get mocks getting protocol version based on blockchain(transaction) time.
+// Get mocks getting protocol version based on anchoring(transaction) time.
 func (m *MockProtocolClient) Get(transactionTime uint64) (protocol.Version, error) {
 	if m.Err != nil {
 		return nil, m.Err
@@ -81,7 +81,7 @@ func (m *MockProtocolClient) Get(transactionTime uint64) (protocol.Version, erro
 		}
 	}
 
-	return nil, fmt.Errorf("protocol parameters are not defined for blockchain time: %d", transactionTime)
+	return nil, fmt.Errorf("protocol parameters are not defined for anchoring time: %d", transactionTime)
 }
 
 // NewMockProtocolClientProvider creates new mock protocol client provider.

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -97,7 +97,7 @@ func TestResolve(t *testing.T) {
 		doc, err := op.applyOperation(createOp, &protocol.ResolutionModel{})
 		require.Nil(t, doc)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "apply 'create' operation: protocol parameters are not defined for blockchain time")
+		require.Contains(t, err.Error(), "apply 'create' operation: protocol parameters are not defined for anchoring time")
 	})
 
 	t.Run("resolution error", func(t *testing.T) {
@@ -634,7 +634,7 @@ func TestGetOperationCommitment(t *testing.T) {
 		value, err := New("test", store, pcWithoutProtocols).getRevealValue(updateOp)
 		require.Error(t, err)
 		require.Empty(t, value)
-		require.Contains(t, err.Error(), "protocol parameters are not defined for blockchain time")
+		require.Contains(t, err.Error(), "protocol parameters are not defined for anchoring time")
 	})
 
 	t.Run("error - create operation doesn't have reveal value", func(t *testing.T) {
@@ -769,7 +769,7 @@ func TestGetNextOperationCommitment(t *testing.T) {
 		value, err := New("test", store, pcWithoutProtocols).getCommitment(updateOp)
 		require.Error(t, err)
 		require.Empty(t, value)
-		require.Contains(t, err.Error(), "protocol parameters are not defined for blockchain time")
+		require.Contains(t, err.Error(), "protocol parameters are not defined for anchoring time")
 	})
 
 	t.Run("error - create operation is currently not supported", func(t *testing.T) {

--- a/pkg/versions/0_1/txnprocessor/txnprocessor.go
+++ b/pkg/versions/0_1/txnprocessor/txnprocessor.go
@@ -70,7 +70,7 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperatio
 
 		updatedOp := updateAnchoredOperation(op, sidetreeTxn)
 
-		logger.Debugf("updated operation with blockchain time: %s", updatedOp.UniqueSuffix)
+		logger.Debugf("updated operation with anchoring time: %s", updatedOp.UniqueSuffix)
 		ops = append(ops, updatedOp)
 
 		batchSuffixes[op.UniqueSuffix] = true
@@ -85,7 +85,7 @@ func (p *TxnProcessor) processTxnOperations(txnOps []*operation.AnchoredOperatio
 }
 
 func updateAnchoredOperation(op *operation.AnchoredOperation, sidetreeTxn txn.SidetreeTxn) *operation.AnchoredOperation {
-	//  The logical blockchain time that this operation was anchored on the blockchain
+	//  The logical anchoring time that this operation was anchored on
 	op.TransactionTime = sidetreeTxn.TransactionTime
 	// The transaction number of the transaction this operation was batched within
 	op.TransactionNumber = sidetreeTxn.TransactionNumber


### PR DESCRIPTION
Rename BlockchainClient to AnchorWriter and modify references to blockchain accordingly.

Closea #548

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>