### PR TITLE
feat: Add support for anchor origin

### DIFF
--- a/pkg/versions/0_1/client/create.go
+++ b/pkg/versions/0_1/client/create.go
@@ -38,6 +38,12 @@ type CreateRequestInfo struct {
 	// required
 	UpdateCommitment string
 
+	// AnchorOrigin signifies the system(s) that know the most recent anchor for this DID (optional)
+	AnchorOrigin interface{}
+
+	// Type signifies the type of entity a DID represents (optional)
+	Type string
+
 	// latest hashing algorithm supported by protocol
 	MultihashCode uint
 }
@@ -66,6 +72,8 @@ func NewCreateRequest(info *CreateRequestInfo) ([]byte, error) {
 	suffixData := &model.SuffixDataModel{
 		DeltaHash:          deltaHash,
 		RecoveryCommitment: info.RecoveryCommitment,
+		AnchorOrigin:       info.AnchorOrigin,
+		Type:               info.Type,
 	}
 
 	schema := &model.CreateRequest{

--- a/pkg/versions/0_1/client/create_test.go
+++ b/pkg/versions/0_1/client/create_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/model"
 )
 
 const (
@@ -143,6 +145,31 @@ func TestNewCreateRequest(t *testing.T) {
 		request, err := NewCreateRequest(info)
 		require.NoError(t, err)
 		require.NotEmpty(t, request)
+	})
+
+	t.Run("success - optional params (entity type and anchor origin)", func(t *testing.T) {
+		p, err := patch.NewAddPublicKeysPatch(addKeys)
+		require.NoError(t, err)
+
+		info := &CreateRequestInfo{
+			Patches:            []patch.Patch{p},
+			RecoveryCommitment: recoveryCommitment,
+			UpdateCommitment:   updateCommitment,
+			AnchorOrigin:       "anchor-origin",
+			Type:               "did-entity-type",
+			MultihashCode:      sha2_256,
+		}
+
+		bytes, err := NewCreateRequest(info)
+		require.NoError(t, err)
+		require.NotEmpty(t, bytes)
+
+		var request model.CreateRequest
+		err = json.Unmarshal(bytes, &request)
+		require.NoError(t, err)
+
+		require.Contains(t, request.SuffixData.AnchorOrigin, "anchor-origin")
+		require.Contains(t, request.SuffixData.Type, "did-entity-type")
 	})
 }
 

--- a/pkg/versions/0_1/client/recover.go
+++ b/pkg/versions/0_1/client/recover.go
@@ -42,6 +42,9 @@ type RecoverRequestInfo struct {
 	// UpdateCommitment is update commitment to be used for the next update
 	UpdateCommitment string
 
+	// AnchorOrigin signifies the system(s) that know the most recent anchor for this DID (optional)
+	AnchorOrigin interface{}
+
 	// MultihashCode is the latest hashing algorithm supported by protocol
 	MultihashCode uint
 
@@ -79,6 +82,7 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 		DeltaHash:          deltaHash,
 		RecoveryKey:        info.RecoveryKey,
 		RecoveryCommitment: info.RecoveryCommitment,
+		AnchorOrigin:       info.AnchorOrigin,
 	}
 
 	err = validateCommitment(info.RecoveryKey, info.MultihashCode, info.RecoveryCommitment)

--- a/pkg/versions/0_1/model/request.go
+++ b/pkg/versions/0_1/model/request.go
@@ -30,11 +30,17 @@ type CreateRequest struct {
 // SuffixDataModel is part of create request.
 type SuffixDataModel struct {
 
-	// Hash of the delta object
+	// Hash of the delta object (required)
 	DeltaHash string `json:"deltaHash,omitempty"`
 
-	// Commitment hash for the next recovery or deactivate operation
+	// Commitment hash for the next recovery or deactivate operation (required)
 	RecoveryCommitment string `json:"recoveryCommitment,omitempty"`
+
+	// AnchorOrigin signifies the system(s) that know the most recent anchor for this DID (optional)
+	AnchorOrigin interface{} `json:"anchorOrigin,omitempty"`
+
+	// Type signifies the type of entity a DID represents (optional)
+	Type string `json:"type,omitempty"`
 }
 
 // DeltaModel contains patch data (patches used for create, recover, update).
@@ -102,6 +108,9 @@ type RecoverSignedDataModel struct {
 
 	// RecoveryCommitment is the commitment used for the next recovery/deactivate
 	RecoveryCommitment string `json:"recoveryCommitment"`
+
+	// AnchorOrigin signifies the system(s) that know the most recent anchor for this DID (optional)
+	AnchorOrigin interface{} `json:"anchorOrigin,omitempty"`
 }
 
 // DeactivateSignedDataModel defines data model for deactivate.

--- a/pkg/versions/0_1/operationparser/create.go
+++ b/pkg/versions/0_1/operationparser/create.go
@@ -151,6 +151,10 @@ func (p *Parser) ValidateSuffixData(suffixData *model.SuffixDataModel) error {
 		return err
 	}
 
+	if err := p.anchorValidator.Validate(suffixData.AnchorOrigin); err != nil {
+		return err
+	}
+
 	return p.validateMultihash(suffixData.DeltaHash, "delta hash")
 }
 

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -8,6 +8,7 @@ package operationparser
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -167,6 +168,24 @@ func TestValidateSuffixData(t *testing.T) {
 
 	parser := New(p)
 
+	t.Run("success", func(t *testing.T) {
+		suffixData, err := getSuffixData()
+		require.NoError(t, err)
+
+		err = parser.ValidateSuffixData(suffixData)
+		require.NoError(t, err)
+	})
+	t.Run("anchor origin validation error", func(t *testing.T) {
+		suffixData, err := getSuffixData()
+		require.NoError(t, err)
+
+		testErr := errors.New("validation error")
+		parserWithErr := New(p, WithAnchorOriginValidator(&mockObjectValidator{Err: testErr}))
+
+		err = parserWithErr.ValidateSuffixData(suffixData)
+		require.Error(t, err)
+		require.Equal(t, testErr, err)
+	})
 	t.Run("invalid patch data hash", func(t *testing.T) {
 		suffixData, err := getSuffixData()
 		require.NoError(t, err)

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -93,6 +93,10 @@ func (p *Parser) ParseSignedDataForRecover(compactJWS string) (*model.RecoverSig
 }
 
 func (p *Parser) validateSignedDataForRecovery(signedData *model.RecoverSignedDataModel) error {
+	if err := p.anchorValidator.Validate(signedData.AnchorOrigin); err != nil {
+		return err
+	}
+
 	if err := p.validateSigningKey(signedData.RecoveryKey, p.KeyAlgorithms); err != nil {
 		return err
 	}


### PR DESCRIPTION
Add optional anchor origin in:
- suffix data for create operation
- signed model for recover operation

Add anchor origin object validator to parser and validate anchor origin against it. Default object validator accepts all objects.

Closes #546

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>