### PR TITLE
chore: Implement anchor from and until

### DIFF
--- a/pkg/versions/0_1/client/deactivate.go
+++ b/pkg/versions/0_1/client/deactivate.go
@@ -41,6 +41,12 @@ type DeactivateRequestInfo struct {
 
 	// RevealValue is reveal value
 	RevealValue string
+
+	// AnchorFrom defines earliest time for this operation.
+	AnchorFrom int64
+
+	// AnchorUntil defines expiry time for this operation.
+	AnchorUntil int64
 }
 
 // NewDeactivateRequest is utility function to create payload for 'deactivate' request.
@@ -52,6 +58,8 @@ func NewDeactivateRequest(info *DeactivateRequestInfo) ([]byte, error) {
 	signedDataModel := model.DeactivateSignedDataModel{
 		DidSuffix:   info.DidSuffix,
 		RecoveryKey: info.RecoveryKey,
+		AnchorFrom:  info.AnchorFrom,
+		AnchorUntil: info.AnchorUntil,
 	}
 
 	jws, err := signutil.SignModel(signedDataModel, info.Signer)

--- a/pkg/versions/0_1/client/recover.go
+++ b/pkg/versions/0_1/client/recover.go
@@ -45,6 +45,12 @@ type RecoverRequestInfo struct {
 	// AnchorOrigin signifies the system(s) that know the most recent anchor for this DID (optional)
 	AnchorOrigin interface{}
 
+	// AnchorFrom defines earliest time for this operation.
+	AnchorFrom int64
+
+	// AnchorUntil defines expiry time for this operation.
+	AnchorUntil int64
+
 	// MultihashCode is the latest hashing algorithm supported by protocol
 	MultihashCode uint
 
@@ -83,6 +89,8 @@ func NewRecoverRequest(info *RecoverRequestInfo) ([]byte, error) {
 		RecoveryKey:        info.RecoveryKey,
 		RecoveryCommitment: info.RecoveryCommitment,
 		AnchorOrigin:       info.AnchorOrigin,
+		AnchorFrom:         info.AnchorFrom,
+		AnchorUntil:        info.AnchorUntil,
 	}
 
 	err = validateCommitment(info.RecoveryKey, info.MultihashCode, info.RecoveryCommitment)

--- a/pkg/versions/0_1/client/update.go
+++ b/pkg/versions/0_1/client/update.go
@@ -41,6 +41,12 @@ type UpdateRequestInfo struct {
 
 	// RevealValue is reveal value
 	RevealValue string
+
+	// AnchorFrom defines earliest time for this operation.
+	AnchorFrom int64
+
+	// AnchorUntil defines expiry time for this operation.
+	AnchorUntil int64
 }
 
 // NewUpdateRequest is utility function to create payload for 'update' request.
@@ -60,8 +66,10 @@ func NewUpdateRequest(info *UpdateRequestInfo) ([]byte, error) {
 	}
 
 	signedDataModel := &model.UpdateSignedDataModel{
-		DeltaHash: deltaHash,
-		UpdateKey: info.UpdateKey,
+		DeltaHash:   deltaHash,
+		UpdateKey:   info.UpdateKey,
+		AnchorFrom:  info.AnchorFrom,
+		AnchorUntil: info.AnchorUntil,
 	}
 
 	err = validateCommitment(info.UpdateKey, info.MultihashCode, info.UpdateCommitment)

--- a/pkg/versions/0_1/model/request.go
+++ b/pkg/versions/0_1/model/request.go
@@ -95,6 +95,12 @@ type UpdateSignedDataModel struct {
 
 	// DeltaHash of the unsigned delta object
 	DeltaHash string `json:"deltaHash"`
+
+	// AnchorFrom defines earliest time for this operation.
+	AnchorFrom int64 `json:"anchorFrom,omitempty"`
+
+	// AnchorUntil defines expiry time for this operation.
+	AnchorUntil int64 `json:"anchorUntil,omitempty"`
 }
 
 // RecoverSignedDataModel defines signed data model for recovery.
@@ -111,6 +117,12 @@ type RecoverSignedDataModel struct {
 
 	// AnchorOrigin signifies the system(s) that know the most recent anchor for this DID (optional)
 	AnchorOrigin interface{} `json:"anchorOrigin,omitempty"`
+
+	// AnchorFrom defines earliest time for this operation.
+	AnchorFrom int64 `json:"anchorFrom,omitempty"`
+
+	// AnchorUntil defines expiry time for this operation.
+	AnchorUntil int64 `json:"anchorUntil,omitempty"`
 }
 
 // DeactivateSignedDataModel defines data model for deactivate.
@@ -125,6 +137,12 @@ type DeactivateSignedDataModel struct {
 
 	// RecoveryKey is the current recovery key
 	RecoveryKey *jws.JWK `json:"recoveryKey"`
+
+	// AnchorFrom defines earliest time for this operation.
+	AnchorFrom int64 `json:"anchorFrom,omitempty"`
+
+	// AnchorUntil defines expiry time for this operation.
+	AnchorUntil int64 `json:"anchorUntil,omitempty"`
 }
 
 // RecoverRequest is the struct for document recovery payload.

--- a/pkg/versions/0_1/operationparser/create.go
+++ b/pkg/versions/0_1/operationparser/create.go
@@ -33,6 +33,11 @@ func (p *Parser) ParseCreateOperation(request []byte, batch bool) (*model.Operat
 	}
 
 	if !batch {
+		err = p.anchorOriginValidator.Validate(schema.SuffixData.AnchorOrigin)
+		if err != nil {
+			return nil, err
+		}
+
 		err = p.ValidateDelta(schema.Delta)
 		if err != nil {
 			return nil, err
@@ -148,10 +153,6 @@ func (p *Parser) ValidateSuffixData(suffixData *model.SuffixDataModel) error {
 	}
 
 	if err := p.validateMultihash(suffixData.RecoveryCommitment, "recovery commitment"); err != nil {
-		return err
-	}
-
-	if err := p.anchorValidator.Validate(suffixData.AnchorOrigin); err != nil {
 		return err
 	}
 

--- a/pkg/versions/0_1/operationparser/create_test.go
+++ b/pkg/versions/0_1/operationparser/create_test.go
@@ -8,7 +8,6 @@ package operationparser
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -174,17 +173,6 @@ func TestValidateSuffixData(t *testing.T) {
 
 		err = parser.ValidateSuffixData(suffixData)
 		require.NoError(t, err)
-	})
-	t.Run("anchor origin validation error", func(t *testing.T) {
-		suffixData, err := getSuffixData()
-		require.NoError(t, err)
-
-		testErr := errors.New("validation error")
-		parserWithErr := New(p, WithAnchorOriginValidator(&mockObjectValidator{Err: testErr}))
-
-		err = parserWithErr.ValidateSuffixData(suffixData)
-		require.Error(t, err)
-		require.Equal(t, testErr, err)
 	})
 	t.Run("invalid patch data hash", func(t *testing.T) {
 		suffixData, err := getSuffixData()

--- a/pkg/versions/0_1/operationparser/deactivate.go
+++ b/pkg/versions/0_1/operationparser/deactivate.go
@@ -37,6 +37,12 @@ func (p *Parser) ParseDeactivateOperation(request []byte, batch bool) (*model.Op
 		return nil, fmt.Errorf("canonicalized recovery public key hash doesn't match reveal value: %s", err.Error())
 	}
 
+	if !batch {
+		if err := p.anchorTimeValidator.Validate(signedData.AnchorFrom, signedData.AnchorUntil); err != nil {
+			return nil, err
+		}
+	}
+
 	return &model.Operation{
 		Type:            operation.TypeDeactivate,
 		OperationBuffer: request,

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -33,6 +33,16 @@ func (p *Parser) ParseRecoverOperation(request []byte, batch bool) (*model.Opera
 	}
 
 	if !batch {
+		err = p.anchorOriginValidator.Validate(signedData.AnchorOrigin)
+		if err != nil {
+			return nil, err
+		}
+
+		err = p.anchorTimeValidator.Validate(signedData.AnchorFrom, signedData.AnchorUntil)
+		if err != nil {
+			return nil, err
+		}
+
 		err = p.ValidateDelta(schema.Delta)
 		if err != nil {
 			return nil, err
@@ -93,10 +103,6 @@ func (p *Parser) ParseSignedDataForRecover(compactJWS string) (*model.RecoverSig
 }
 
 func (p *Parser) validateSignedDataForRecovery(signedData *model.RecoverSignedDataModel) error {
-	if err := p.anchorValidator.Validate(signedData.AnchorOrigin); err != nil {
-		return err
-	}
-
 	if err := p.validateSigningKey(signedData.RecoveryKey, p.KeyAlgorithms); err != nil {
 		return err
 	}

--- a/pkg/versions/0_1/operationparser/recover_test.go
+++ b/pkg/versions/0_1/operationparser/recover_test.go
@@ -8,7 +8,6 @@ package operationparser
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -206,16 +205,6 @@ func TestValidateSignedDataForRecovery(t *testing.T) {
 		signed := getSignedDataForRecovery()
 		err := parser.validateSignedDataForRecovery(signed)
 		require.NoError(t, err)
-	})
-	t.Run("anchor origin validation error", func(t *testing.T) {
-		signed := getSignedDataForRecovery()
-
-		testErr := errors.New("validation error")
-		parserWithErr := New(p, WithAnchorOriginValidator(&mockObjectValidator{Err: testErr}))
-
-		err := parserWithErr.validateSignedDataForRecovery(signed)
-		require.Error(t, err)
-		require.Equal(t, testErr, err)
 	})
 	t.Run("invalid patch data hash", func(t *testing.T) {
 		signed := getSignedDataForRecovery()

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -29,6 +29,11 @@ func (p *Parser) ParseUpdateOperation(request []byte, batch bool) (*model.Operat
 	}
 
 	if !batch {
+		err = p.anchorTimeValidator.Validate(signedData.AnchorFrom, signedData.AnchorUntil)
+		if err != nil {
+			return nil, err
+		}
+
 		err = p.ValidateDelta(schema.Delta)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Included: 
- anchor origin should only be checked at REST/Batch Writer points 
- add anchor from and anchor until to client interface and Sidetree model
- add validation of anchor from and anchor at REST and Batch Writer points
- ignore expired operations when creating Sidetree batches

TODO (in different PR): 
- add validation of anchor from and anchor until to operation applier (will be checked against anchoring time)
- add protocol parameter MAX_OPERATION_TIME_DELTA  to calculate until time if from time is provided and until time is not provided

Closes #547

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>