### PR TITLE
feat: Add protocol parameter MAX_OPERATION_TIME_DELTA

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -29,35 +29,52 @@ type Protocol struct {
 	// GenesisTime is inclusive starting logical anchoring time that this protocol applies to.
 	// (e.g. block number in a blockchain)
 	GenesisTime uint64 `json:"genesisTime"`
+
 	// MultihashAlgorithms are supported multihash algorithm codes
 	MultihashAlgorithms []uint `json:"multihashAlgorithms"`
+
 	// MaxOperationCount defines maximum number of operations per batch.
 	MaxOperationCount uint `json:"maxOperationCount"`
+
 	// MaxOperationSize is maximum operation size in bytes (used to reject operations before parsing them)
 	// It has to be greater than max delta size (big) + max proof size (medium) + other small values (operation type, suffix-data)
 	MaxOperationSize uint `json:"maxOperationSize"`
+
 	// MaxOperationHashLength is maximum operation hash length
 	MaxOperationHashLength uint `json:"maxOperationHashLength"`
+
 	// MaxDeltaSize is maximum size of operation's delta property.
 	MaxDeltaSize uint `json:"maxDeltaSize"`
+
 	// MaxCasUriLength is maximum length of CAS URI in batch files.
 	MaxCasURILength uint `json:"maxCasUriLength"`
+
 	// CompressionAlgorithm is file compression algorithm.
 	CompressionAlgorithm string `json:"compressionAlgorithm"`
+
 	// MaxCoreIndexFileSize is maximum allowed size (in bytes) of core index file stored in CAS.
 	MaxCoreIndexFileSize uint `json:"maxCoreIndexFileSize"`
+
 	// MaxProofFileSize is maximum allowed size (in bytes) of proof files stored in CAS.
 	MaxProofFileSize uint `json:"maxProofFileSize"`
+
 	// MaxProvisionalIndexFileSize is maximum allowed size (in bytes) of provisional index file stored in CAS.
 	MaxProvisionalIndexFileSize uint `json:"maxProvisionalIndexFileSize"`
+
 	// MaxChunkFileSize is maximum allowed size (in bytes) of chunk file stored in CAS.
 	MaxChunkFileSize uint `json:"maxChunkFileSize"`
+
 	// Patches contains the list of allowed patches.
 	Patches []string `json:"patches"`
+
 	// SignatureAlgorithms contain supported signature algorithms for signed operations (e.g. EdDSA, ES256, ES384, ES512, ES256K).
 	SignatureAlgorithms []string `json:"signatureAlgorithms"`
+
 	// KeyAlgorithms contain supported key algorithms for signed operations (e.g. secp256k1, P-256, P-384, P-512, Ed25519).
 	KeyAlgorithms []string `json:"keyAlgorithms"`
+
+	// MaxOperationTimeDelta is maximum time that operation should be valid before it expires; used with anchor from time
+	MaxOperationTimeDelta uint64 `json:"maxOperationTimeDelta"`
 }
 
 // TxnProcessor defines the functions for processing a Sidetree transaction.

--- a/pkg/mocks/protocol.go
+++ b/pkg/mocks/protocol.go
@@ -154,5 +154,6 @@ func GetDefaultProtocolParameters() protocol.Protocol {
 		SignatureAlgorithms:         []string{"EdDSA", "ES256"},
 		KeyAlgorithms:               []string{"Ed25519", "P-256"},
 		Patches:                     []string{"add-public-keys", "remove-public-keys", "add-services", "remove-services", "ietf-json-patch"},
+		MaxOperationTimeDelta:       2 * 60 * 60,
 	}
 }

--- a/pkg/versions/0_1/operationapplier/operationapplier.go
+++ b/pkg/versions/0_1/operationapplier/operationapplier.go
@@ -312,9 +312,17 @@ func (s *Applier) verifyAnchoringTimeRange(from, until int64, anchor uint64) err
 		return fmt.Errorf("anchor from time is greater then anchoring time")
 	}
 
-	if until < int64(anchor) {
+	if s.getAnchorUntil(from, until) < int64(anchor) {
 		return fmt.Errorf("anchor until time is less then anchoring time")
 	}
 
 	return nil
+}
+
+func (s *Applier) getAnchorUntil(from, until int64) int64 {
+	if from != 0 && until == 0 {
+		return from + int64(s.MaxDeltaSize)
+	}
+
+	return until
 }

--- a/pkg/versions/0_1/operationparser/deactivate.go
+++ b/pkg/versions/0_1/operationparser/deactivate.go
@@ -38,7 +38,9 @@ func (p *Parser) ParseDeactivateOperation(request []byte, batch bool) (*model.Op
 	}
 
 	if !batch {
-		if err := p.anchorTimeValidator.Validate(signedData.AnchorFrom, signedData.AnchorUntil); err != nil {
+		until := p.getAnchorUntil(signedData.AnchorFrom, signedData.AnchorUntil)
+
+		if err := p.anchorTimeValidator.Validate(signedData.AnchorFrom, until); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/versions/0_1/operationparser/recover.go
+++ b/pkg/versions/0_1/operationparser/recover.go
@@ -38,7 +38,9 @@ func (p *Parser) ParseRecoverOperation(request []byte, batch bool) (*model.Opera
 			return nil, err
 		}
 
-		err = p.anchorTimeValidator.Validate(signedData.AnchorFrom, signedData.AnchorUntil)
+		until := p.getAnchorUntil(signedData.AnchorFrom, signedData.AnchorUntil)
+
+		err = p.anchorTimeValidator.Validate(signedData.AnchorFrom, until)
 		if err != nil {
 			return nil, err
 		}
@@ -227,4 +229,12 @@ func (p *Parser) validateCommitment(jwk *jws.JWK, nextCommitment string) error {
 	}
 
 	return nil
+}
+
+func (p *Parser) getAnchorUntil(from, until int64) int64 {
+	if from != 0 && until == 0 {
+		return from + int64(p.MaxDeltaSize)
+	}
+
+	return until
 }

--- a/pkg/versions/0_1/operationparser/update.go
+++ b/pkg/versions/0_1/operationparser/update.go
@@ -29,7 +29,9 @@ func (p *Parser) ParseUpdateOperation(request []byte, batch bool) (*model.Operat
 	}
 
 	if !batch {
-		err = p.anchorTimeValidator.Validate(signedData.AnchorFrom, signedData.AnchorUntil)
+		until := p.getAnchorUntil(signedData.AnchorFrom, signedData.AnchorUntil)
+
+		err = p.anchorTimeValidator.Validate(signedData.AnchorFrom, until)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If anchor from time is provided and anchor until time is not provided calculate until time by adding max operation time delta to from time.

Closes #555

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>