### PR TITLE
fix: Fix the order for namespace checking

### DIFF
--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -198,16 +198,16 @@ func (r *DocumentHandler) ResolveDocument(shortOrLongFormDID string) (*document.
 }
 
 func (r *DocumentHandler) getNamespace(shortOrLongFormDID string) (string, error) {
-	// check namespace
-	if strings.HasPrefix(shortOrLongFormDID, r.namespace+docutil.NamespaceDelimiter) {
-		return r.namespace, nil
-	}
-
-	// check aliases
+	// check aliases first (if configured)
 	for _, ns := range r.aliases {
 		if strings.HasPrefix(shortOrLongFormDID, ns+docutil.NamespaceDelimiter) {
 			return ns, nil
 		}
+	}
+
+	// check namespace
+	if strings.HasPrefix(shortOrLongFormDID, r.namespace+docutil.NamespaceDelimiter) {
+		return r.namespace, nil
 	}
 
 	return "", fmt.Errorf("did must start with configured namespace[%s] or aliases%v", r.namespace, r.aliases)


### PR DESCRIPTION
Fix the order for namespace checking: aliases should be checked first since true namespace can be a subset of alias.

Closes #578

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>