### PR TITLE
Add relevant key context to did document

### DIFF
--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -39,6 +39,11 @@ func (doc Document) ID() string {
 	return stringEntry(doc[IDProperty])
 }
 
+// Context is the context of document.
+func (doc Document) Context() []interface{} {
+	return interfaceArray(doc[ContextProperty])
+}
+
 // PublicKeys in generic document are used for managing operation keys.
 func (doc Document) PublicKeys() []PublicKey {
 	return ParsePublicKeys(doc[PublicKeyProperty])

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -26,6 +26,7 @@ func TestFromBytes(t *testing.T) {
 	require.NotNil(t, doc)
 	require.Equal(t, "", doc.ID())
 	require.Equal(t, 1, len(doc.PublicKeys()))
+	require.Equal(t, 0, len(doc.Context()))
 
 	bytes, err := doc.Bytes()
 	require.Nil(t, err)

--- a/pkg/document/publickey_test.go
+++ b/pkg/document/publickey_test.go
@@ -20,11 +20,11 @@ func TestPublicKey(t *testing.T) {
 
 	pk = NewPublicKey(map[string]interface{}{
 		"id":         "did:example:123456789abcdefghi#keys-1",
-		"type":       "JwsVerificationKey2020",
+		"type":       "JsonWebKey2020",
 		"controller": "did:example:123456789abcdefghi",
 	})
 	require.Equal(t, "did:example:123456789abcdefghi#keys-1", pk.ID())
-	require.Equal(t, "JwsVerificationKey2020", pk.Type())
+	require.Equal(t, "JsonWebKey2020", pk.Type())
 	require.Equal(t, "did:example:123456789abcdefghi", pk.Controller())
 	require.Empty(t, pk.Purpose())
 	require.Empty(t, pk.PublicKeyJwk())


### PR DESCRIPTION
DID WG is deleted crypto suite’s contexts from the core did context.
Add relevant context to did document (based on the public key types that are actually in the did document).

Closes #570

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>