### PR TITLE
chore: Handle bytes input for MarshalCanonical

### DIFF
--- a/pkg/canonicalizer/canonicalizer.go
+++ b/pkg/canonicalizer/canonicalizer.go
@@ -14,10 +14,16 @@ import (
 
 // MarshalCanonical is using JCS RFC canonicalization.
 func MarshalCanonical(value interface{}) ([]byte, error) {
-	jsonLiteralValByte, err := json.Marshal(value)
-	if err != nil {
-		return nil, err
+	valueBytes, ok := value.([]byte)
+
+	if !ok {
+		var err error
+
+		valueBytes, err = json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return jsoncanonicalizer.Transform(jsonLiteralValByte)
+	return jsoncanonicalizer.Transform(valueBytes)
 }

--- a/pkg/canonicalizer/canonicalizer_test.go
+++ b/pkg/canonicalizer/canonicalizer_test.go
@@ -27,6 +27,12 @@ func TestMarshalCanonical(t *testing.T) {
 		require.Equal(t, string(result), `{"alpha":"alpha","beta":"beta"}`)
 	})
 
+	t.Run("success - accepts bytes", func(t *testing.T) {
+		result, err := MarshalCanonical([]byte(`{"beta":"beta","alpha":"alpha"}`))
+		require.NoError(t, err)
+		require.Equal(t, string(result), `{"alpha":"alpha","beta":"beta"}`)
+	})
+
 	t.Run("marshal error", func(t *testing.T) {
 		var c chan int
 		result, err := MarshalCanonical(c)


### PR DESCRIPTION
Currently MarshalCanonical will return an error if bytes are passed in since json.Marshal fails for bytes. Do not marshal if bytes are passed in.

Closes #593

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>