### PR TITLE
feat: Operation queue Ack/Nack

### DIFF
--- a/pkg/api/operation/models.go
+++ b/pkg/api/operation/models.go
@@ -96,3 +96,17 @@ type QueuedOperationAtTime struct {
 	QueuedOperation
 	ProtocolGenesisTime uint64
 }
+
+// QueuedOperationsAtTime contains a collection of queued operations with protocol genesis time.
+type QueuedOperationsAtTime []*QueuedOperationAtTime
+
+// QueuedOperations returns a collection of QueuedOperation.
+func (o QueuedOperationsAtTime) QueuedOperations() []*QueuedOperation {
+	ops := make([]*QueuedOperation, len(o))
+
+	for i, op := range o {
+		ops[i] = &op.QueuedOperation
+	}
+
+	return ops
+}

--- a/pkg/batch/opqueue/memqueue_test.go
+++ b/pkg/batch/opqueue/memqueue_test.go
@@ -55,18 +55,35 @@ func TestMemQueue(t *testing.T) {
 	require.Equal(t, *op2, ops[1].QueuedOperation)
 	require.Equal(t, *op3, ops[2].QueuedOperation)
 
-	n, l, err := q.Remove(1)
+	ops, ack, nack, err := q.Remove(1)
 	require.NoError(t, err)
-	require.Equal(t, uint(1), n)
-	require.Equal(t, uint(2), l)
+	require.NotNil(t, ack)
+	require.NotNil(t, nack)
+	require.Len(t, ops, 1)
+	require.Equal(t, *op1, ops[0].QueuedOperation)
+
+	require.Equal(t, uint(2), ack())
 
 	ops, err = q.Peek(1)
 	require.NoError(t, err)
 	require.Len(t, ops, 1)
 	require.Equal(t, *op2, ops[0].QueuedOperation)
 
-	n, l, err = q.Remove(5)
+	ops, _, nack, err = q.Remove(5)
 	require.NoError(t, err)
-	require.Equal(t, uint(2), n)
-	require.Zero(t, l)
+	require.NotNil(t, nack)
+	require.Len(t, ops, 2)
+	require.Equal(t, *op2, ops[0].QueuedOperation)
+	require.Equal(t, *op3, ops[1].QueuedOperation)
+
+	nack()
+
+	ops, ack, _, err = q.Remove(5)
+	require.NoError(t, err)
+	require.NotNil(t, ack)
+	require.Len(t, ops, 2)
+	require.Equal(t, *op2, ops[0].QueuedOperation)
+	require.Equal(t, *op3, ops[1].QueuedOperation)
+
+	require.Zero(t, ack())
 }

--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -364,6 +364,7 @@ func TestProcessError(t *testing.T) {
 
 		q.LenReturns(1)
 		q.PeekReturns(invalidQueue, nil)
+		q.RemoveReturns(nil, func() uint { return 0 }, func() {}, nil)
 
 		ctx := newMockContext()
 		ctx.ProtocolClient.Protocol.MaxOperationCount = 1
@@ -410,7 +411,7 @@ func TestProcessError(t *testing.T) {
 		const numOperations = 3
 		q.LenReturns(numOperations)
 		q.PeekReturns(generateOperationsAtTime(numOperations, 0), nil)
-		q.RemoveReturns(0, 1, errExpected)
+		q.RemoveReturns(nil, nil, nil, errExpected)
 
 		ctx := newMockContext()
 		ctx.ProtocolClient.Protocol.MaxOperationCount = 2
@@ -423,8 +424,6 @@ func TestProcessError(t *testing.T) {
 		defer writer.Stop()
 
 		time.Sleep(50 * time.Millisecond)
-
-		require.Truef(t, writer.Stopped(), "The batch writer should have been stopped due to a remove error")
 	})
 }
 

--- a/pkg/mocks/operationqueue.gen.go
+++ b/pkg/mocks/operationqueue.gen.go
@@ -22,32 +22,34 @@ type OperationQueue struct {
 		result1 uint
 		result2 error
 	}
-	RemoveStub        func(num uint) (uint, uint, error)
+	RemoveStub        func(num uint) (ops operation.QueuedOperationsAtTime, ack func() uint, nack func(), err error)
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
 		num uint
 	}
 	removeReturns struct {
-		result1 uint
-		result2 uint
-		result3 error
+		result1 operation.QueuedOperationsAtTime
+		result2 func() uint
+		result3 func()
+		result4 error
 	}
 	removeReturnsOnCall map[int]struct {
-		result1 uint
-		result2 uint
-		result3 error
+		result1 operation.QueuedOperationsAtTime
+		result2 func() uint
+		result3 func()
+		result4 error
 	}
-	PeekStub        func(num uint) ([]*operation.QueuedOperationAtTime, error)
+	PeekStub        func(num uint) (operation.QueuedOperationsAtTime, error)
 	peekMutex       sync.RWMutex
 	peekArgsForCall []struct {
 		num uint
 	}
 	peekReturns struct {
-		result1 []*operation.QueuedOperationAtTime
+		result1 operation.QueuedOperationsAtTime
 		result2 error
 	}
 	peekReturnsOnCall map[int]struct {
-		result1 []*operation.QueuedOperationAtTime
+		result1 operation.QueuedOperationsAtTime
 		result2 error
 	}
 	LenStub        func() uint
@@ -115,7 +117,7 @@ func (fake *OperationQueue) AddReturnsOnCall(i int, result1 uint, result2 error)
 	}{result1, result2}
 }
 
-func (fake *OperationQueue) Remove(num uint) (uint, uint, error) {
+func (fake *OperationQueue) Remove(num uint) (ops operation.QueuedOperationsAtTime, ack func() uint, nack func(), err error) {
 	fake.removeMutex.Lock()
 	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
 	fake.removeArgsForCall = append(fake.removeArgsForCall, struct {
@@ -127,9 +129,9 @@ func (fake *OperationQueue) Remove(num uint) (uint, uint, error) {
 		return fake.RemoveStub(num)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	return fake.removeReturns.result1, fake.removeReturns.result2, fake.removeReturns.result3
+	return fake.removeReturns.result1, fake.removeReturns.result2, fake.removeReturns.result3, fake.removeReturns.result4
 }
 
 func (fake *OperationQueue) RemoveCallCount() int {
@@ -144,32 +146,35 @@ func (fake *OperationQueue) RemoveArgsForCall(i int) uint {
 	return fake.removeArgsForCall[i].num
 }
 
-func (fake *OperationQueue) RemoveReturns(result1 uint, result2 uint, result3 error) {
+func (fake *OperationQueue) RemoveReturns(result1 operation.QueuedOperationsAtTime, result2 func() uint, result3 func(), result4 error) {
 	fake.RemoveStub = nil
 	fake.removeReturns = struct {
-		result1 uint
-		result2 uint
-		result3 error
-	}{result1, result2, result3}
+		result1 operation.QueuedOperationsAtTime
+		result2 func() uint
+		result3 func()
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
-func (fake *OperationQueue) RemoveReturnsOnCall(i int, result1 uint, result2 uint, result3 error) {
+func (fake *OperationQueue) RemoveReturnsOnCall(i int, result1 operation.QueuedOperationsAtTime, result2 func() uint, result3 func(), result4 error) {
 	fake.RemoveStub = nil
 	if fake.removeReturnsOnCall == nil {
 		fake.removeReturnsOnCall = make(map[int]struct {
-			result1 uint
-			result2 uint
-			result3 error
+			result1 operation.QueuedOperationsAtTime
+			result2 func() uint
+			result3 func()
+			result4 error
 		})
 	}
 	fake.removeReturnsOnCall[i] = struct {
-		result1 uint
-		result2 uint
-		result3 error
-	}{result1, result2, result3}
+		result1 operation.QueuedOperationsAtTime
+		result2 func() uint
+		result3 func()
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
-func (fake *OperationQueue) Peek(num uint) ([]*operation.QueuedOperationAtTime, error) {
+func (fake *OperationQueue) Peek(num uint) (operation.QueuedOperationsAtTime, error) {
 	fake.peekMutex.Lock()
 	ret, specificReturn := fake.peekReturnsOnCall[len(fake.peekArgsForCall)]
 	fake.peekArgsForCall = append(fake.peekArgsForCall, struct {
@@ -198,24 +203,24 @@ func (fake *OperationQueue) PeekArgsForCall(i int) uint {
 	return fake.peekArgsForCall[i].num
 }
 
-func (fake *OperationQueue) PeekReturns(result1 []*operation.QueuedOperationAtTime, result2 error) {
+func (fake *OperationQueue) PeekReturns(result1 operation.QueuedOperationsAtTime, result2 error) {
 	fake.PeekStub = nil
 	fake.peekReturns = struct {
-		result1 []*operation.QueuedOperationAtTime
+		result1 operation.QueuedOperationsAtTime
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *OperationQueue) PeekReturnsOnCall(i int, result1 []*operation.QueuedOperationAtTime, result2 error) {
+func (fake *OperationQueue) PeekReturnsOnCall(i int, result1 operation.QueuedOperationsAtTime, result2 error) {
 	fake.PeekStub = nil
 	if fake.peekReturnsOnCall == nil {
 		fake.peekReturnsOnCall = make(map[int]struct {
-			result1 []*operation.QueuedOperationAtTime
+			result1 operation.QueuedOperationsAtTime
 			result2 error
 		})
 	}
 	fake.peekReturnsOnCall[i] = struct {
-		result1 []*operation.QueuedOperationAtTime
+		result1 operation.QueuedOperationsAtTime
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
Added explicit 'Ack' and 'Nack' capability when operations are removed from the queue. When Remove is invoked, the return values are 'Ack' and 'Nack' functions. The 'Ack' function commits the remove and the 'Nack' function ensures that the operations remain in the queue so that they may be retried.

closes #596

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>