### PR TITLE
feat: Add unpublished operation store option

### DIFF
--- a/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
@@ -66,6 +66,41 @@ func TestProcessTxnOperations(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("success - with unpublished operation store option", func(t *testing.T) {
+		providers := &Providers{
+			OperationProtocolProvider: &mockTxnOpsProvider{},
+			OpStore:                   &mockOperationStore{},
+		}
+
+		opt := WithUnpublishedOperationStore(&mockUnpublishedOpsStore{}, []operation.Type{operation.TypeUpdate})
+
+		p := New(providers, opt)
+		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
+		require.NoError(t, err)
+
+		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		require.NoError(t, err)
+	})
+
+	t.Run("error - unpublished operation store error", func(t *testing.T) {
+		providers := &Providers{
+			OperationProtocolProvider: &mockTxnOpsProvider{},
+			OpStore:                   &mockOperationStore{},
+		}
+
+		opt := WithUnpublishedOperationStore(
+			&mockUnpublishedOpsStore{DeleteAllErr: fmt.Errorf("delete all error")},
+			[]operation.Type{operation.TypeUpdate})
+
+		p := New(providers, opt)
+		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
+		require.NoError(t, err)
+
+		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to delete unpublished operations for anchor string[1.coreIndexURI]: delete all error")
+	})
+
 	t.Run("success - multiple operations with same suffix in transaction operations", func(t *testing.T) {
 		providers := &Providers{
 			OperationProtocolProvider: &mockTxnOpsProvider{},
@@ -126,7 +161,16 @@ func (m *mockTxnOpsProvider) GetTxnOperations(txn *txn.SidetreeTxn) ([]*operatio
 
 	op := &operation.AnchoredOperation{
 		UniqueSuffix: "abc",
+		Type:         operation.TypeUpdate,
 	}
 
 	return []*operation.AnchoredOperation{op}, nil
+}
+
+type mockUnpublishedOpsStore struct {
+	DeleteAllErr error
+}
+
+func (m *mockUnpublishedOpsStore) DeleteAll(_ []string) error {
+	return m.DeleteAllErr
 }


### PR DESCRIPTION
Add unpublished operation store option to the following components:
1. resolver (add unpublished operation to the unpublished operation store during ingestion)
2. operation processor (add operation from unpublished store to the operations from published store and assemble document)
3. txn processor (will delete all unpublished operations once they are published to operation store)

Closes #610

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>