### PR TITLE
feat: Add additional operations to Resolver and Operation Processor

### DIFF
--- a/pkg/api/operation/models.go
+++ b/pkg/api/operation/models.go
@@ -18,8 +18,8 @@ type Operation struct {
 	// ID defines ID
 	ID string
 
-	// OperationBuffer is the original operation request
-	OperationBuffer []byte
+	// OperationRequest is the original operation request
+	OperationRequest []byte
 
 	// AnchorOrigin defines anchor origin.
 	AnchorOrigin interface{}
@@ -47,8 +47,8 @@ type AnchoredOperation struct {
 	// UniqueSuffix defines document unique suffix.
 	UniqueSuffix string `json:"uniqueSuffix"`
 
-	// OperationBuffer is the original operation request
-	OperationBuffer []byte `json:"operationBuffer"`
+	// OperationRequest is the original operation request
+	OperationRequest []byte `json:"operationRequest"`
 
 	// TransactionTime is the logical anchoring time (block number in case of blockchain) for this operation in the anchoring system (blockchain).
 	TransactionTime uint64 `json:"transactionTime"`
@@ -56,8 +56,8 @@ type AnchoredOperation struct {
 	// TransactionNumber is the transaction number of the transaction this operation was batched within.
 	TransactionNumber uint64 `json:"transactionNumber"`
 
-	// ProtocolGenesisTime is the genesis time of the protocol that was used for this operation.
-	ProtocolGenesisTime uint64 `json:"protocolGenesisTime"`
+	// ProtocolVersion is the genesis time (version) of the protocol that was used for this operation.
+	ProtocolVersion uint64 `json:"protocolVersion"`
 
 	// CanonicalReference contains canonical reference that applies to this operation.
 	CanonicalReference string `json:"canonicalReference,omitempty"`
@@ -89,16 +89,16 @@ const (
 
 // QueuedOperation stores minimum required operation info for operations queue.
 type QueuedOperation struct {
-	OperationBuffer []byte
-	UniqueSuffix    string
-	Namespace       string
-	AnchorOrigin    interface{}
+	OperationRequest []byte
+	UniqueSuffix     string
+	Namespace        string
+	AnchorOrigin     interface{}
 }
 
 // QueuedOperationAtTime contains queued operation info with protocol genesis time.
 type QueuedOperationAtTime struct {
 	QueuedOperation
-	ProtocolGenesisTime uint64
+	ProtocolVersion uint64
 }
 
 // QueuedOperationsAtTime contains a collection of queued operations with protocol genesis time.

--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -98,18 +98,18 @@ type OperationParser interface {
 
 // ResolutionModel contains temporary data during document resolution.
 type ResolutionModel struct {
-	Doc                              document.Document
-	LastOperationTransactionTime     uint64
-	LastOperationTransactionNumber   uint64
-	LastOperationProtocolGenesisTime uint64
-	UpdateCommitment                 string
-	RecoveryCommitment               string
-	Deactivated                      bool
-	AnchorOrigin                     interface{}
-	EquivalentReferences             []string
-	CanonicalReference               string
-	PublishedOperations              []*operation.AnchoredOperation
-	UnpublishedOperations            []*operation.AnchoredOperation
+	Doc                            document.Document
+	LastOperationTransactionTime   uint64
+	LastOperationTransactionNumber uint64
+	LastOperationProtocolVersion   uint64
+	UpdateCommitment               string
+	RecoveryCommitment             string
+	Deactivated                    bool
+	AnchorOrigin                   interface{}
+	EquivalentReferences           []string
+	CanonicalReference             string
+	PublishedOperations            []*operation.AnchoredOperation
+	UnpublishedOperations          []*operation.AnchoredOperation
 }
 
 // OperationApplier applies the given operation to the document.

--- a/pkg/api/txn/sidetree.go
+++ b/pkg/api/txn/sidetree.go
@@ -12,7 +12,7 @@ type SidetreeTxn struct {
 	TransactionNumber    uint64
 	AnchorString         string
 	Namespace            string
-	ProtocolGenesisTime  uint64
+	ProtocolVersion      uint64
 	CanonicalReference   string
 	EquivalentReferences []string
 }

--- a/pkg/batch/cutter/cutter_test.go
+++ b/pkg/batch/cutter/cutter_test.go
@@ -18,12 +18,12 @@ import (
 )
 
 var (
-	operation1 = &operation.QueuedOperation{UniqueSuffix: "1", OperationBuffer: []byte("operation1")}
-	operation2 = &operation.QueuedOperation{UniqueSuffix: "2", OperationBuffer: []byte("operation2")}
-	operation3 = &operation.QueuedOperation{UniqueSuffix: "3", OperationBuffer: []byte("operation3")}
-	operation4 = &operation.QueuedOperation{UniqueSuffix: "4", OperationBuffer: []byte("operation4")}
-	operation5 = &operation.QueuedOperation{UniqueSuffix: "5", OperationBuffer: []byte("operation5")}
-	operation6 = &operation.QueuedOperation{UniqueSuffix: "6", OperationBuffer: []byte("operation6")}
+	operation1 = &operation.QueuedOperation{UniqueSuffix: "1", OperationRequest: []byte("operation1")}
+	operation2 = &operation.QueuedOperation{UniqueSuffix: "2", OperationRequest: []byte("operation2")}
+	operation3 = &operation.QueuedOperation{UniqueSuffix: "3", OperationRequest: []byte("operation3")}
+	operation4 = &operation.QueuedOperation{UniqueSuffix: "4", OperationRequest: []byte("operation4")}
+	operation5 = &operation.QueuedOperation{UniqueSuffix: "5", OperationRequest: []byte("operation5")}
+	operation6 = &operation.QueuedOperation{UniqueSuffix: "6", OperationRequest: []byte("operation6")}
 )
 
 func TestBatchCutter(t *testing.T) {
@@ -38,7 +38,7 @@ func TestBatchCutter(t *testing.T) {
 	require.EqualError(t, err, c.Err.Error())
 	require.Empty(t, result.Operations)
 	require.Zero(t, result.Pending)
-	require.Zero(t, result.ProtocolGenesisTime)
+	require.Zero(t, result.ProtocolVersion)
 
 	c.Err = nil
 
@@ -46,7 +46,7 @@ func TestBatchCutter(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, result.Operations)
 	require.Zero(t, result.Pending)
-	require.Zero(t, result.ProtocolGenesisTime)
+	require.Zero(t, result.ProtocolVersion)
 
 	l, err := r.Add(operation1, 10)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestBatchCutter(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, result.Operations)
 	require.Equal(t, uint(2), result.Pending)
-	require.Equal(t, uint64(0), result.ProtocolGenesisTime)
+	require.Equal(t, uint64(0), result.ProtocolVersion)
 
 	result, err = r.Cut(true)
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestBatchCutter(t *testing.T) {
 	require.Equal(t, operation1, result.Operations[0])
 	require.Equal(t, operation2, result.Operations[1])
 	require.Zero(t, result.Pending)
-	require.Equal(t, uint64(10), result.ProtocolGenesisTime)
+	require.Equal(t, uint64(10), result.ProtocolVersion)
 
 	result.Nack()
 

--- a/pkg/batch/opqueue/memqueue.go
+++ b/pkg/batch/opqueue/memqueue.go
@@ -19,13 +19,13 @@ type MemQueue struct {
 }
 
 // Add adds the given data to the tail of the queue and returns the new length of the queue.
-func (q *MemQueue) Add(data *operation.QueuedOperation, protocolGenesisTime uint64) (uint, error) {
+func (q *MemQueue) Add(data *operation.QueuedOperation, protocolVersion uint64) (uint, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
 	q.items = append(q.items, &operation.QueuedOperationAtTime{
-		QueuedOperation:     *data,
-		ProtocolGenesisTime: protocolGenesisTime,
+		QueuedOperation: *data,
+		ProtocolVersion: protocolVersion,
 	})
 
 	return uint(len(q.items)), nil

--- a/pkg/batch/opqueue/memqueue_test.go
+++ b/pkg/batch/opqueue/memqueue_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	op1 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op1", OperationBuffer: []byte("op1")}
-	op2 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op2", OperationBuffer: []byte("op2")}
-	op3 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op3", OperationBuffer: []byte("op3")}
+	op1 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op1", OperationRequest: []byte("op1")}
+	op2 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op2", OperationRequest: []byte("op2")}
+	op3 = &operation.QueuedOperation{Namespace: "ns", UniqueSuffix: "op3", OperationRequest: []byte("op3")}
 )
 
 func TestMemQueue(t *testing.T) {

--- a/pkg/batch/writer_test.go
+++ b/pkg/batch/writer_test.go
@@ -360,7 +360,7 @@ func TestProcessError(t *testing.T) {
 	t.Run("process operation error", func(t *testing.T) {
 		q := &mocks.OperationQueue{}
 
-		invalidQueue := []*operation.QueuedOperationAtTime{{QueuedOperation: operation.QueuedOperation{OperationBuffer: []byte(""), UniqueSuffix: "unique", Namespace: "ns"}}}
+		invalidQueue := []*operation.QueuedOperationAtTime{{QueuedOperation: operation.QueuedOperation{OperationRequest: []byte(""), UniqueSuffix: "unique", Namespace: "ns"}}}
 
 		q.LenReturns(1)
 		q.PeekReturns(invalidQueue, nil)
@@ -447,7 +447,7 @@ func generateOperations(numOfOperations int) (ops []*operation.QueuedOperation) 
 	return
 }
 
-func generateOperationsAtTime(numOfOperations int, protocolGenesisTime uint64) (ops []*operation.QueuedOperationAtTime) {
+func generateOperationsAtTime(numOfOperations int, protocolVersion uint64) (ops []*operation.QueuedOperationAtTime) {
 	for j := 1; j <= numOfOperations; j++ {
 		op, err := generateOperation(j)
 		if err != nil {
@@ -455,8 +455,8 @@ func generateOperationsAtTime(numOfOperations int, protocolGenesisTime uint64) (
 		}
 
 		ops = append(ops, &operation.QueuedOperationAtTime{
-			QueuedOperation:     *op,
-			ProtocolGenesisTime: protocolGenesisTime,
+			QueuedOperation: *op,
+			ProtocolVersion: protocolVersion,
 		})
 	}
 
@@ -501,9 +501,9 @@ func generateOperation(num int) (*operation.QueuedOperation, error) {
 	}
 
 	op := &operation.QueuedOperation{
-		Namespace:       "did:sidetree",
-		UniqueSuffix:    fmt.Sprint(num),
-		OperationBuffer: request,
+		Namespace:        "did:sidetree",
+		UniqueSuffix:     fmt.Sprint(num),
+		OperationRequest: request,
 	}
 
 	return op, nil

--- a/pkg/dochandler/handler_test.go
+++ b/pkg/dochandler/handler_test.go
@@ -84,7 +84,7 @@ func TestDocumentHandler_ProcessOperation_Create(t *testing.T) {
 
 	createOp := getCreateOperation()
 
-	doc, err := dochandler.ProcessOperation(createOp.OperationBuffer, 0)
+	doc, err := dochandler.ProcessOperation(createOp.OperationRequest, 0)
 	require.NoError(t, err)
 	require.NotNil(t, doc)
 }
@@ -105,7 +105,7 @@ func TestDocumentHandler_ProcessOperation_Update(t *testing.T) {
 		updateOp, err := generateUpdateOperation(createOp.UniqueSuffix)
 		require.NoError(t, err)
 
-		err = store.Put(&operation.AnchoredOperation{UniqueSuffix: createOp.UniqueSuffix, Type: operation.TypeCreate, OperationBuffer: createOpBuffer})
+		err = store.Put(&operation.AnchoredOperation{UniqueSuffix: createOp.UniqueSuffix, Type: operation.TypeCreate, OperationRequest: createOpBuffer})
 		require.NoError(t, err)
 
 		doc, err := dochandler.ProcessOperation(updateOp, 0)
@@ -130,7 +130,7 @@ func TestDocumentHandler_ProcessOperation_Update(t *testing.T) {
 		updateOp, err := generateUpdateOperation(createOp.UniqueSuffix)
 		require.NoError(t, err)
 
-		err = store.Put(&operation.AnchoredOperation{UniqueSuffix: createOp.UniqueSuffix, Type: operation.TypeCreate, OperationBuffer: createOpBuffer})
+		err = store.Put(&operation.AnchoredOperation{UniqueSuffix: createOp.UniqueSuffix, Type: operation.TypeCreate, OperationRequest: createOpBuffer})
 		require.NoError(t, err)
 
 		doc, err := dochandler.ProcessOperation(updateOp, 0)
@@ -157,7 +157,7 @@ func TestDocumentHandler_ProcessOperation_Update(t *testing.T) {
 		updateOp, err := generateUpdateOperation(createOp.UniqueSuffix)
 		require.NoError(t, err)
 
-		err = store.Put(&operation.AnchoredOperation{UniqueSuffix: createOp.UniqueSuffix, Type: operation.TypeCreate, OperationBuffer: createOpBuffer})
+		err = store.Put(&operation.AnchoredOperation{UniqueSuffix: createOp.UniqueSuffix, Type: operation.TypeCreate, OperationRequest: createOpBuffer})
 		require.NoError(t, err)
 
 		doc, err := dochandler.ProcessOperation(updateOp, 0)
@@ -212,7 +212,7 @@ func TestDocumentHandler_ProcessOperation_Create_WithDomain(t *testing.T) {
 
 	createOp := getCreateOperation()
 
-	result, err := dochandler.ProcessOperation(createOp.OperationBuffer, 0)
+	result, err := dochandler.ProcessOperation(createOp.OperationRequest, 0)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -242,7 +242,7 @@ func TestDocumentHandler_ProcessOperation_Create_ApplyDeltaError(t *testing.T) {
 	createOp, err := getCreateOperationWithInitialState(suffixData, delta)
 	require.NoError(t, err)
 
-	doc, err := dochandler.ProcessOperation(createOp.OperationBuffer, 0)
+	doc, err := dochandler.ProcessOperation(createOp.OperationRequest, 0)
 	require.Error(t, err)
 	require.Nil(t, doc)
 	require.Contains(t, err.Error(), "applying delta resulted in an empty document (most likely due to an invalid patch)")
@@ -257,7 +257,7 @@ func TestDocumentHandler_ProcessOperation_ProtocolError(t *testing.T) {
 
 	createOp := getCreateOperation()
 
-	doc, err := dochandler.ProcessOperation(createOp.OperationBuffer, 0)
+	doc, err := dochandler.ProcessOperation(createOp.OperationRequest, 0)
 	require.EqualError(t, err, pc.Err.Error())
 	require.Nil(t, doc)
 }
@@ -557,7 +557,7 @@ func TestProcessOperation_ParseOperationError(t *testing.T) {
 	err := store.Put(getAnchoredCreateOperation())
 	require.NoError(t, err)
 
-	doc, err := dochandler.ProcessOperation(getUpdateOperation().OperationBuffer, 0)
+	doc, err := dochandler.ProcessOperation(getUpdateOperation().OperationRequest, 0)
 	require.Error(t, err)
 	require.Nil(t, doc)
 	require.Contains(t, err.Error(), "bad request: missing signed data")
@@ -649,12 +649,12 @@ func getCreateOperationWithInitialState(suffixData *model.SuffixDataModel, delta
 	}
 
 	return &model.Operation{
-		Type:            operation.TypeCreate,
-		UniqueSuffix:    uniqueSuffix,
-		ID:              namespace + docutil.NamespaceDelimiter + uniqueSuffix,
-		OperationBuffer: payload,
-		Delta:           delta,
-		SuffixData:      suffixData,
+		Type:             operation.TypeCreate,
+		UniqueSuffix:     uniqueSuffix,
+		ID:               namespace + docutil.NamespaceDelimiter + uniqueSuffix,
+		OperationRequest: payload,
+		Delta:            delta,
+		SuffixData:       suffixData,
 	}, nil
 }
 
@@ -806,10 +806,10 @@ func getUpdateOperation() *operation.Operation {
 	}
 
 	return &operation.Operation{
-		OperationBuffer: payload,
-		Type:            operation.TypeUpdate,
-		UniqueSuffix:    request.DidSuffix,
-		ID:              namespace + docutil.NamespaceDelimiter + request.DidSuffix,
+		OperationRequest: payload,
+		Type:             operation.TypeUpdate,
+		UniqueSuffix:     request.DidSuffix,
+		ID:               namespace + docutil.NamespaceDelimiter + request.DidSuffix,
 	}
 }
 

--- a/pkg/dochandler/mocks/operationprocessor.gen.go
+++ b/pkg/dochandler/mocks/operationprocessor.gen.go
@@ -4,14 +4,16 @@ package mocks
 import (
 	"sync"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 )
 
 type OperationProcessor struct {
-	ResolveStub        func(string) (*protocol.ResolutionModel, error)
+	ResolveStub        func(string, ...*operation.AnchoredOperation) (*protocol.ResolutionModel, error)
 	resolveMutex       sync.RWMutex
 	resolveArgsForCall []struct {
 		arg1 string
+		arg2 []*operation.AnchoredOperation
 	}
 	resolveReturns struct {
 		result1 *protocol.ResolutionModel
@@ -25,16 +27,17 @@ type OperationProcessor struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OperationProcessor) Resolve(arg1 string) (*protocol.ResolutionModel, error) {
+func (fake *OperationProcessor) Resolve(arg1 string, arg2 ...*operation.AnchoredOperation) (*protocol.ResolutionModel, error) {
 	fake.resolveMutex.Lock()
 	ret, specificReturn := fake.resolveReturnsOnCall[len(fake.resolveArgsForCall)]
 	fake.resolveArgsForCall = append(fake.resolveArgsForCall, struct {
 		arg1 string
-	}{arg1})
-	fake.recordInvocation("Resolve", []interface{}{arg1})
+		arg2 []*operation.AnchoredOperation
+	}{arg1, arg2})
+	fake.recordInvocation("Resolve", []interface{}{arg1, arg2})
 	fake.resolveMutex.Unlock()
 	if fake.ResolveStub != nil {
-		return fake.ResolveStub(arg1)
+		return fake.ResolveStub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -49,17 +52,17 @@ func (fake *OperationProcessor) ResolveCallCount() int {
 	return len(fake.resolveArgsForCall)
 }
 
-func (fake *OperationProcessor) ResolveCalls(stub func(string) (*protocol.ResolutionModel, error)) {
+func (fake *OperationProcessor) ResolveCalls(stub func(string, ...*operation.AnchoredOperation) (*protocol.ResolutionModel, error)) {
 	fake.resolveMutex.Lock()
 	defer fake.resolveMutex.Unlock()
 	fake.ResolveStub = stub
 }
 
-func (fake *OperationProcessor) ResolveArgsForCall(i int) string {
+func (fake *OperationProcessor) ResolveArgsForCall(i int) (string, []*operation.AnchoredOperation) {
 	fake.resolveMutex.RLock()
 	defer fake.resolveMutex.RUnlock()
 	argsForCall := fake.resolveArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *OperationProcessor) ResolveReturns(result1 *protocol.ResolutionModel, result2 error) {

--- a/pkg/mocks/operationqueue.gen.go
+++ b/pkg/mocks/operationqueue.gen.go
@@ -8,11 +8,11 @@ import (
 )
 
 type OperationQueue struct {
-	AddStub        func(data *operation.QueuedOperation, protocolGenesisTime uint64) (uint, error)
+	AddStub        func(data *operation.QueuedOperation, protocolVersion uint64) (uint, error)
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
-		data                *operation.QueuedOperation
-		protocolGenesisTime uint64
+		data            *operation.QueuedOperation
+		protocolVersion uint64
 	}
 	addReturns struct {
 		result1 uint
@@ -65,17 +65,17 @@ type OperationQueue struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OperationQueue) Add(data *operation.QueuedOperation, protocolGenesisTime uint64) (uint, error) {
+func (fake *OperationQueue) Add(data *operation.QueuedOperation, protocolVersion uint64) (uint, error) {
 	fake.addMutex.Lock()
 	ret, specificReturn := fake.addReturnsOnCall[len(fake.addArgsForCall)]
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
-		data                *operation.QueuedOperation
-		protocolGenesisTime uint64
-	}{data, protocolGenesisTime})
-	fake.recordInvocation("Add", []interface{}{data, protocolGenesisTime})
+		data            *operation.QueuedOperation
+		protocolVersion uint64
+	}{data, protocolVersion})
+	fake.recordInvocation("Add", []interface{}{data, protocolVersion})
 	fake.addMutex.Unlock()
 	if fake.AddStub != nil {
-		return fake.AddStub(data, protocolGenesisTime)
+		return fake.AddStub(data, protocolVersion)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -92,7 +92,7 @@ func (fake *OperationQueue) AddCallCount() int {
 func (fake *OperationQueue) AddArgsForCall(i int) (*operation.QueuedOperation, uint64) {
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
-	return fake.addArgsForCall[i].data, fake.addArgsForCall[i].protocolGenesisTime
+	return fake.addArgsForCall[i].data, fake.addArgsForCall[i].protocolVersion
 }
 
 func (fake *OperationQueue) AddReturns(result1 uint, result2 error) {

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -91,9 +91,9 @@ func (o *Observer) process(txns []txn.SidetreeTxn) {
 			continue
 		}
 
-		v, err := pc.Get(txn.ProtocolGenesisTime)
+		v, err := pc.Get(txn.ProtocolVersion)
 		if err != nil {
-			logger.Warnf("Failed to get processor for transaction time [%d]: %s", txn.ProtocolGenesisTime, err.Error())
+			logger.Warnf("Failed to get processor for transaction time [%d]: %s", txn.ProtocolVersion, err.Error())
 
 			continue
 		}

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -64,9 +64,9 @@ func TestStartObserver(t *testing.T) {
 		defer o.Stop()
 
 		sidetreeTxnCh <- []txn.SidetreeTxn{
-			{Namespace: namespace1, ProtocolGenesisTime: 0, TransactionTime: 10, TransactionNumber: 0, AnchorString: "1.address"},
-			{Namespace: namespace1, ProtocolGenesisTime: 20, TransactionTime: 21, TransactionNumber: 2, AnchorString: "1.address"},
-			{Namespace: namespace2, ProtocolGenesisTime: 100, TransactionTime: 200, TransactionNumber: 2, AnchorString: "2.address"},
+			{Namespace: namespace1, ProtocolVersion: 0, TransactionTime: 10, TransactionNumber: 0, AnchorString: "1.address"},
+			{Namespace: namespace1, ProtocolVersion: 20, TransactionTime: 21, TransactionNumber: 2, AnchorString: "1.address"},
+			{Namespace: namespace2, ProtocolVersion: 100, TransactionTime: 200, TransactionNumber: 2, AnchorString: "2.address"},
 		}
 		time.Sleep(200 * time.Millisecond)
 

--- a/pkg/restapi/dochandler/updatehandler.go
+++ b/pkg/restapi/dochandler/updatehandler.go
@@ -19,7 +19,7 @@ import (
 // Processor processes document operations.
 type Processor interface {
 	Namespace() string
-	ProcessOperation(operation []byte, protocolGenesisTime uint64) (*document.ResolutionResult, error)
+	ProcessOperation(operation []byte, protocolVersion uint64) (*document.ResolutionResult, error)
 }
 
 // UpdateHandler handles the creation and update of documents.

--- a/pkg/versions/1_0/doctransformer/metadata/metadata.go
+++ b/pkg/versions/1_0/doctransformer/metadata/metadata.go
@@ -113,10 +113,10 @@ func getPublishedOperations(ops []*operation.AnchoredOperation) []*PublishedOper
 	for i, op := range ops {
 		publishedOps[i] = &PublishedOperation{
 			Type:                 op.Type,
-			OperationRequest:     op.OperationBuffer,
+			OperationRequest:     op.OperationRequest,
 			TransactionTime:      op.TransactionTime,
 			TransactionNumber:    op.TransactionNumber,
-			ProtocolVersion:      op.ProtocolGenesisTime,
+			ProtocolVersion:      op.ProtocolVersion,
 			CanonicalReference:   op.CanonicalReference,
 			EquivalentReferences: op.EquivalentReferences,
 			AnchorOrigin:         op.AnchorOrigin,
@@ -132,9 +132,9 @@ func getUnpublishedOperations(ops []*operation.AnchoredOperation) []*Unpublished
 	for i, op := range ops {
 		unpublishedOps[i] = &UnpublishedOperation{
 			Type:             op.Type,
-			OperationRequest: op.OperationBuffer,
+			OperationRequest: op.OperationRequest,
 			TransactionTime:  op.TransactionTime,
-			ProtocolVersion:  op.ProtocolGenesisTime,
+			ProtocolVersion:  op.ProtocolVersion,
 			AnchorOrigin:     op.AnchorOrigin,
 		}
 	}

--- a/pkg/versions/1_0/model/operation.go
+++ b/pkg/versions/1_0/model/operation.go
@@ -25,8 +25,8 @@ type Operation struct {
 	// UniqueSuffix is unique suffix
 	UniqueSuffix string
 
-	// OperationBuffer is the original operation request
-	OperationBuffer []byte
+	// OperationRequest is the original operation request
+	OperationRequest []byte
 
 	// SignedData is signed data for the operation (compact JWS)
 	SignedData string

--- a/pkg/versions/1_0/model/util.go
+++ b/pkg/versions/1_0/model/util.go
@@ -62,10 +62,10 @@ func GetAnchoredOperation(op *Operation) (*operation.AnchoredOperation, error) {
 	}
 
 	return &operation.AnchoredOperation{
-		Type:            op.Type,
-		UniqueSuffix:    op.UniqueSuffix,
-		OperationBuffer: operationBuffer,
-		AnchorOrigin:    op.AnchorOrigin,
+		Type:             op.Type,
+		UniqueSuffix:     op.UniqueSuffix,
+		OperationRequest: operationBuffer,
+		AnchorOrigin:     op.AnchorOrigin,
 	}, nil
 }
 

--- a/pkg/versions/1_0/model/util_test.go
+++ b/pkg/versions/1_0/model/util_test.go
@@ -37,7 +37,7 @@ func TestGetAnchoredOperation(t *testing.T) {
 		require.NotNil(t, anchored)
 
 		require.Equal(t, op.Type, anchored.Type)
-		require.Equal(t, opBuffer, string(anchored.OperationBuffer))
+		require.Equal(t, opBuffer, string(anchored.OperationRequest))
 		require.Equal(t, suffix, anchored.UniqueSuffix)
 	})
 
@@ -56,7 +56,7 @@ func TestGetAnchoredOperation(t *testing.T) {
 		require.NotNil(t, anchored)
 
 		require.Equal(t, op.Type, anchored.Type)
-		require.Equal(t, opBuffer, string(anchored.OperationBuffer))
+		require.Equal(t, opBuffer, string(anchored.OperationRequest))
 		require.Equal(t, suffix, anchored.UniqueSuffix)
 	})
 
@@ -78,7 +78,7 @@ func TestGetAnchoredOperation(t *testing.T) {
 		require.NotNil(t, anchored)
 		require.Equal(t, op.Type, anchored.Type)
 
-		require.Equal(t, opBuffer, string(anchored.OperationBuffer))
+		require.Equal(t, opBuffer, string(anchored.OperationRequest))
 		require.Equal(t, suffix, anchored.UniqueSuffix)
 	})
 
@@ -99,7 +99,7 @@ func TestGetAnchoredOperation(t *testing.T) {
 		require.NotNil(t, anchored)
 		require.Equal(t, anchored.Type, op.Type)
 
-		require.Equal(t, opBuffer, string(anchored.OperationBuffer))
+		require.Equal(t, opBuffer, string(anchored.OperationRequest))
 		require.Equal(t, suffix, anchored.UniqueSuffix)
 	})
 

--- a/pkg/versions/1_0/operationapplier/operationapplier.go
+++ b/pkg/versions/1_0/operationapplier/operationapplier.go
@@ -76,23 +76,23 @@ func (s *Applier) applyCreateOperation(anchoredOp *operation.AnchoredOperation, 
 		return nil, errors.New("create has to be the first operation")
 	}
 
-	op, err := s.OperationParser.ParseCreateOperation(anchoredOp.OperationBuffer, true)
+	op, err := s.OperationParser.ParseCreateOperation(anchoredOp.OperationRequest, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse create operation in batch mode: %s", err.Error())
 	}
 
 	// from this point any error should advance recovery commitment
 	result := &protocol.ResolutionModel{
-		Doc:                              make(document.Document),
-		LastOperationTransactionTime:     anchoredOp.TransactionTime,
-		LastOperationTransactionNumber:   anchoredOp.TransactionTime,
-		LastOperationProtocolGenesisTime: anchoredOp.ProtocolGenesisTime,
-		CanonicalReference:               anchoredOp.CanonicalReference,
-		EquivalentReferences:             anchoredOp.EquivalentReferences,
-		RecoveryCommitment:               op.SuffixData.RecoveryCommitment,
-		AnchorOrigin:                     op.SuffixData.AnchorOrigin,
-		PublishedOperations:              rm.PublishedOperations,
-		UnpublishedOperations:            rm.UnpublishedOperations,
+		Doc:                            make(document.Document),
+		LastOperationTransactionTime:   anchoredOp.TransactionTime,
+		LastOperationTransactionNumber: anchoredOp.TransactionTime,
+		LastOperationProtocolVersion:   anchoredOp.ProtocolVersion,
+		CanonicalReference:             anchoredOp.CanonicalReference,
+		EquivalentReferences:           anchoredOp.EquivalentReferences,
+		RecoveryCommitment:             op.SuffixData.RecoveryCommitment,
+		AnchorOrigin:                   op.SuffixData.AnchorOrigin,
+		PublishedOperations:            rm.PublishedOperations,
+		UnpublishedOperations:          rm.UnpublishedOperations,
 	}
 
 	// verify actual delta hash matches expected delta hash
@@ -131,7 +131,7 @@ func (s *Applier) applyUpdateOperation(anchoredOp *operation.AnchoredOperation, 
 		return nil, errors.New("update cannot be first operation")
 	}
 
-	op, err := s.OperationParser.ParseUpdateOperation(anchoredOp.OperationBuffer, true)
+	op, err := s.OperationParser.ParseUpdateOperation(anchoredOp.OperationRequest, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse update operation in batch mode: %s", err.Error())
 	}
@@ -160,17 +160,17 @@ func (s *Applier) applyUpdateOperation(anchoredOp *operation.AnchoredOperation, 
 
 	// delta is valid so advance update commitment
 	result := &protocol.ResolutionModel{
-		Doc:                              rm.Doc,
-		LastOperationTransactionTime:     anchoredOp.TransactionTime,
-		LastOperationTransactionNumber:   anchoredOp.TransactionTime,
-		LastOperationProtocolGenesisTime: anchoredOp.ProtocolGenesisTime,
-		CanonicalReference:               rm.CanonicalReference,
-		EquivalentReferences:             rm.EquivalentReferences,
-		UpdateCommitment:                 op.Delta.UpdateCommitment,
-		RecoveryCommitment:               rm.RecoveryCommitment,
-		AnchorOrigin:                     rm.AnchorOrigin,
-		PublishedOperations:              rm.PublishedOperations,
-		UnpublishedOperations:            rm.UnpublishedOperations,
+		Doc:                            rm.Doc,
+		LastOperationTransactionTime:   anchoredOp.TransactionTime,
+		LastOperationTransactionNumber: anchoredOp.TransactionTime,
+		LastOperationProtocolVersion:   anchoredOp.ProtocolVersion,
+		CanonicalReference:             rm.CanonicalReference,
+		EquivalentReferences:           rm.EquivalentReferences,
+		UpdateCommitment:               op.Delta.UpdateCommitment,
+		RecoveryCommitment:             rm.RecoveryCommitment,
+		AnchorOrigin:                   rm.AnchorOrigin,
+		PublishedOperations:            rm.PublishedOperations,
+		UnpublishedOperations:          rm.UnpublishedOperations,
 	}
 
 	// verify anchor from and until time against anchoring time
@@ -201,7 +201,7 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperati
 		return nil, errors.New("deactivate can only be applied to an existing document")
 	}
 
-	op, err := s.OperationParser.ParseDeactivateOperation(anchoredOp.OperationBuffer, true)
+	op, err := s.OperationParser.ParseDeactivateOperation(anchoredOp.OperationRequest, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse deactive operation in batch mode: %s", err.Error())
 	}
@@ -229,18 +229,18 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperati
 	}
 
 	return &protocol.ResolutionModel{
-		Doc:                              make(document.Document),
-		LastOperationTransactionTime:     anchoredOp.TransactionTime,
-		LastOperationTransactionNumber:   anchoredOp.TransactionTime,
-		LastOperationProtocolGenesisTime: anchoredOp.ProtocolGenesisTime,
-		CanonicalReference:               rm.CanonicalReference,
-		EquivalentReferences:             rm.EquivalentReferences,
-		UpdateCommitment:                 "",
-		RecoveryCommitment:               "",
-		Deactivated:                      true,
-		AnchorOrigin:                     rm.AnchorOrigin,
-		PublishedOperations:              rm.PublishedOperations,
-		UnpublishedOperations:            rm.UnpublishedOperations,
+		Doc:                            make(document.Document),
+		LastOperationTransactionTime:   anchoredOp.TransactionTime,
+		LastOperationTransactionNumber: anchoredOp.TransactionTime,
+		LastOperationProtocolVersion:   anchoredOp.ProtocolVersion,
+		CanonicalReference:             rm.CanonicalReference,
+		EquivalentReferences:           rm.EquivalentReferences,
+		UpdateCommitment:               "",
+		RecoveryCommitment:             "",
+		Deactivated:                    true,
+		AnchorOrigin:                   rm.AnchorOrigin,
+		PublishedOperations:            rm.PublishedOperations,
+		UnpublishedOperations:          rm.UnpublishedOperations,
 	}, nil
 }
 
@@ -251,7 +251,7 @@ func (s *Applier) applyRecoverOperation(anchoredOp *operation.AnchoredOperation,
 		return nil, errors.New("recover can only be applied to an existing document")
 	}
 
-	op, err := s.OperationParser.ParseRecoverOperation(anchoredOp.OperationBuffer, true)
+	op, err := s.OperationParser.ParseRecoverOperation(anchoredOp.OperationRequest, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse recover operation in batch mode: %s", err.Error())
 	}
@@ -269,16 +269,16 @@ func (s *Applier) applyRecoverOperation(anchoredOp *operation.AnchoredOperation,
 
 	// from this point any error should advance recovery commitment
 	result := &protocol.ResolutionModel{
-		Doc:                              make(document.Document),
-		LastOperationTransactionTime:     anchoredOp.TransactionTime,
-		LastOperationTransactionNumber:   anchoredOp.TransactionTime,
-		LastOperationProtocolGenesisTime: anchoredOp.ProtocolGenesisTime,
-		CanonicalReference:               anchoredOp.CanonicalReference,
-		EquivalentReferences:             anchoredOp.EquivalentReferences,
-		RecoveryCommitment:               signedDataModel.RecoveryCommitment,
-		AnchorOrigin:                     signedDataModel.AnchorOrigin,
-		PublishedOperations:              rm.PublishedOperations,
-		UnpublishedOperations:            rm.UnpublishedOperations,
+		Doc:                            make(document.Document),
+		LastOperationTransactionTime:   anchoredOp.TransactionTime,
+		LastOperationTransactionNumber: anchoredOp.TransactionTime,
+		LastOperationProtocolVersion:   anchoredOp.ProtocolVersion,
+		CanonicalReference:             anchoredOp.CanonicalReference,
+		EquivalentReferences:           anchoredOp.EquivalentReferences,
+		RecoveryCommitment:             signedDataModel.RecoveryCommitment,
+		AnchorOrigin:                   signedDataModel.AnchorOrigin,
+		PublishedOperations:            rm.PublishedOperations,
+		UnpublishedOperations:          rm.UnpublishedOperations,
 	}
 
 	// verify the delta against the signed delta hash

--- a/pkg/versions/1_0/operationapplier/operationapplier_test.go
+++ b/pkg/versions/1_0/operationapplier/operationapplier_test.go
@@ -875,13 +875,13 @@ func TestRecover(t *testing.T) {
 		require.NoError(t, err)
 
 		recoverOp := &model.Operation{
-			Namespace:       mocks.DefaultNS,
-			UniqueSuffix:    uniqueSuffix,
-			Type:            operation.TypeRecover,
-			OperationBuffer: operationBuffer,
-			Delta:           recoverRequest.Delta,
-			SignedData:      recoverRequest.SignedData,
-			RevealValue:     recoverRequest.RevealValue,
+			Namespace:        mocks.DefaultNS,
+			UniqueSuffix:     uniqueSuffix,
+			Type:             operation.TypeRecover,
+			OperationRequest: operationBuffer,
+			Delta:            recoverRequest.Delta,
+			SignedData:       recoverRequest.SignedData,
+			RevealValue:      recoverRequest.RevealValue,
 		}
 
 		anchoredOp := getAnchoredOperation(recoverOp)
@@ -1113,13 +1113,13 @@ func getRecoverOperationWithSigner(signer client.Signer, recoveryKey, updateKey 
 	}
 
 	return &model.Operation{
-		Namespace:       mocks.DefaultNS,
-		UniqueSuffix:    uniqueSuffix,
-		Type:            operation.TypeRecover,
-		OperationBuffer: operationBuffer,
-		Delta:           recoverRequest.Delta,
-		SignedData:      recoverRequest.SignedData,
-		RevealValue:     recoverRequest.RevealValue,
+		Namespace:        mocks.DefaultNS,
+		UniqueSuffix:     uniqueSuffix,
+		Type:             operation.TypeRecover,
+		OperationRequest: operationBuffer,
+		Delta:            recoverRequest.Delta,
+		SignedData:       recoverRequest.SignedData,
+		RevealValue:      recoverRequest.RevealValue,
 	}, nextRecoveryKey, nil
 }
 
@@ -1239,13 +1239,13 @@ func getCreateOperationWithDoc(recoveryKey, updateKey *ecdsa.PrivateKey, doc str
 	}
 
 	return &model.Operation{
-		Namespace:       mocks.DefaultNS,
-		ID:              "did:sidetree:" + uniqueSuffix,
-		UniqueSuffix:    uniqueSuffix,
-		Type:            operation.TypeCreate,
-		OperationBuffer: operationBuffer,
-		Delta:           delta,
-		SuffixData:      suffixData,
+		Namespace:        mocks.DefaultNS,
+		ID:               "did:sidetree:" + uniqueSuffix,
+		UniqueSuffix:     uniqueSuffix,
+		Type:             operation.TypeCreate,
+		OperationRequest: operationBuffer,
+		Delta:            delta,
+		SuffixData:       suffixData,
 	}, nil
 }
 

--- a/pkg/versions/1_0/operationparser/create.go
+++ b/pkg/versions/1_0/operationparser/create.go
@@ -60,12 +60,12 @@ func (p *Parser) ParseCreateOperation(request []byte, batch bool) (*model.Operat
 	}
 
 	return &model.Operation{
-		OperationBuffer: request,
-		Type:            operation.TypeCreate,
-		UniqueSuffix:    uniqueSuffix,
-		Delta:           schema.Delta,
-		SuffixData:      schema.SuffixData,
-		AnchorOrigin:    schema.SuffixData.AnchorOrigin,
+		OperationRequest: request,
+		Type:             operation.TypeCreate,
+		UniqueSuffix:     uniqueSuffix,
+		Delta:            schema.Delta,
+		SuffixData:       schema.SuffixData,
+		AnchorOrigin:     schema.SuffixData.AnchorOrigin,
 	}, nil
 }
 

--- a/pkg/versions/1_0/operationparser/deactivate.go
+++ b/pkg/versions/1_0/operationparser/deactivate.go
@@ -46,11 +46,11 @@ func (p *Parser) ParseDeactivateOperation(request []byte, batch bool) (*model.Op
 	}
 
 	return &model.Operation{
-		Type:            operation.TypeDeactivate,
-		OperationBuffer: request,
-		UniqueSuffix:    schema.DidSuffix,
-		SignedData:      schema.SignedData,
-		RevealValue:     schema.RevealValue,
+		Type:             operation.TypeDeactivate,
+		OperationRequest: request,
+		UniqueSuffix:     schema.DidSuffix,
+		SignedData:       schema.SignedData,
+		RevealValue:      schema.RevealValue,
 	}, nil
 }
 

--- a/pkg/versions/1_0/operationparser/operation.go
+++ b/pkg/versions/1_0/operationparser/operation.go
@@ -95,10 +95,10 @@ func (p *Parser) Parse(namespace string, operationBuffer []byte) (*operation.Ope
 	}
 
 	return &operation.Operation{
-		Type:            internal.Type,
-		UniqueSuffix:    internal.UniqueSuffix,
-		ID:              internal.ID,
-		OperationBuffer: operationBuffer,
+		Type:             internal.Type,
+		UniqueSuffix:     internal.UniqueSuffix,
+		ID:               internal.ID,
+		OperationRequest: operationBuffer,
 	}, nil
 }
 

--- a/pkg/versions/1_0/operationparser/recover.go
+++ b/pkg/versions/1_0/operationparser/recover.go
@@ -62,13 +62,13 @@ func (p *Parser) ParseRecoverOperation(request []byte, batch bool) (*model.Opera
 	}
 
 	return &model.Operation{
-		OperationBuffer: request,
-		Type:            operation.TypeRecover,
-		UniqueSuffix:    schema.DidSuffix,
-		Delta:           schema.Delta,
-		SignedData:      schema.SignedData,
-		RevealValue:     schema.RevealValue,
-		AnchorOrigin:    signedData.AnchorOrigin,
+		OperationRequest: request,
+		Type:             operation.TypeRecover,
+		UniqueSuffix:     schema.DidSuffix,
+		Delta:            schema.Delta,
+		SignedData:       schema.SignedData,
+		RevealValue:      schema.RevealValue,
+		AnchorOrigin:     signedData.AnchorOrigin,
 	}, nil
 }
 

--- a/pkg/versions/1_0/operationparser/update.go
+++ b/pkg/versions/1_0/operationparser/update.go
@@ -53,12 +53,12 @@ func (p *Parser) ParseUpdateOperation(request []byte, batch bool) (*model.Operat
 	}
 
 	return &model.Operation{
-		Type:            operation.TypeUpdate,
-		OperationBuffer: request,
-		UniqueSuffix:    schema.DidSuffix,
-		Delta:           schema.Delta,
-		SignedData:      schema.SignedData,
-		RevealValue:     schema.RevealValue,
+		Type:             operation.TypeUpdate,
+		OperationRequest: request,
+		UniqueSuffix:     schema.DidSuffix,
+		Delta:            schema.Delta,
+		SignedData:       schema.SignedData,
+		RevealValue:      schema.RevealValue,
 	}, nil
 }
 

--- a/pkg/versions/1_0/txnprocessor/txnprocessor.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor.go
@@ -130,7 +130,7 @@ func updateAnchoredOperation(op *operation.AnchoredOperation, sidetreeTxn txn.Si
 	// The transaction number of the transaction this operation was batched within
 	op.TransactionNumber = sidetreeTxn.TransactionNumber
 	// The genesis time of the protocol that was used for this operation
-	op.ProtocolGenesisTime = sidetreeTxn.ProtocolGenesisTime
+	op.ProtocolVersion = sidetreeTxn.ProtocolVersion
 
 	return op
 }

--- a/pkg/versions/1_0/txnprovider/handler.go
+++ b/pkg/versions/1_0/txnprovider/handler.go
@@ -131,11 +131,11 @@ func (h *OperationHandler) parseOperations(ops []*operation.QueuedOperation) (*m
 
 	result := &models.SortedOperations{}
 	for _, d := range ops {
-		op, e := h.parser.ParseOperation(d.Namespace, d.OperationBuffer, false)
+		op, e := h.parser.ParseOperation(d.Namespace, d.OperationRequest, false)
 		if e != nil {
 			if e == operationparser.ErrOperationExpired {
 				// stale operations should not be added to the batch; ignore operation
-				logger.Warnf("[%s] stale operation for suffix[%s] found in batch operations: discarding operation %s", d.Namespace, d.UniqueSuffix, d.OperationBuffer)
+				logger.Warnf("[%s] stale operation for suffix[%s] found in batch operations: discarding operation %s", d.Namespace, d.UniqueSuffix, d.OperationRequest)
 
 				continue
 			}

--- a/pkg/versions/1_0/txnprovider/handler_test.go
+++ b/pkg/versions/1_0/txnprovider/handler_test.go
@@ -288,9 +288,9 @@ func TestOperationHandler_PrepareTxnFiles(t *testing.T) {
 			operationparser.New(protocol))
 
 		op := &operation.QueuedOperation{
-			OperationBuffer: []byte(`{"key":"value"}`),
-			UniqueSuffix:    "suffix",
-			Namespace:       defaultNS,
+			OperationRequest: []byte(`{"key":"value"}`),
+			UniqueSuffix:     "suffix",
+			Namespace:        defaultNS,
 		}
 
 		anchorString, artifacts, refs, err := handler.PrepareTxnFiles([]*operation.QueuedOperation{op})
@@ -419,10 +419,10 @@ func generateOperationInfo(num int, opType operation.Type) (*operation.QueuedOpe
 	}
 
 	return &operation.QueuedOperation{
-		OperationBuffer: op,
-		UniqueSuffix:    fmt.Sprintf("%s-%d", opType, num),
-		Namespace:       defaultNS,
-		AnchorOrigin:    universalAnchorOrigin,
+		OperationRequest: op,
+		UniqueSuffix:     fmt.Sprintf("%s-%d", opType, num),
+		Namespace:        defaultNS,
+		AnchorOrigin:     universalAnchorOrigin,
 	}, nil
 }
 
@@ -704,9 +704,9 @@ func generateQueueOperationWithAnchorTimes(opType operation.Type, suffix string,
 	}
 
 	return &operation.QueuedOperation{
-		OperationBuffer: opBuffer,
-		UniqueSuffix:    suffix,
-		Namespace:       defaultNS,
+		OperationRequest: opBuffer,
+		UniqueSuffix:     suffix,
+		Namespace:        defaultNS,
 	}, nil
 }
 

--- a/pkg/versions/1_0/txnprovider/provider.go
+++ b/pkg/versions/1_0/txnprovider/provider.go
@@ -40,7 +40,7 @@ type OperationProvider struct {
 
 // OperationParser defines the functions for parsing operations.
 type OperationParser interface {
-	ParseOperation(namespace string, operationBuffer []byte, batch bool) (*model.Operation, error)
+	ParseOperation(namespace string, operationRequest []byte, batch bool) (*model.Operation, error)
 	ValidateSuffixData(suffixData *model.SuffixDataModel) error
 	ValidateDelta(delta *model.DeltaModel) error
 	ParseSignedDataForUpdate(compactJWS string) (*model.UpdateSignedDataModel, error)


### PR DESCRIPTION
Add additional operations to Resolver and Operation Processor

This is required in order to apply e.g. unpublished operations to resolution result.

Also, rename anchored operation fields:
OperationBuffer -> OperationRequest
ProtocolGenesisTime -> ProtocolVersion
in order to align with requirement that published/unpublished operations in metadata are subset of anchored operation.

Closes #614

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>