### PR TITLE
chore: Add operation decorator to document handler

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -135,6 +135,9 @@ func addAdditionalOperations(published, unpublished, additional []*operation.Anc
 		}
 	}
 
+	sortOperations(published)
+	sortOperations(unpublished)
+
 	return published, unpublished
 }
 


### PR DESCRIPTION
This component will be invoked before adding operation to the batch queue. It will be used for additional business validation/pre-processing of operation.

Closes #618

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>