### PR TITLE
chore: Use batch flag during operation commitment assembling

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
 jobs:
   - job: UnitTest
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-latest
     timeoutInMinutes: 30
     steps:
     - template: azp-dependencies.yml

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -825,18 +825,6 @@ func TestGetNextOperationCommitment(t *testing.T) {
 		require.Contains(t, err.Error(), "missing signed data")
 	})
 
-	t.Run("error - invalid delta", func(t *testing.T) {
-		updateOp, _, err := getUpdateOperation(updateKey, uniqueSuffix, 1)
-		require.NoError(t, err)
-
-		updateOp.Delta = &model.DeltaModel{}
-
-		value, err := p.getCommitment(getAnchoredOperation(updateOp, 1))
-		require.Error(t, err)
-		require.Empty(t, value)
-		require.Contains(t, err.Error(), "get commitment - parse operation error: missing patches")
-	})
-
 	t.Run("error - operation type not supported", func(t *testing.T) {
 		request := model.RecoverRequest{
 			Operation: "other",

--- a/pkg/versions/1_0/operationparser/commitment.go
+++ b/pkg/versions/1_0/operationparser/commitment.go
@@ -9,7 +9,7 @@ import (
 // GetRevealValue returns this operation reveal value.
 func (p *Parser) GetRevealValue(opBytes []byte) (string, error) {
 	// namespace is irrelevant in this case
-	op, err := p.ParseOperation("", opBytes, false)
+	op, err := p.ParseOperation("", opBytes, true)
 	if err != nil {
 		return "", fmt.Errorf("get reveal value - parse operation error: %s", err.Error())
 	}
@@ -24,7 +24,7 @@ func (p *Parser) GetRevealValue(opBytes []byte) (string, error) {
 // GetCommitment returns next operation commitment.
 func (p *Parser) GetCommitment(opBytes []byte) (string, error) {
 	// namespace is irrelevant in this case
-	op, err := p.ParseOperation("", opBytes, false)
+	op, err := p.ParseOperation("", opBytes, true)
 	if err != nil {
 		return "", fmt.Errorf("get commitment - parse operation error: %s", err.Error())
 	}


### PR DESCRIPTION
Don't check expiry time during commitment assembling - it will be checked later on during applying operations against anchor publishing time.

Closes #620

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>