### PR TITLE
feat: Return the number of operations processed

### DIFF
--- a/pkg/api/protocol/protocol.go
+++ b/pkg/api/protocol/protocol.go
@@ -85,7 +85,7 @@ type Protocol struct {
 
 // TxnProcessor defines the functions for processing a Sidetree transaction.
 type TxnProcessor interface {
-	Process(sidetreeTxn txn.SidetreeTxn, suffixes ...string) error
+	Process(sidetreeTxn txn.SidetreeTxn, suffixes ...string) (numProcessed int, err error)
 }
 
 // OperationParser defines the functions for parsing operations.

--- a/pkg/mocks/txnprocessor.gen.go
+++ b/pkg/mocks/txnprocessor.gen.go
@@ -9,39 +9,42 @@ import (
 )
 
 type TxnProcessor struct {
-	ProcessStub        func(txn.SidetreeTxn, ...string) error
+	ProcessStub        func(txn.SidetreeTxn, ...string) (int, error)
 	processMutex       sync.RWMutex
 	processArgsForCall []struct {
 		arg1 txn.SidetreeTxn
 		arg2 []string
 	}
 	processReturns struct {
-		result1 error
+		result1 int
+		result2 error
 	}
 	processReturnsOnCall map[int]struct {
-		result1 error
+		result1 int
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TxnProcessor) Process(arg1 txn.SidetreeTxn, arg2 ...string) error {
+func (fake *TxnProcessor) Process(arg1 txn.SidetreeTxn, arg2 ...string) (int, error) {
 	fake.processMutex.Lock()
 	ret, specificReturn := fake.processReturnsOnCall[len(fake.processArgsForCall)]
 	fake.processArgsForCall = append(fake.processArgsForCall, struct {
 		arg1 txn.SidetreeTxn
 		arg2 []string
 	}{arg1, arg2})
+	stub := fake.ProcessStub
+	fakeReturns := fake.processReturns
 	fake.recordInvocation("Process", []interface{}{arg1, arg2})
 	fake.processMutex.Unlock()
-	if fake.ProcessStub != nil {
-		return fake.ProcessStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.processReturns
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *TxnProcessor) ProcessCallCount() int {
@@ -50,7 +53,7 @@ func (fake *TxnProcessor) ProcessCallCount() int {
 	return len(fake.processArgsForCall)
 }
 
-func (fake *TxnProcessor) ProcessCalls(stub func(txn.SidetreeTxn, ...string) error) {
+func (fake *TxnProcessor) ProcessCalls(stub func(txn.SidetreeTxn, ...string) (int, error)) {
 	fake.processMutex.Lock()
 	defer fake.processMutex.Unlock()
 	fake.ProcessStub = stub
@@ -63,27 +66,30 @@ func (fake *TxnProcessor) ProcessArgsForCall(i int) (txn.SidetreeTxn, []string) 
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *TxnProcessor) ProcessReturns(result1 error) {
+func (fake *TxnProcessor) ProcessReturns(result1 int, result2 error) {
 	fake.processMutex.Lock()
 	defer fake.processMutex.Unlock()
 	fake.ProcessStub = nil
 	fake.processReturns = struct {
-		result1 error
-	}{result1}
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *TxnProcessor) ProcessReturnsOnCall(i int, result1 error) {
+func (fake *TxnProcessor) ProcessReturnsOnCall(i int, result1 int, result2 error) {
 	fake.processMutex.Lock()
 	defer fake.processMutex.Unlock()
 	fake.ProcessStub = nil
 	if fake.processReturnsOnCall == nil {
 		fake.processReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 int
+			result2 error
 		})
 	}
 	fake.processReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *TxnProcessor) Invocations() map[string][][]interface{} {

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -98,7 +98,7 @@ func (o *Observer) process(txns []txn.SidetreeTxn) {
 			continue
 		}
 
-		err = v.TransactionProcessor().Process(txn)
+		_, err = v.TransactionProcessor().Process(txn)
 		if err != nil {
 			logger.Warnf("Failed to process anchor[%s]: %s", txn.AnchorString, err.Error())
 

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -88,7 +88,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 		}
 
 		p := txnprocessor.New(providers)
-		err := p.Process(txn.SidetreeTxn{})
+		_, err := p.Process(txn.SidetreeTxn{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})

--- a/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
+++ b/pkg/versions/1_0/txnprocessor/txnprocessor_test.go
@@ -32,7 +32,7 @@ func TestTxnProcessor_Process(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.Process(txn.SidetreeTxn{})
+		_, err := p.Process(txn.SidetreeTxn{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 	})
@@ -47,7 +47,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		}
 
 		p := New(providers)
-		err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}}, txn.SidetreeTxn{AnchorString: anchorString})
+		_, err := p.processTxnOperations([]*operation.AnchoredOperation{{UniqueSuffix: "abc"}}, txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to store operation from anchor string")
 	})
@@ -62,8 +62,9 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		numProcessed, err := p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
+		require.Equal(t, 1, numProcessed)
 	})
 
 	t.Run("success - with unpublished operation store option", func(t *testing.T) {
@@ -78,7 +79,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 
@@ -96,7 +97,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		batchOps, err := p.OperationProtocolProvider.GetTxnOperations(&txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 
-		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to delete unpublished operations for anchor string[1.coreIndexURI]: delete all error")
 	})
@@ -115,7 +116,7 @@ func TestProcessTxnOperations(t *testing.T) {
 		// only first operation will be processed, subsequent operations will be discarded
 		batchOps = append(batchOps, batchOps...)
 
-		err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
+		_, err = p.processTxnOperations(batchOps, txn.SidetreeTxn{AnchorString: anchorString})
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Change the transaction processor interface to return the number of operations that were actually processed. In the case of duplicate operations, the number processed may be zero and the caller may wish to take a different path in this case.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>