### PR TITLE
fix: Should not be able to specify both versionId and versionTime

### DIFF
--- a/pkg/restapi/dochandler/resolvehandler_test.go
+++ b/pkg/restapi/dochandler/resolvehandler_test.go
@@ -115,6 +115,28 @@ func TestResolveHandler_Resolve(t *testing.T) {
 		require.Equal(t, http.StatusOK, rw.Code)
 		require.Equal(t, "application/did+ld+json", rw.Header().Get("content-type"))
 	})
+	t.Run("error - with versionId and versionTime parameter", func(t *testing.T) {
+		docHandler := mocks.NewMockDocumentHandler().
+			WithNamespace(namespace)
+
+		create, err := getCreateRequest()
+		require.NoError(t, err)
+
+		bytes, err := canonicalizer.MarshalCanonical(create)
+		require.NoError(t, err)
+
+		result, err := docHandler.ProcessOperation(bytes, 0)
+		require.NoError(t, err)
+
+		getID = func(req *http.Request) string { return result.Document.ID() }
+		handler := NewResolveHandler(docHandler, &mocks.MetricsProvider{})
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet,
+			"/document/"+result.Document.ID()+"?versionId=abc&versionTime=2021-05-10T17:00:00Z", nil)
+		handler.Resolve(rw, req)
+		require.Equal(t, http.StatusBadRequest, rw.Code)
+		require.Contains(t, rw.Body.String(), "cannot specify both 'versionId' and 'versionTime'")
+	})
 	t.Run("Invalid ID", func(t *testing.T) {
 		getID = func(req *http.Request) string { return "someid" }
 		docHandler := mocks.NewMockDocumentHandler().WithNamespace(namespace)


### PR DESCRIPTION
Return an error if the client specifies both versionId and versionTime.

closes #651

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>