### PR TITLE
fix: Fix published operations in document metadata

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -232,7 +232,7 @@ func applyResolutionOptions(uniqueSuffix string, published, unpublished []*opera
 	for _, op := range filteredOps {
 		if op.CanonicalReference == "" {
 			filteredUnpublishedOps = append(filteredUnpublishedOps, op)
-		} else if _, ok := canonicalIds[op.CanonicalReference]; !ok {
+		} else {
 			filteredPublishedOps = append(filteredPublishedOps, op)
 		}
 	}


### PR DESCRIPTION
Fix published operations in document metadata, got broken with filtering published/unpublished operations as per versionId/versionTime.

Closes #653

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>