### PR TITLE
chore: Fix propagating created

### DIFF
--- a/pkg/versions/1_0/doctransformer/metadata/metadata.go
+++ b/pkg/versions/1_0/doctransformer/metadata/metadata.go
@@ -112,7 +112,9 @@ func (t *Metadata) CreateDocumentMetadata(rm *protocol.ResolutionModel, info pro
 
 	if rm.VersionID != "" {
 		docMetadata[document.VersionIDProperty] = rm.VersionID
-		docMetadata[document.UpdatedProperty] = time.Unix(int64(rm.UpdatedTime), 0).UTC().Format(time.RFC3339)
+		if rm.UpdatedTime > 0 {
+			docMetadata[document.UpdatedProperty] = time.Unix(int64(rm.UpdatedTime), 0).UTC().Format(time.RFC3339)
+		}
 	}
 
 	return docMetadata, nil

--- a/pkg/versions/1_0/operationapplier/operationapplier.go
+++ b/pkg/versions/1_0/operationapplier/operationapplier.go
@@ -163,6 +163,7 @@ func (s *Applier) applyUpdateOperation(anchoredOp *operation.AnchoredOperation, 
 	// delta is valid so advance update commitment
 	result := &protocol.ResolutionModel{
 		Doc:                            rm.Doc,
+		CreatedTime:                    rm.CreatedTime,
 		UpdatedTime:                    anchoredOp.TransactionTime,
 		LastOperationTransactionTime:   anchoredOp.TransactionTime,
 		LastOperationTransactionNumber: anchoredOp.TransactionNumber,
@@ -234,6 +235,8 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperati
 
 	return &protocol.ResolutionModel{
 		Doc:                            make(document.Document),
+		CreatedTime:                    rm.CreatedTime,
+		UpdatedTime:                    rm.UpdatedTime,
 		LastOperationTransactionTime:   anchoredOp.TransactionTime,
 		LastOperationTransactionNumber: anchoredOp.TransactionNumber,
 		LastOperationProtocolVersion:   anchoredOp.ProtocolVersion,
@@ -275,6 +278,7 @@ func (s *Applier) applyRecoverOperation(anchoredOp *operation.AnchoredOperation,
 	// from this point any error should advance recovery commitment
 	result := &protocol.ResolutionModel{
 		Doc:                            make(document.Document),
+		CreatedTime:                    rm.CreatedTime,
 		UpdatedTime:                    anchoredOp.TransactionTime,
 		LastOperationTransactionTime:   anchoredOp.TransactionTime,
 		LastOperationTransactionNumber: anchoredOp.TransactionNumber,


### PR DESCRIPTION
Propagate "created" time for update, recover, deactivate operations.
Also, don't include "updated" if there was no update operations (e.g. create followed by deactivate)

Closes #666

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>