### PR TITLE
chore: Remove "updated" for deactivated document

### DIFF
--- a/pkg/versions/1_0/doctransformer/metadata/metadata.go
+++ b/pkg/versions/1_0/doctransformer/metadata/metadata.go
@@ -112,7 +112,7 @@ func (t *Metadata) CreateDocumentMetadata(rm *protocol.ResolutionModel, info pro
 
 	if rm.VersionID != "" {
 		docMetadata[document.VersionIDProperty] = rm.VersionID
-		if rm.UpdatedTime > 0 {
+		if !rm.Deactivated && rm.UpdatedTime > 0 {
 			docMetadata[document.UpdatedProperty] = time.Unix(int64(rm.UpdatedTime), 0).UTC().Format(time.RFC3339)
 		}
 	}

--- a/pkg/versions/1_0/doctransformer/metadata/metadata_test.go
+++ b/pkg/versions/1_0/doctransformer/metadata/metadata_test.go
@@ -124,7 +124,13 @@ func TestPopulateDocumentMetadata(t *testing.T) {
 	})
 
 	t.Run("success - deactivated, commitments empty", func(t *testing.T) {
-		internal2 := &protocol.ResolutionModel{Doc: doc, Deactivated: true}
+		internal2 := &protocol.ResolutionModel{
+			Doc:         doc,
+			Deactivated: true,
+			CreatedTime: uint64(time.Now().Unix() - 60),
+			UpdatedTime: uint64(time.Now().Unix()),
+			VersionID:   "version",
+		}
 
 		info := make(protocol.TransformationInfo)
 		info[document.IDProperty] = testDID
@@ -135,6 +141,8 @@ func TestPopulateDocumentMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, true, documentMetadata[document.DeactivatedProperty])
+		require.Empty(t, documentMetadata[document.UpdatedProperty])
+		require.NotEmpty(t, documentMetadata[document.CreatedProperty])
 		require.Equal(t, canonicalID, documentMetadata[document.CanonicalIDProperty])
 		require.Empty(t, documentMetadata[document.EquivalentIDProperty])
 


### PR DESCRIPTION
Since Sidetree resolution is processing full operations first (create, recover, deactivate) having "updated" in the resolution result for deactivate document will lead to inconsistent behaviour. If there was a 'recover' operation in the chain it will return "updated" otherwise it will be empty. Also in this case "updated" means the anchoring time of last recover and not necessarily the last update.

Closes #668

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>