### PR TITLE
chore: Return deactivate operation anchoring time in "updated"

### DIFF
--- a/pkg/versions/1_0/doctransformer/metadata/metadata.go
+++ b/pkg/versions/1_0/doctransformer/metadata/metadata.go
@@ -112,7 +112,7 @@ func (t *Metadata) CreateDocumentMetadata(rm *protocol.ResolutionModel, info pro
 
 	if rm.VersionID != "" {
 		docMetadata[document.VersionIDProperty] = rm.VersionID
-		if !rm.Deactivated && rm.UpdatedTime > 0 {
+		if rm.UpdatedTime > 0 {
 			docMetadata[document.UpdatedProperty] = time.Unix(int64(rm.UpdatedTime), 0).UTC().Format(time.RFC3339)
 		}
 	}

--- a/pkg/versions/1_0/doctransformer/metadata/metadata_test.go
+++ b/pkg/versions/1_0/doctransformer/metadata/metadata_test.go
@@ -141,6 +141,38 @@ func TestPopulateDocumentMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, true, documentMetadata[document.DeactivatedProperty])
+		require.NotEmpty(t, documentMetadata[document.UpdatedProperty])
+		require.NotEmpty(t, documentMetadata[document.CreatedProperty])
+		require.Equal(t, canonicalID, documentMetadata[document.CanonicalIDProperty])
+		require.Empty(t, documentMetadata[document.EquivalentIDProperty])
+
+		methodMetadataEntry, ok := documentMetadata[document.MethodProperty]
+		require.True(t, ok)
+		methodMetadata, ok := methodMetadataEntry.(document.Metadata)
+		require.True(t, ok)
+
+		require.Equal(t, true, methodMetadata[document.PublishedProperty])
+		require.Empty(t, methodMetadata[document.RecoveryCommitmentProperty])
+		require.Empty(t, methodMetadata[document.UpdateCommitmentProperty])
+	})
+
+	t.Run("success - deactivated, no version ID (unpublished)", func(t *testing.T) {
+		internal2 := &protocol.ResolutionModel{
+			Doc:         doc,
+			Deactivated: true,
+			CreatedTime: uint64(time.Now().Unix() - 60),
+			UpdatedTime: uint64(time.Now().Unix()),
+		}
+
+		info := make(protocol.TransformationInfo)
+		info[document.IDProperty] = testDID
+		info[document.PublishedProperty] = true
+		info[document.CanonicalIDProperty] = canonicalID
+
+		documentMetadata, err := New().CreateDocumentMetadata(internal2, info)
+		require.NoError(t, err)
+
+		require.Equal(t, true, documentMetadata[document.DeactivatedProperty])
 		require.Empty(t, documentMetadata[document.UpdatedProperty])
 		require.NotEmpty(t, documentMetadata[document.CreatedProperty])
 		require.Equal(t, canonicalID, documentMetadata[document.CanonicalIDProperty])

--- a/pkg/versions/1_0/operationapplier/operationapplier.go
+++ b/pkg/versions/1_0/operationapplier/operationapplier.go
@@ -236,7 +236,7 @@ func (s *Applier) applyDeactivateOperation(anchoredOp *operation.AnchoredOperati
 	return &protocol.ResolutionModel{
 		Doc:                            make(document.Document),
 		CreatedTime:                    rm.CreatedTime,
-		UpdatedTime:                    rm.UpdatedTime,
+		UpdatedTime:                    anchoredOp.TransactionTime,
 		LastOperationTransactionTime:   anchoredOp.TransactionTime,
 		LastOperationTransactionNumber: anchoredOp.TransactionNumber,
 		LastOperationProtocolVersion:   anchoredOp.ProtocolVersion,


### PR DESCRIPTION
Resolution result for 'deactivated' document should return deactivate operation anchoring time in "updated" field of document metadata.

Closes #670

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>