### PR TITLE
feat: Add custom patches for also known as

### DIFF
--- a/pkg/document/diddocument.go
+++ b/pkg/document/diddocument.go
@@ -68,6 +68,11 @@ func (doc DIDDocument) VerificationMethods() []PublicKey {
 	return ParsePublicKeys(doc[VerificationMethodProperty])
 }
 
+// AlsoKnownAs are alternate identifiers for DID subject.
+func (doc DIDDocument) AlsoKnownAs() []string {
+	return StringArray(doc[AlsoKnownAs])
+}
+
 // ParsePublicKeys is helper function for parsing public keys.
 func ParsePublicKeys(entry interface{}) []PublicKey {
 	if entry == nil {

--- a/pkg/document/diddocument_test.go
+++ b/pkg/document/diddocument_test.go
@@ -52,6 +52,12 @@ func TestValid(t *testing.T) {
 
 	require.Empty(t, doc.Context())
 	require.Equal(t, "whatever", doc.Authentications()[0])
+
+	require.Equal(t, 1, len(doc.AlsoKnownAs()))
+	require.Equal(t, "identityURI", doc.AlsoKnownAs()[0])
+
+	newDoc := DidDocumentFromJSONLDObject(doc.JSONLdObject())
+	require.Equal(t, newDoc, doc)
 }
 
 func TestValidWithVerificationMethods(t *testing.T) {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -88,11 +88,13 @@ func StringArray(entry interface{}) []string {
 	}
 
 	var result []string
-
 	for _, e := range entries {
-		if e != nil {
-			result = append(result, stringEntry(e))
+		val, ok := e.(string)
+		if !ok {
+			continue
 		}
+
+		result = append(result, val)
 	}
 
 	return result

--- a/pkg/document/testdata/pk-doc.json
+++ b/pkg/document/testdata/pk-doc.json
@@ -22,5 +22,6 @@
       "priority": 0
     }
   ],
-  "authentication": ["whatever"]
+  "authentication": ["whatever"],
+  "alsoKnownAs": ["identityURI"]
 }

--- a/pkg/versions/1_0/doctransformer/didtransformer/transformer.go
+++ b/pkg/versions/1_0/doctransformer/didtransformer/transformer.go
@@ -153,8 +153,8 @@ func (t *Transformer) TransformDocument(rm *protocol.ResolutionModel, info proto
 		ctx = append(ctx, getBase(id.(string)))
 	}
 
-	alsoKnownAs, ok := internal[document.AlsoKnownAs]
-	if ok {
+	alsoKnownAs := internal.AlsoKnownAs()
+	if len(alsoKnownAs) > 0 {
 		external[document.AlsoKnownAs] = alsoKnownAs
 	}
 

--- a/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas.go
+++ b/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas.go
@@ -1,0 +1,70 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package patchvalidator
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+// NewAlsoKnownAsValidator creates new validator.
+func NewAlsoKnownAsValidator() *AlsoKnownAsValidator {
+	return &AlsoKnownAsValidator{}
+}
+
+// AlsoKnownAsValidator implements validator for custom "-add-also-known-as" and "-remove-also-known-as" patches.
+// Both patches take have as value URIs so the validation for both add and remove are the same.
+type AlsoKnownAsValidator struct {
+}
+
+// Validate validates patch.
+func (v *AlsoKnownAsValidator) Validate(p patch.Patch) error {
+	action, err := p.GetAction()
+	if err != nil {
+		return err
+	}
+
+	value, err := p.GetValue()
+	if err != nil {
+		return fmt.Errorf("%s", err)
+	}
+
+	_, err = getRequiredArray(value)
+	if err != nil {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+
+	uris := document.StringArray(value)
+
+	if err := validate(uris); err != nil {
+		return fmt.Errorf("%s: validate URIs: %w", action, err)
+	}
+
+	return nil
+}
+
+// validateURIs validates URIs.
+func validate(uris []string) error {
+	ids := make(map[string]bool)
+	for _, uri := range uris {
+		u, err := url.Parse(uri)
+		if err != nil {
+			return fmt.Errorf("failed to parse URI: %w", err)
+		}
+
+		if _, ok := ids[u.String()]; ok {
+			return fmt.Errorf("duplicate uri: %s", u.String())
+		}
+
+		ids[u.String()] = true
+	}
+
+	return nil
+}

--- a/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas_test.go
+++ b/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas_test.go
@@ -1,0 +1,72 @@
+package patchvalidator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
+)
+
+func TestAddAlsoKnowAsValidator(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addAlsoKnownAs))
+		require.NoError(t, err)
+
+		err = NewAlsoKnownAsValidator().Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("error - missing action", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addAlsoKnownAs))
+		require.NoError(t, err)
+
+		delete(p, patch.ActionKey)
+		err = NewAlsoKnownAsValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "patch is missing action key")
+	})
+	t.Run("error - missing uris", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addAlsoKnownAs))
+		require.NoError(t, err)
+
+		delete(p, patch.UrisKey)
+		err = NewAlsoKnownAsValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "-add-also-known-as patch is missing key: uris")
+	})
+	t.Run("error - uris value is not expected type", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addAlsoKnownAs))
+		require.NoError(t, err)
+
+		p[patch.UrisKey] = []int{123}
+		err = NewAlsoKnownAsValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "-add-also-known-as: expected array of interfaces")
+	})
+	t.Run("error - uri is not valid", func(t *testing.T) {
+		p, err := patch.NewAddAlsoKnownAs(`[":abc"]`)
+		require.NoError(t, err)
+
+		err = NewAlsoKnownAsValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "-add-also-known-as: validate URIs: failed to parse URI:")
+	})
+	t.Run("error - duplicate URI", func(t *testing.T) {
+		p, err := patch.NewAddAlsoKnownAs(`["https://abc.com", "https://abc.com"]`)
+		require.NoError(t, err)
+
+		err = NewAlsoKnownAsValidator().Validate(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "-add-also-known-as: validate URIs: duplicate uri: https://abc.com")
+	})
+}
+
+const addAlsoKnownAs = `{
+  "action": "-add-also-known-as",
+  "uris": ["https://blog.com", "https://other.com"]
+}`
+
+const removeAlsoKnownAs = `{
+  "action": "-remove-also-known-as",
+  "uris": ["https://blog.com"]
+}`

--- a/pkg/versions/1_0/operationparser/patchvalidator/validator.go
+++ b/pkg/versions/1_0/operationparser/patchvalidator/validator.go
@@ -26,6 +26,8 @@ func Validate(p patch.Patch) error {
 		return NewAddServicesValidator().Validate(p)
 	case patch.RemoveServiceEndpoints:
 		return NewRemoveServicesValidator().Validate(p)
+	case patch.AddAlsoKnownAs, patch.RemoveAlsoKnownAs:
+		return NewAlsoKnownAsValidator().Validate(p)
 	}
 
 	return fmt.Errorf(" validation for action '%s' is not supported", action)

--- a/pkg/versions/1_0/operationparser/patchvalidator/validator_test.go
+++ b/pkg/versions/1_0/operationparser/patchvalidator/validator_test.go
@@ -43,6 +43,20 @@ func TestValidate(t *testing.T) {
 		err = Validate(p)
 		require.NoError(t, err)
 	})
+	t.Run("success - add also known as", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(addAlsoKnownAs))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
+	t.Run("success - remove also known as", func(t *testing.T) {
+		p, err := patch.FromBytes([]byte(removeAlsoKnownAs))
+		require.NoError(t, err)
+
+		err = Validate(p)
+		require.NoError(t, err)
+	})
 	t.Run("success - ietf patch", func(t *testing.T) {
 		p, err := patch.FromBytes([]byte(ietfPatch))
 		require.NoError(t, err)


### PR DESCRIPTION
Add two custom patches for adding/removing also known as URIs:
-add-also-known-as
-remove-also-known-as

Closes #679

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>