### PR TITLE
chore: Rename "also known as" sidetree patch

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -41,11 +41,11 @@ const (
 	// JSONPatch captures enum value "json-patch".
 	JSONPatch Action = "ietf-json-patch"
 
-	// AddAlsoKnownAs captures "-add-also-known-as".
-	AddAlsoKnownAs Action = "-add-also-known-as"
+	// AddAlsoKnownAs captures "add-also-known-as".
+	AddAlsoKnownAs Action = "add-also-known-as"
 
-	// RemoveAlsoKnownAs captures "-remove-also-known-as".
-	RemoveAlsoKnownAs Action = "-remove-also-known-as"
+	// RemoveAlsoKnownAs captures "remove-also-known-as".
+	RemoveAlsoKnownAs Action = "remove-also-known-as"
 )
 
 // Key defines key that will be used to get document patch information.

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -396,10 +396,10 @@ func TestAddAlsoKnownAsPatch(t *testing.T) {
 		require.Equal(t, value, patch[UrisKey])
 	})
 	t.Run("missing URIs", func(t *testing.T) {
-		patch, err := FromBytes([]byte(`{"action": "-add-also-known-as"}`))
+		patch, err := FromBytes([]byte(`{"action": "add-also-known-as"}`))
 		require.Error(t, err)
 		require.Nil(t, patch)
-		require.Contains(t, err.Error(), "-add-also-known-as patch is missing key: uris")
+		require.Contains(t, err.Error(), "add-also-known-as patch is missing key: uris")
 	})
 	t.Run("success from new", func(t *testing.T) {
 		p, err := NewAddAlsoKnownAs(`["testURI"]`)
@@ -445,10 +445,10 @@ func TestRemoveAlsoKnownAsPatch(t *testing.T) {
 		require.Equal(t, value, p[UrisKey])
 	})
 	t.Run("missing public key ids", func(t *testing.T) {
-		patch, err := FromBytes([]byte(`{"action": "-remove-also-known-as"}`))
+		patch, err := FromBytes([]byte(`{"action": "remove-also-known-as"}`))
 		require.Error(t, err)
 		require.Nil(t, patch)
-		require.Contains(t, err.Error(), "-remove-also-known-as patch is missing key: uris")
+		require.Contains(t, err.Error(), "remove-also-known-as patch is missing key: uris")
 	})
 	t.Run("success from new", func(t *testing.T) {
 		const uris = `["identity1", "identity2"]`
@@ -665,12 +665,12 @@ const replaceDoc = `{
 }`
 
 const addAlsoKnownAs = `{
-  "action": "-add-also-known-as",
+  "action": "add-also-known-as",
   "uris": ["testURI"]
 }`
 
 const removeAlsoKnownAs = `{
-  "action": "-remove-also-known-as",
+  "action": "remove-also-known-as",
   "uris": ["testURI", "nonExistentURI"]
 }`
 

--- a/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas.go
+++ b/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas.go
@@ -19,7 +19,7 @@ func NewAlsoKnownAsValidator() *AlsoKnownAsValidator {
 	return &AlsoKnownAsValidator{}
 }
 
-// AlsoKnownAsValidator implements validator for custom "-add-also-known-as" and "-remove-also-known-as" patches.
+// AlsoKnownAsValidator implements validator for "add-also-known-as" and "remove-also-known-as" patches.
 // Both patches take have as value URIs so the validation for both add and remove are the same.
 type AlsoKnownAsValidator struct {
 }

--- a/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas_test.go
+++ b/pkg/versions/1_0/operationparser/patchvalidator/alsoknownas_test.go
@@ -32,7 +32,7 @@ func TestAddAlsoKnowAsValidator(t *testing.T) {
 		delete(p, patch.UrisKey)
 		err = NewAlsoKnownAsValidator().Validate(p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "-add-also-known-as patch is missing key: uris")
+		require.Contains(t, err.Error(), "add-also-known-as patch is missing key: uris")
 	})
 	t.Run("error - uris value is not expected type", func(t *testing.T) {
 		p, err := patch.FromBytes([]byte(addAlsoKnownAs))
@@ -41,7 +41,7 @@ func TestAddAlsoKnowAsValidator(t *testing.T) {
 		p[patch.UrisKey] = []int{123}
 		err = NewAlsoKnownAsValidator().Validate(p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "-add-also-known-as: expected array of interfaces")
+		require.Contains(t, err.Error(), "add-also-known-as: expected array of interfaces")
 	})
 	t.Run("error - uri is not valid", func(t *testing.T) {
 		p, err := patch.NewAddAlsoKnownAs(`[":abc"]`)
@@ -49,7 +49,7 @@ func TestAddAlsoKnowAsValidator(t *testing.T) {
 
 		err = NewAlsoKnownAsValidator().Validate(p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "-add-also-known-as: validate URIs: failed to parse URI:")
+		require.Contains(t, err.Error(), "add-also-known-as: validate URIs: failed to parse URI:")
 	})
 	t.Run("error - duplicate URI", func(t *testing.T) {
 		p, err := patch.NewAddAlsoKnownAs(`["https://abc.com", "https://abc.com"]`)
@@ -57,16 +57,16 @@ func TestAddAlsoKnowAsValidator(t *testing.T) {
 
 		err = NewAlsoKnownAsValidator().Validate(p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "-add-also-known-as: validate URIs: duplicate uri: https://abc.com")
+		require.Contains(t, err.Error(), "add-also-known-as: validate URIs: duplicate uri: https://abc.com")
 	})
 }
 
 const addAlsoKnownAs = `{
-  "action": "-add-also-known-as",
-  "uris": ["https://blog.com", "https://other.com"]
+  "action": "add-also-known-as",
+  "uris": ["did:abc:123", "https://other.com"]
 }`
 
 const removeAlsoKnownAs = `{
-  "action": "-remove-also-known-as",
-  "uris": ["https://blog.com"]
+  "action": "remove-also-known-as",
+  "uris": ["did:abc:123"]
 }`


### PR DESCRIPTION
Remove the '-' prefix from the patches.

Closes #681

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>