### PR TITLE
chore: Fill-in controller when base is present

### DIFF
--- a/pkg/dochandler/handler.go
+++ b/pkg/dochandler/handler.go
@@ -275,7 +275,7 @@ func contains(values []operation.Type, value operation.Type) bool {
 	return false
 }
 
-func (r *DocumentHandler) getCreateResult(op *operation.Operation, pv protocol.Version) (*protocol.ResolutionModel, error) {
+func GetCreateResult(op *operation.Operation, pv protocol.Version) (*protocol.ResolutionModel, error) {
 	// we can use operation applier to generate create response even though operation is not anchored yet
 	anchored := &operation.AnchoredOperation{
 		Type:             op.Type,
@@ -307,7 +307,7 @@ func (r *DocumentHandler) getCreateResponse(op *operation.Operation, pv protocol
 		r.metrics.GetCreateOperationResultTime(time.Since(startTime))
 	}()
 
-	rm, err := r.getCreateResult(op, pv)
+	rm, err := GetCreateResult(op, pv)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (r *DocumentHandler) resolveRequestWithInitialState(uniqueSuffix, longFormD
 		return nil, fmt.Errorf("%s: provided did doesn't match did created from initial state", badRequest)
 	}
 
-	rm, err := r.getCreateResult(op, pv)
+	rm, err := GetCreateResult(op, pv)
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +554,7 @@ func (r *DocumentHandler) validateOperation(op *operation.Operation, pv protocol
 }
 
 func (r *DocumentHandler) validateCreateDocument(op *operation.Operation, pv protocol.Version) error {
-	rm, err := r.getCreateResult(op, pv)
+	rm, err := GetCreateResult(op, pv)
 	if err != nil {
 		return err
 	}

--- a/pkg/versions/1_0/doctransformer/didtransformer/transformer.go
+++ b/pkg/versions/1_0/doctransformer/didtransformer/transformer.go
@@ -248,7 +248,7 @@ func (t *Transformer) processKeys(internal document.DIDDocument,
 		externalPK := make(document.PublicKey)
 		externalPK[document.IDProperty] = id
 		externalPK[document.TypeProperty] = pk.Type()
-		externalPK[document.ControllerProperty] = t.getController(did)
+		externalPK[document.ControllerProperty] = did
 
 		if pkJwk := pk.PublicKeyJwk(); pkJwk != nil { //nolint:nestif
 			if pk.Type() == ed25519VerificationKey2018 {
@@ -350,14 +350,6 @@ func (t *Transformer) getObjectID(docID, objectID string) interface{} {
 	}
 
 	return docID + relativeID
-}
-
-func (t *Transformer) getController(docID string) interface{} {
-	if t.includeBase {
-		return ""
-	}
-
-	return docID
 }
 
 func getED2519PublicKey(pkJWK document.JWK) ([]byte, error) {


### PR DESCRIPTION
Fill in controller when base is present.

This will make it as per spec. Reference app fixed the issue too.

Closes #691

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>