### PR TITLE
fix: Ensure "patches" slice is alway constructed in the same order

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
@@ -103,8 +104,8 @@ func PatchesFromDocument(doc string) ([]Patch, error) {
 	var docPatches []Patch
 	var jsonPatches []string
 
-	for key, value := range parsed {
-		jsonBytes, err := json.Marshal(value)
+	for _, key := range sortedKeys(parsed) {
+		jsonBytes, err := json.Marshal(parsed[key])
 		if err != nil {
 			return nil, err
 		}
@@ -431,4 +432,19 @@ func getGenericArray(arr []string) []interface{} {
 	}
 
 	return values
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, len(m))
+
+	i := 0
+
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+
+	sort.Strings(keys)
+
+	return keys
 }

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -100,6 +100,20 @@ func TestPatchesFromDocument(t *testing.T) {
 		require.Nil(t, p)
 		require.Contains(t, err.Error(), "document must NOT have the id property")
 	})
+	t.Run("patches array is always in the same order", func(t *testing.T) {
+		var prev []Patch
+
+		for i := 1; i <= 100; i++ {
+			patches, err := PatchesFromDocument(testDoc)
+			require.NoError(t, err)
+
+			if prev != nil {
+				require.Equalf(t, prev, patches, "expecting the patches array to be in the same order")
+			}
+
+			prev = patches
+		}
+	})
 }
 
 func TestReplacePatch(t *testing.T) {


### PR DESCRIPTION
closes #699